### PR TITLE
ci: isolate autonomous production concurrency locks

### DIFF
--- a/.github/workflows/production-airflow.yml
+++ b/.github/workflows/production-airflow.yml
@@ -63,7 +63,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-airflow
+  group: production-airflow-v2
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -41,7 +41,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-release
+  group: production-release-v2
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/production-webapp.yml
+++ b/.github/workflows/production-webapp.yml
@@ -37,7 +37,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-webapp
+  group: production-webapp-v2
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/production-wechat-sender.yml
+++ b/.github/workflows/production-wechat-sender.yml
@@ -52,7 +52,7 @@ jobs:
       WECHAT_SENDER_SSH_PORT: ${{ secrets.WECHAT_SENDER_SSH_PORT }}
       WECHAT_SENDER_SSH_USER: ${{ secrets.WECHAT_SENDER_SSH_USER }}
     steps:
-      - uses: actions/checkout@3d342e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.target_commit }}
           fetch-depth: 0

--- a/.github/workflows/production-wechat-sender.yml
+++ b/.github/workflows/production-wechat-sender.yml
@@ -40,7 +40,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-wechat-sender
+  group: production-wechat-sender-v2
   cancel-in-progress: false
 
 jobs:
@@ -52,7 +52,7 @@ jobs:
       WECHAT_SENDER_SSH_PORT: ${{ secrets.WECHAT_SENDER_SSH_PORT }}
       WECHAT_SENDER_SSH_USER: ${{ secrets.WECHAT_SENDER_SSH_USER }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d342e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.target_commit }}
           fetch-depth: 0


### PR DESCRIPTION
Moves the autonomous production release, Web, Airflow, and sender concurrency groups to a v2 namespace. This preserves single-flight protection for all new production operations while allowing the new no-manual-approval pipeline to proceed independently of historical runs that are still blocked on the retired production environment approval. No deployment logic, target validation, health checks, or real-send safeguards are relaxed.