### PR TITLE
ci: bind protected production jobs to production environment

### DIFF
--- a/.github/workflows/production-airflow.yml
+++ b/.github/workflows/production-airflow.yml
@@ -69,6 +69,7 @@ concurrency:
 jobs:
   operate:
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 45
     env:
       AIRFLOW_SSH_HOST: ${{ secrets.AIRFLOW_SSH_HOST }}

--- a/.github/workflows/production-webapp.yml
+++ b/.github/workflows/production-webapp.yml
@@ -43,6 +43,7 @@ concurrency:
 jobs:
   operate:
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 30
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/production-wechat-sender.yml
+++ b/.github/workflows/production-wechat-sender.yml
@@ -46,6 +46,7 @@ concurrency:
 jobs:
   operate:
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 30
     env:
       WECHAT_SENDER_SSH_HOST: ${{ secrets.WECHAT_SENDER_SSH_HOST }}


### PR DESCRIPTION
Bind the Web, Airflow, and WeChat sender protected jobs to the GitHub `production` Environment so environment-scoped production secrets are actually injected. This keeps all existing exact-main-commit gates, CI verification, component concurrency, and release ordering unchanged while making the current ChatOps release path compatible with production Environment secrets.