### PR TITLE
ci: isolate autonomous ChatOps entry lock

### DIFF
--- a/.github/workflows/release-chatops.yml
+++ b/.github/workflows/release-chatops.yml
@@ -11,7 +11,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: release-chatops-v2
+  group: release-chatops-v3
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Moves the Release ChatOps concurrency group to `release-chatops-v3`. This is a one-line isolation change so historical v2 ChatOps runs blocked behind the retired approval-based pipeline cannot prevent new fully autonomous releases from starting. All owner-only parsing, CI wait, exact-main-commit release gates, preflight, health checks, and real-send safeguards remain unchanged.