### PR TITLE
ci: isolate autonomous release concurrency

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -41,7 +41,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-release
+  group: production-release-v2
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/production-webapp.yml
+++ b/.github/workflows/production-webapp.yml
@@ -37,7 +37,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-webapp
+  group: production-webapp-v2
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Superseded by the merged autonomous release concurrency and current-main ChatOps workflows. Closing this historical duplicate to prevent accidental merge.