### PR TITLE
ci: make ChatOps release wait for CI and report runs

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -47,7 +47,7 @@ concurrency:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -70,7 +70,10 @@ jobs:
         run: |
           PYTHONPATH=scripts python scripts/github_release_gate.py \
             --target-commit "${{ inputs.target_commit }}" \
-            --required-check verify --format json
+            --required-check verify \
+            --wait-seconds 1200 \
+            --poll-seconds 10 \
+            --format json
 
   webapp:
     needs: gate

--- a/.github/workflows/release-chatops.yml
+++ b/.github/workflows/release-chatops.yml
@@ -53,9 +53,10 @@ jobs:
           MODE: ${{ steps.command.outputs.mode }}
           TARGET_COMMIT: ${{ steps.command.outputs.target_commit }}
           INCLUDE_SENDER: ${{ steps.command.outputs.include_sender }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body \
-            "Accepted production release command: mode=\`$MODE\`, commit=\`$TARGET_COMMIT\`, sender=\`$INCLUDE_SENDER\`. Existing release gates remain authoritative."
+            "Accepted production release command: mode=\`$MODE\`, commit=\`$TARGET_COMMIT\`, sender=\`$INCLUDE_SENDER\`. Run: $RUN_URL. Existing release gates remain authoritative."
 
   release:
     needs: parse

--- a/scripts/github_release_gate.py
+++ b/scripts/github_release_gate.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import os
 import re
+import time
 import urllib.error
 import urllib.request
 from typing import Any
@@ -55,10 +56,31 @@ def fetch_check_runs(repository: str, commit: str, token: str) -> Any:
         raise OpsError("GitHub check-runs API returned invalid JSON") from exc
 
 
+def wait_for_required_check(
+    repository: str,
+    commit: str,
+    token: str,
+    name: str,
+    wait_seconds: float,
+    poll_seconds: float,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        check = required_check_result(fetch_check_runs(repository, commit, token), name)
+        if check["status"] == "completed" or wait_seconds <= 0:
+            return check
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return check
+        time.sleep(min(poll_seconds, remaining))
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Validate an exact GitHub release candidate.")
     parser.add_argument("--target-commit", required=True)
     parser.add_argument("--required-check", default="verify")
+    parser.add_argument("--wait-seconds", type=float, default=0)
+    parser.add_argument("--poll-seconds", type=float, default=10)
     parser.add_argument("--format", choices=("text", "json"), default="text")
     args = parser.parse_args()
 
@@ -70,6 +92,10 @@ def main() -> None:
         raise OpsError("GITHUB_REPOSITORY must be owner/name")
     if not token:
         raise OpsError("GITHUB_TOKEN is required")
+    if args.wait_seconds < 0:
+        raise OpsError("wait seconds must not be negative")
+    if args.poll_seconds <= 0:
+        raise OpsError("poll seconds must be positive")
 
     run(["git", "fetch", "--quiet", "origin", "main"])
     on_main = (
@@ -79,8 +105,13 @@ def main() -> None:
         ).returncode
         == 0
     )
-    check = required_check_result(
-        fetch_check_runs(repository, args.target_commit, token), args.required_check
+    check = wait_for_required_check(
+        repository,
+        args.target_commit,
+        token,
+        args.required_check,
+        args.wait_seconds,
+        args.poll_seconds,
     )
     checks = {
         "target_commit_on_main": on_main,

--- a/tests/release_gate_wait_test.py
+++ b/tests/release_gate_wait_test.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS_DIR = Path(__file__).parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import github_release_gate  # noqa: E402
+
+
+def test_release_gate_waits_for_running_check() -> None:
+    running = {
+        "check_runs": [
+            {
+                "id": 10,
+                "name": "verify",
+                "status": "in_progress",
+                "conclusion": None,
+            }
+        ]
+    }
+    ready = {
+        "check_runs": [
+            {
+                "id": 10,
+                "name": "verify",
+                "status": "completed",
+                "conclusion": "success",
+            }
+        ]
+    }
+    with (
+        patch.object(github_release_gate, "fetch_check_runs", side_effect=[running, ready]) as fetch,
+        patch.object(github_release_gate.time, "monotonic", side_effect=[0, 1]),
+        patch.object(github_release_gate.time, "sleep") as sleep,
+    ):
+        result = github_release_gate.wait_for_required_check(
+            "owner/repo",
+            "a" * 40,
+            "token",
+            "verify",
+            30,
+            5,
+        )
+
+    assert result["ok"] is True
+    assert fetch.call_count == 2
+    sleep.assert_called_once_with(5)
+
+
+def test_release_gate_does_not_wait_after_completed_failure() -> None:
+    failed = {
+        "check_runs": [
+            {
+                "id": 10,
+                "name": "verify",
+                "status": "completed",
+                "conclusion": "failure",
+            }
+        ]
+    }
+    with (
+        patch.object(github_release_gate, "fetch_check_runs", return_value=failed),
+        patch.object(github_release_gate.time, "sleep") as sleep,
+    ):
+        result = github_release_gate.wait_for_required_check(
+            "owner/repo",
+            "a" * 40,
+            "token",
+            "verify",
+            30,
+            5,
+        )
+
+    assert result["ok"] is False
+    assert result["conclusion"] == "failure"
+    sleep.assert_not_called()

--- a/tests/release_gate_wait_test.py
+++ b/tests/release_gate_wait_test.py
@@ -37,7 +37,11 @@ def test_release_gate_waits_for_running_check() -> None:
             "fetch_check_runs",
             side_effect=[running, ready],
         ) as fetch,
-        patch.object(github_release_gate.time, "monotonic", side_effect=[0, 1]),
+        patch.object(
+            github_release_gate.time,
+            "monotonic",
+            side_effect=[0, 1],
+        ),
         patch.object(github_release_gate.time, "sleep") as sleep,
     ):
         result = github_release_gate.wait_for_required_check(

--- a/tests/release_gate_wait_test.py
+++ b/tests/release_gate_wait_test.py
@@ -32,7 +32,11 @@ def test_release_gate_waits_for_running_check() -> None:
         ]
     }
     with (
-        patch.object(github_release_gate, "fetch_check_runs", side_effect=[running, ready]) as fetch,
+        patch.object(
+            github_release_gate,
+            "fetch_check_runs",
+            side_effect=[running, ready],
+        ) as fetch,
         patch.object(github_release_gate.time, "monotonic", side_effect=[0, 1]),
         patch.object(github_release_gate.time, "sleep") as sleep,
     ):


### PR DESCRIPTION
Superseded by the autonomous ChatOps implementation already merged to main. Main now waits for `verify` at the ChatOps entry, reports the Actions run URL immediately, and isolates release concurrency; keeping this PR open would duplicate that behavior.