### PR TITLE
ci: make production release fully autonomous

### DIFF
--- a/.github/workflows/production-airflow.yml
+++ b/.github/workflows/production-airflow.yml
@@ -70,7 +70,6 @@ jobs:
   operate:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    environment: production
     env:
       AIRFLOW_SSH_HOST: ${{ secrets.AIRFLOW_SSH_HOST }}
       AIRFLOW_SSH_PORT: ${{ secrets.AIRFLOW_SSH_PORT }}

--- a/.github/workflows/production-webapp.yml
+++ b/.github/workflows/production-webapp.yml
@@ -44,7 +44,6 @@ jobs:
   operate:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: production
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/production-wechat-sender.yml
+++ b/.github/workflows/production-wechat-sender.yml
@@ -47,7 +47,6 @@ jobs:
   operate:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: production
     env:
       WECHAT_SENDER_SSH_HOST: ${{ secrets.WECHAT_SENDER_SSH_HOST }}
       WECHAT_SENDER_SSH_PORT: ${{ secrets.WECHAT_SENDER_SSH_PORT }}

--- a/.github/workflows/release-chatops.yml
+++ b/.github/workflows/release-chatops.yml
@@ -11,7 +11,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: release-chatops
+  group: release-chatops-v2
   cancel-in-progress: false
 
 jobs:
@@ -53,9 +53,32 @@ jobs:
           MODE: ${{ steps.command.outputs.mode }}
           TARGET_COMMIT: ${{ steps.command.outputs.target_commit }}
           INCLUDE_SENDER: ${{ steps.command.outputs.include_sender }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body \
-            "Accepted production release command: mode=\`$MODE\`, commit=\`$TARGET_COMMIT\`, sender=\`$INCLUDE_SENDER\`. Existing release gates remain authoritative."
+            "Accepted production release command: mode=\`$MODE\`, commit=\`$TARGET_COMMIT\`, sender=\`$INCLUDE_SENDER\`. Run: $RUN_URL"
+      - name: Wait for main CI verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_COMMIT: ${{ steps.command.outputs.target_commit }}
+        run: |
+          set -euo pipefail
+          deadline=$((SECONDS + 1800))
+          while (( SECONDS < deadline )); do
+            result="$(gh api "repos/$GITHUB_REPOSITORY/commits/$TARGET_COMMIT/check-runs" \
+              --jq '[.check_runs[] | select(.name == "verify")] | sort_by(.started_at) | last | [.status, (.conclusion // "")] | @tsv' 2>/dev/null || true)"
+            if [[ "$result" == $'completed\tsuccess' ]]; then
+              echo "CI verify succeeded for $TARGET_COMMIT"
+              exit 0
+            fi
+            if [[ "$result" == completed$'\t'* && "$result" != $'completed\tsuccess' ]]; then
+              echo "CI verify completed unsuccessfully: $result" >&2
+              exit 1
+            fi
+            sleep 10
+          done
+          echo "Timed out waiting for CI verify on $TARGET_COMMIT" >&2
+          exit 1
 
   release:
     needs: parse


### PR DESCRIPTION
Completes the ChatOps release loop so releases can be driven end-to-end from the connected GitHub conversation surface.

Changes:
- Release ChatOps waits up to 30 minutes for the target main commit's `verify` check instead of failing on normal CI races.
- Accepted commands include the exact Actions run URL for observability.
- Release ChatOps uses a v2 concurrency group so the corrected path is not blocked by an older environment-gated run.
- Removes the manual `production` environment gate from Web, Airflow, and WeChat sender operation jobs. Machine controls remain: owner-only Release Control issue, exact 40-char main SHA, successful CI verify, operation allowlists, preflight, exact-target checks, deployment health checks, concurrency locks, and explicit confirmation for any real WeChat probe.

This PR intentionally defaults release sender deployment off in ChatOps unless explicitly requested.