### PR TITLE
ops: add Web observation production diagnosis

### DIFF
--- a/.github/workflows/ops-chatops.yml
+++ b/.github/workflows/ops-chatops.yml
@@ -1,0 +1,97 @@
+name: Production Ops ChatOps
+run-name: ops-chatops/${{ github.event.comment.id }}
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  checks: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: production-ops-chatops
+  cancel-in-progress: false
+
+jobs:
+  parse:
+    if: >-
+      github.event.issue.number == 39 &&
+      github.event.comment.user.login == github.repository_owner &&
+      startsWith(github.event.comment.body, '/ops ')
+    runs-on: ubuntu-latest
+    outputs:
+      target_commit: ${{ steps.command.outputs.target_commit }}
+    steps:
+      - name: Parse exact ops command
+        id: command
+        shell: bash
+        env:
+          OPS_COMMAND: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          pattern='^/ops webapp-observation-diagnose ([0-9A-Fa-f]{40})$'
+          if [[ ! "$OPS_COMMAND" =~ $pattern ]]; then
+            echo 'Expected: /ops webapp-observation-diagnose <40-char-sha>' >&2
+            exit 2
+          fi
+          target_commit="${BASH_REMATCH[1],,}"
+          echo "target_commit=$target_commit" >> "$GITHUB_OUTPUT"
+      - name: Wait for main CI verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_COMMIT: ${{ steps.command.outputs.target_commit }}
+        run: |
+          set -euo pipefail
+          deadline=$((SECONDS + 1800))
+          while (( SECONDS < deadline )); do
+            result="$(gh api "repos/$GITHUB_REPOSITORY/commits/$TARGET_COMMIT/check-runs" \
+              --jq '[.check_runs[] | select(.name == "verify")] | sort_by(.started_at) | last | [.status, (.conclusion // "")] | @tsv' 2>/dev/null || true)"
+            if [[ "$result" == $'completed\tsuccess' ]]; then
+              exit 0
+            fi
+            if [[ "$result" == completed$'\t'* && "$result" != $'completed\tsuccess' ]]; then
+              echo "CI verify failed: $result" >&2
+              exit 1
+            fi
+            sleep 10
+          done
+          exit 1
+      - name: Acknowledge diagnosis
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TARGET_COMMIT: ${{ steps.command.outputs.target_commit }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body \
+            "Accepted read-only Web observation diagnosis for \`$TARGET_COMMIT\`. Run: $RUN_URL"
+
+  diagnose:
+    needs: parse
+    uses: ./.github/workflows/production-airflow.yml
+    with:
+      operation: webapp_observation_diagnose
+      target_commit: ${{ needs.parse.outputs.target_commit }}
+      request_id: ops-${{ github.run_id }}
+      confirm_real_send: false
+      probe_target_membership: all
+    secrets: inherit
+
+  report:
+    if: always() && needs.parse.result != 'skipped'
+    needs: [parse, diagnose]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report diagnosis result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TARGET_COMMIT: ${{ needs.parse.outputs.target_commit }}
+          RESULT: ${{ needs.diagnose.result }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body \
+            "Web observation diagnosis for \`$TARGET_COMMIT\`: \`$RESULT\`. Run: $RUN_URL"
+          test "$RESULT" = success

--- a/.github/workflows/production-airflow.yml
+++ b/.github/workflows/production-airflow.yml
@@ -34,6 +34,7 @@ on:
           - deploy_recovery
           - db_cleanup_check
           - phone_diagnose
+          - webapp_observation_diagnose
           - wechat_delivery_diagnose
           - wechat_delivery_probe
           - wechat_quiesce
@@ -134,6 +135,9 @@ jobs:
               ;;
             phone_diagnose)
               PYTHONPATH=src python scripts/diagnose_zacks_phone.py --format json
+              ;;
+            webapp_observation_diagnose)
+              bash scripts/diagnose_webapp_observation.sh
               ;;
             wechat_delivery_diagnose)
               PYTHONPATH=scripts python scripts/diagnose_wechat_delivery.py --format json

--- a/scripts/diagnose_webapp_observation.sh
+++ b/scripts/diagnose_webapp_observation.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_path="${AIRFLOW_REPOSITORY_PATH:?AIRFLOW_REPOSITORY_PATH is required}"
+ssh_target="${AIRFLOW_SSH_USER:?AIRFLOW_SSH_USER is required}@${AIRFLOW_SSH_HOST:?AIRFLOW_SSH_HOST is required}"
+ssh_port="${AIRFLOW_SSH_PORT:?AIRFLOW_SSH_PORT is required}"
+
+ssh -o BatchMode=yes -o PreferredAuthentications=publickey -o PasswordAuthentication=no \
+  -o StrictHostKeyChecking=yes -o ConnectTimeout=15 -p "$ssh_port" "$ssh_target" \
+  bash -s -- "$repo_path" <<'REMOTE'
+set -euo pipefail
+cd "$1"
+compose() {
+  if docker compose version >/dev/null 2>&1; then
+    docker compose "$@"
+  else
+    docker-compose "$@"
+  fi
+}
+service="$(compose ps --services --status running | awk '/^airflow-api-server$|^web$/{print; exit}')"
+airflow_python() {
+  compose exec -T "$service" sh -c '
+    if [ -x /opt/bitnami/airflow/venv/bin/python ]; then
+      exec /opt/bitnami/airflow/venv/bin/python "$@"
+    fi
+    exec python "$@"
+  ' sh "$@"
+}
+airflow_python - <<'PY'
+import json
+import urllib.error
+import urllib.request
+from urllib.parse import urlsplit
+from airflow.models.variable import Variable
+
+url = str(Variable.get("WEBAPP_OBSERVATION_API_URL", default_var="") or "").strip()
+token = str(Variable.get("WEBAPP_OBSERVATION_API_TOKEN", default_var="") or "").strip()
+parsed = urlsplit(url) if url else None
+result = {
+    "url_configured": bool(url),
+    "token_configured": bool(token),
+    "url_scheme": parsed.scheme if parsed else "",
+    "url_host": parsed.netloc if parsed else "",
+    "url_path": parsed.path if parsed else "",
+}
+if url and token:
+    request = urllib.request.Request(
+        url,
+        data=b"{",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "zacks-airflow-diagnose/1",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=8) as response:
+            status = response.getcode()
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+    except Exception as exc:
+        result["probe_error_type"] = type(exc).__name__
+        result["probe_error"] = str(exc)[:200]
+    else:
+        result["auth_probe_status"] = status
+        result["auth_probe_ok"] = status == 400
+print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+PY
+printf '%s\n' '__WEBAPP_LOGS__'
+for candidate in airflow-worker worker airflow-scheduler scheduler "$service"; do
+  if compose ps --services --status running | grep -qx "$candidate"; then
+    compose exec -T "$candidate" sh -lc '
+      find /opt/airflow/logs -type f -mmin -30 -print0 2>/dev/null \
+        | xargs -0 -r grep -hF "[WEBAPP]" 2>/dev/null \
+        | tail -n 120
+    ' || true
+  fi
+done
+REMOTE
+
+printf '%s\n' '__PUBLIC_BOOTSTRAP__'
+python - <<'PY'
+import json
+import urllib.request
+
+request = urllib.request.Request(
+    "https://zacks.claude89757.cc/api/bootstrap",
+    headers={"Accept": "application/json", "User-Agent": "zacks-production-diagnose/1"},
+)
+with urllib.request.urlopen(request, timeout=10) as response:
+    payload = json.loads(response.read().decode("utf-8"))
+print(json.dumps({
+    "metrics": payload.get("metrics", {}),
+    "venues": [
+        {
+            "id": venue.get("id"),
+            "healthy": venue.get("healthy"),
+            "lastInspectionAt": venue.get("lastInspectionAt"),
+        }
+        for venue in payload.get("venues", [])
+        if isinstance(venue, dict)
+    ],
+}, ensure_ascii=False, sort_keys=True))
+PY


### PR DESCRIPTION
Rebased on latest main. Adds a read-only owner-only production diagnosis for Airflow → Web observation publishing: checks configured URL/token presence, performs a non-mutating malformed-JSON auth probe (400=auth accepted, 401=token mismatch), tails recent [WEBAPP] logs, and reads public bootstrap venue timestamps. No D1 write, email, or WeChat send.