### PR TITLE
ops: make Web observation diagnosis fast and independent

### DIFF
--- a/.github/workflows/ops-chatops.yml
+++ b/.github/workflows/ops-chatops.yml
@@ -11,7 +11,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: production-ops-chatops
+  group: production-ops-chatops-${{ github.event.comment.id }}
   cancel-in-progress: false
 
 jobs:
@@ -70,14 +70,38 @@ jobs:
 
   diagnose:
     needs: parse
-    uses: ./.github/workflows/production-airflow.yml
-    with:
-      operation: webapp_observation_diagnose
-      target_commit: ${{ needs.parse.outputs.target_commit }}
-      request_id: ops-${{ github.run_id }}
-      confirm_real_send: false
-      probe_target_membership: all
-    secrets: inherit
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 10
+    env:
+      AIRFLOW_SSH_HOST: ${{ secrets.AIRFLOW_SSH_HOST }}
+      AIRFLOW_SSH_PORT: ${{ secrets.AIRFLOW_SSH_PORT }}
+      AIRFLOW_SSH_USER: ${{ secrets.AIRFLOW_SSH_USER }}
+      AIRFLOW_REPOSITORY_PATH: ${{ secrets.AIRFLOW_REPOSITORY_PATH }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.parse.outputs.target_commit }}
+          fetch-depth: 0
+      - name: Validate exact main target
+        env:
+          TARGET_COMMIT: ${{ needs.parse.outputs.target_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$TARGET_COMMIT"
+          git fetch --quiet origin main
+          git merge-base --is-ancestor "$TARGET_COMMIT" origin/main
+      - name: Configure production SSH identity
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.AIRFLOW_SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.AIRFLOW_SSH_KNOWN_HOSTS }}
+        run: |
+          umask 077
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+      - name: Diagnose Airflow to Web observations
+        run: bash scripts/diagnose_webapp_observation.sh
 
   report:
     if: always() && needs.parse.result != 'skipped'

--- a/scripts/diagnose_webapp_observation.sh
+++ b/scripts/diagnose_webapp_observation.sh
@@ -19,6 +19,7 @@ compose() {
   fi
 }
 service="$(compose ps --services --status running | awk '/^airflow-api-server$|^web$/{print; exit}')"
+test -n "$service"
 airflow_python() {
   compose exec -T "$service" sh -c '
     if [ -x /opt/bitnami/airflow/venv/bin/python ]; then
@@ -51,10 +52,11 @@ if url and token:
         headers={
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
-            "User-Agent": "zacks-airflow-diagnose/2",
+            "User-Agent": "zacks-airflow-diagnose/3",
         },
         method="POST",
     )
+    status = None
     try:
         with urllib.request.urlopen(request, timeout=8) as response:
             status = response.getcode()
@@ -63,22 +65,11 @@ if url and token:
     except Exception as exc:
         result["probe_error_type"] = type(exc).__name__
         result["probe_error"] = str(exc)[:200]
-    else:
+    if status is not None:
         result["auth_probe_status"] = status
         result["auth_probe_ok"] = status == 400
 print(json.dumps(result, ensure_ascii=False, sort_keys=True))
 PY
-printf '%s\n' '__WEBAPP_LOGS__'
-for candidate in airflow-worker worker; do
-  if compose ps --services --status running | grep -qx "$candidate"; then
-    timeout 8s compose exec -T "$candidate" sh -lc '
-      find /opt/airflow/logs -type f -mmin -10 -size -2M -print0 2>/dev/null \
-        | head -z -n 80 \
-        | xargs -0 -r grep -hF "[WEBAPP]" 2>/dev/null \
-        | tail -n 80
-    ' || true
-  fi
-done
 REMOTE
 
 printf '%s\n' '__PUBLIC_BOOTSTRAP__'
@@ -88,7 +79,7 @@ import urllib.request
 
 request = urllib.request.Request(
     "https://zacks.claude89757.cc/api/bootstrap",
-    headers={"Accept": "application/json", "User-Agent": "zacks-production-diagnose/2"},
+    headers={"Accept": "application/json", "User-Agent": "zacks-production-diagnose/3"},
 )
 with urllib.request.urlopen(request, timeout=10) as response:
     payload = json.loads(response.read().decode("utf-8"))


### PR DESCRIPTION
Superseded by the production observation diagnosis already merged through PRs #49–#51 and by the current-main ChatOps control path now on `main`. Closing to avoid accidentally reintroducing an older overlapping implementation.