### PR TITLE
fix: tolerate Worker propagation after deploy

### DIFF
--- a/scripts/webapp_production_health.py
+++ b/scripts/webapp_production_health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import time
 import urllib.error
 import urllib.request
 from typing import Any
@@ -61,24 +62,17 @@ def contains_email(value: Any) -> bool:
     return False
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Read-only production Web application health check."
-    )
-    parser.add_argument("--expected-commit", required=True)
-    parser.add_argument("--format", choices=("text", "json"), default="text")
-    args = parser.parse_args()
+def deployment_is_propagating(payload: dict[str, Any]) -> bool:
+    checks = payload.get("checks")
+    if not isinstance(checks, dict) or checks.get("exact_deployment_commit") is not False:
+        return False
+    other_checks = [value for name, value in checks.items() if name != "exact_deployment_commit"]
+    return bool(other_checks) and all(value is True for value in other_checks)
 
-    if not COMMIT_PATTERN.fullmatch(args.expected_commit):
-        raise OpsError("expected commit must be a full SHA-1")
 
-    runtime_target = yaml.safe_load(
-        (REPO_ROOT / "config" / "runtime-target.yaml").read_text(encoding="utf-8")
-    )
-    target = runtime_target["managed_services"]["webapp"]
-    base_url = str(target["public_base_url"]).rstrip("/")
-    expected_venue_count = int(target["expected_venue_count"])
-
+def inspect_production(
+    *, base_url: str, expected_commit: str, expected_venue_count: int
+) -> dict[str, Any]:
     health_status, health = request_json(f"{base_url}/api/healthz")
     bootstrap_status, bootstrap = request_json(f"{base_url}/api/bootstrap")
     observation_status, _ = request_json(
@@ -92,19 +86,76 @@ def main() -> None:
         "health_http_ok": health_status == 200,
         "service_healthy": isinstance(health, dict) and health.get("ok") is True,
         "exact_deployment_commit": isinstance(health, dict)
-        and health.get("deploymentCommit") == args.expected_commit,
+        and health.get("deploymentCommit") == expected_commit,
         "bootstrap_http_ok": bootstrap_status == 200,
         "expected_venue_count": isinstance(venues, list) and len(venues) == expected_venue_count,
         "bootstrap_contains_no_email": not contains_email(bootstrap),
         "observation_requires_authentication": observation_status == 401,
     }
-    payload = {
+    return {
         "ok": all(checks.values()),
-        "expected_commit": args.expected_commit,
+        "expected_commit": expected_commit,
         "deployed_commit": health.get("deploymentCommit") if isinstance(health, dict) else None,
         "venue_count": len(venues) if isinstance(venues, list) else None,
         "checks": checks,
     }
+
+
+def wait_for_production(
+    *,
+    base_url: str,
+    expected_commit: str,
+    expected_venue_count: int,
+    propagation_timeout_seconds: float,
+    retry_interval_seconds: float,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + propagation_timeout_seconds
+    while True:
+        payload = inspect_production(
+            base_url=base_url,
+            expected_commit=expected_commit,
+            expected_venue_count=expected_venue_count,
+        )
+        if payload["ok"] or not deployment_is_propagating(payload):
+            return payload
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return payload
+        time.sleep(min(retry_interval_seconds, remaining))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Read-only production Web application health check."
+    )
+    parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--propagation-timeout-seconds", type=float, default=90)
+    parser.add_argument("--retry-interval-seconds", type=float, default=5)
+    args = parser.parse_args()
+
+    if not COMMIT_PATTERN.fullmatch(args.expected_commit):
+        raise OpsError("expected commit must be a full SHA-1")
+    if args.propagation_timeout_seconds < 0:
+        raise OpsError("propagation timeout must not be negative")
+    if args.retry_interval_seconds <= 0:
+        raise OpsError("retry interval must be positive")
+
+    runtime_target = yaml.safe_load(
+        (REPO_ROOT / "config" / "runtime-target.yaml").read_text(encoding="utf-8")
+    )
+    target = runtime_target["managed_services"]["webapp"]
+    base_url = str(target["public_base_url"]).rstrip("/")
+    expected_venue_count = int(target["expected_venue_count"])
+
+    payload = wait_for_production(
+        base_url=base_url,
+        expected_commit=args.expected_commit,
+        expected_venue_count=expected_venue_count,
+        propagation_timeout_seconds=args.propagation_timeout_seconds,
+        retry_interval_seconds=args.retry_interval_seconds,
+    )
+
     emit(payload, args.format)
     if not payload["ok"]:
         raise SystemExit(1)

--- a/tests/ops_scripts_test.py
+++ b/tests/ops_scripts_test.py
@@ -815,6 +815,61 @@ class GithubOnlyDeliveryContractTest(unittest.TestCase):
             webapp_production_health.contains_email({"nested": [{"masked": "pe****@example.com"}]})
         )
 
+    def test_webapp_health_retries_only_during_commit_propagation(self):
+        healthy_checks = {
+            "health_http_ok": True,
+            "service_healthy": True,
+            "exact_deployment_commit": False,
+            "bootstrap_http_ok": True,
+            "expected_venue_count": True,
+            "bootstrap_contains_no_email": True,
+            "observation_requires_authentication": True,
+        }
+
+        self.assertTrue(
+            webapp_production_health.deployment_is_propagating({"checks": healthy_checks})
+        )
+        self.assertFalse(
+            webapp_production_health.deployment_is_propagating(
+                {"checks": {**healthy_checks, "bootstrap_http_ok": False}}
+            )
+        )
+        self.assertFalse(
+            webapp_production_health.deployment_is_propagating(
+                {"checks": {**healthy_checks, "exact_deployment_commit": True}}
+            )
+        )
+
+        stale = {"ok": False, "checks": healthy_checks}
+        ready = {
+            "ok": True,
+            "checks": {**healthy_checks, "exact_deployment_commit": True},
+        }
+        with (
+            patch.object(
+                webapp_production_health,
+                "inspect_production",
+                side_effect=[stale, ready],
+            ) as inspect,
+            patch.object(
+                webapp_production_health.time,
+                "monotonic",
+                side_effect=[0, 1],
+            ),
+            patch.object(webapp_production_health.time, "sleep") as sleep,
+        ):
+            result = webapp_production_health.wait_for_production(
+                base_url="https://example.invalid",
+                expected_commit="a" * 40,
+                expected_venue_count=7,
+                propagation_timeout_seconds=10,
+                retry_interval_seconds=5,
+            )
+
+        self.assertIs(result, ready)
+        self.assertEqual(inspect.call_count, 2)
+        sleep.assert_called_once_with(5)
+
     def test_application_preflights_do_not_require_local_database_backups(self):
         for name in ("deploy_check.py", "rollback_check.py"):
             source = (SCRIPTS_DIR / name).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- retry the exact-commit Web health check only while the custom domain still serves the previous Worker version
- fail immediately for availability, venue-contract, privacy, or authentication regressions
- cover propagation and fail-fast behavior with operations tests

## Verification
- `make verify`
- public Web health check against deployed commit

No real email or WeChat messages were sent.