### PR TITLE
fix(ci): wait for verify before production release

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -47,7 +47,7 @@ concurrency:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -70,7 +70,10 @@ jobs:
         run: |
           PYTHONPATH=scripts python scripts/github_release_gate.py \
             --target-commit "${{ inputs.target_commit }}" \
-            --required-check verify --format json
+            --required-check verify \
+            --wait-seconds 1800 \
+            --poll-seconds 10 \
+            --format json
 
   webapp:
     needs: gate

--- a/scripts/github_release_gate.py
+++ b/scripts/github_release_gate.py
@@ -5,8 +5,10 @@ import argparse
 import json
 import os
 import re
+import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from typing import Any
 
 from _ops import OpsError, emit, run
@@ -55,10 +57,76 @@ def fetch_check_runs(repository: str, commit: str, token: str) -> Any:
         raise OpsError("GitHub check-runs API returned invalid JSON") from exc
 
 
+def wait_for_required_check(
+    repository: str,
+    commit: str,
+    token: str,
+    name: str,
+    *,
+    wait_seconds: float,
+    poll_seconds: float,
+    fetcher: Callable[[str, str, str], Any] = fetch_check_runs,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> tuple[dict[str, Any], bool]:
+    """Wait for a required GitHub check to finish.
+
+    A check may be absent for a short period after a push, or already present but
+    still queued/in progress. Those are normal CI states and must not be treated
+    as a failed release. A terminal non-success conclusion still fails
+    immediately, and the wait is bounded by ``wait_seconds``.
+    """
+    deadline = monotonic() + wait_seconds
+    while True:
+        check = required_check_result(fetcher(repository, commit, token), name)
+        if check["status"] == "completed":
+            return check, False
+        if monotonic() >= deadline:
+            return check, True
+        sleeper(poll_seconds)
+
+
+def release_payload(
+    *,
+    target_commit: str,
+    required_check: str,
+    on_main: bool,
+    check: dict[str, Any],
+    timed_out: bool,
+) -> dict[str, Any]:
+    checks = {
+        "target_commit_on_main": on_main,
+        "required_check_present": check["present"],
+        "required_check_completed": check["status"] == "completed",
+        "required_check_successful": check["ok"],
+    }
+    return {
+        "ok": all(checks.values()),
+        "target_commit": target_commit,
+        "required_check": required_check,
+        "check_status": check["status"],
+        "check_conclusion": check["conclusion"],
+        "timed_out_waiting_for_check": timed_out,
+        "checks": checks,
+    }
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Validate an exact GitHub release candidate.")
     parser.add_argument("--target-commit", required=True)
     parser.add_argument("--required-check", default="verify")
+    parser.add_argument(
+        "--wait-seconds",
+        type=float,
+        default=3600,
+        help="Maximum time to wait for the required check to appear and complete.",
+    )
+    parser.add_argument(
+        "--poll-seconds",
+        type=float,
+        default=10,
+        help="Polling interval while the required check is queued, in progress, or not yet visible.",
+    )
     parser.add_argument("--format", choices=("text", "json"), default="text")
     args = parser.parse_args()
 
@@ -70,6 +138,10 @@ def main() -> None:
         raise OpsError("GITHUB_REPOSITORY must be owner/name")
     if not token:
         raise OpsError("GITHUB_TOKEN is required")
+    if args.wait_seconds < 0:
+        raise OpsError("wait seconds must be non-negative")
+    if args.poll_seconds <= 0:
+        raise OpsError("poll seconds must be positive")
 
     run(["git", "fetch", "--quiet", "origin", "main"])
     on_main = (
@@ -79,23 +151,27 @@ def main() -> None:
         ).returncode
         == 0
     )
-    check = required_check_result(
-        fetch_check_runs(repository, args.target_commit, token), args.required_check
+
+    if on_main:
+        check, timed_out = wait_for_required_check(
+            repository,
+            args.target_commit,
+            token,
+            args.required_check,
+            wait_seconds=args.wait_seconds,
+            poll_seconds=args.poll_seconds,
+        )
+    else:
+        check = required_check_result({}, args.required_check)
+        timed_out = False
+
+    payload = release_payload(
+        target_commit=args.target_commit,
+        required_check=args.required_check,
+        on_main=on_main,
+        check=check,
+        timed_out=timed_out,
     )
-    checks = {
-        "target_commit_on_main": on_main,
-        "required_check_present": check["present"],
-        "required_check_completed": check["status"] == "completed",
-        "required_check_successful": check["ok"],
-    }
-    payload = {
-        "ok": all(checks.values()),
-        "target_commit": args.target_commit,
-        "required_check": args.required_check,
-        "check_status": check["status"],
-        "check_conclusion": check["conclusion"],
-        "checks": checks,
-    }
     emit(payload, args.format)
     if not payload["ok"]:
         raise SystemExit(1)

--- a/tests/github_release_gate_test.py
+++ b/tests/github_release_gate_test.py
@@ -12,8 +12,26 @@ import github_release_gate  # noqa: E402
 def test_waits_for_in_progress_verify_then_succeeds():
     payloads = iter(
         [
-            {"check_runs": [{"id": 1, "name": "verify", "status": "in_progress", "conclusion": None}]},
-            {"check_runs": [{"id": 1, "name": "verify", "status": "completed", "conclusion": "success"}]},
+            {
+                "check_runs": [
+                    {
+                        "id": 1,
+                        "name": "verify",
+                        "status": "in_progress",
+                        "conclusion": None,
+                    }
+                ]
+            },
+            {
+                "check_runs": [
+                    {
+                        "id": 1,
+                        "name": "verify",
+                        "status": "completed",
+                        "conclusion": "success",
+                    }
+                ]
+            },
         ]
     )
     sleeps: list[float] = []
@@ -40,7 +58,16 @@ def test_waits_when_verify_is_not_visible_yet():
     payloads = iter(
         [
             {"check_runs": []},
-            {"check_runs": [{"id": 7, "name": "verify", "status": "completed", "conclusion": "success"}]},
+            {
+                "check_runs": [
+                    {
+                        "id": 7,
+                        "name": "verify",
+                        "status": "completed",
+                        "conclusion": "success",
+                    }
+                ]
+            },
         ]
     )
     clock = iter([0.0, 0.0, 1.0])
@@ -74,7 +101,12 @@ def test_terminal_failed_verify_fails_without_sleeping():
         poll_seconds=5,
         fetcher=lambda *_: {
             "check_runs": [
-                {"id": 2, "name": "verify", "status": "completed", "conclusion": "failure"}
+                {
+                    "id": 2,
+                    "name": "verify",
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
             ]
         },
         monotonic=lambda: 0.0,
@@ -99,7 +131,14 @@ def test_wait_is_bounded_when_verify_never_completes():
         wait_seconds=10,
         poll_seconds=5,
         fetcher=lambda *_: {
-            "check_runs": [{"id": 3, "name": "verify", "status": "queued", "conclusion": None}]
+            "check_runs": [
+                {
+                    "id": 3,
+                    "name": "verify",
+                    "status": "queued",
+                    "conclusion": None,
+                }
+            ]
         },
         monotonic=lambda: next(times),
         sleeper=sleeps.append,

--- a/tests/github_release_gate_test.py
+++ b/tests/github_release_gate_test.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import github_release_gate  # noqa: E402
+
+
+def test_waits_for_in_progress_verify_then_succeeds():
+    payloads = iter(
+        [
+            {"check_runs": [{"id": 1, "name": "verify", "status": "in_progress", "conclusion": None}]},
+            {"check_runs": [{"id": 1, "name": "verify", "status": "completed", "conclusion": "success"}]},
+        ]
+    )
+    sleeps: list[float] = []
+    clock = iter([0.0, 0.0, 1.0])
+
+    check, timed_out = github_release_gate.wait_for_required_check(
+        "owner/repo",
+        "a" * 40,
+        "token",
+        "verify",
+        wait_seconds=30,
+        poll_seconds=5,
+        fetcher=lambda *_: next(payloads),
+        monotonic=lambda: next(clock),
+        sleeper=sleeps.append,
+    )
+
+    assert timed_out is False
+    assert check["ok"] is True
+    assert sleeps == [5]
+
+
+def test_waits_when_verify_is_not_visible_yet():
+    payloads = iter(
+        [
+            {"check_runs": []},
+            {"check_runs": [{"id": 7, "name": "verify", "status": "completed", "conclusion": "success"}]},
+        ]
+    )
+    clock = iter([0.0, 0.0, 1.0])
+
+    check, timed_out = github_release_gate.wait_for_required_check(
+        "owner/repo",
+        "a" * 40,
+        "token",
+        "verify",
+        wait_seconds=30,
+        poll_seconds=5,
+        fetcher=lambda *_: next(payloads),
+        monotonic=lambda: next(clock),
+        sleeper=lambda _: None,
+    )
+
+    assert timed_out is False
+    assert check["present"] is True
+    assert check["ok"] is True
+
+
+def test_terminal_failed_verify_fails_without_sleeping():
+    sleeps: list[float] = []
+
+    check, timed_out = github_release_gate.wait_for_required_check(
+        "owner/repo",
+        "a" * 40,
+        "token",
+        "verify",
+        wait_seconds=30,
+        poll_seconds=5,
+        fetcher=lambda *_: {
+            "check_runs": [
+                {"id": 2, "name": "verify", "status": "completed", "conclusion": "failure"}
+            ]
+        },
+        monotonic=lambda: 0.0,
+        sleeper=sleeps.append,
+    )
+
+    assert timed_out is False
+    assert check["ok"] is False
+    assert check["conclusion"] == "failure"
+    assert sleeps == []
+
+
+def test_wait_is_bounded_when_verify_never_completes():
+    times = iter([0.0, 0.0, 10.0])
+    sleeps: list[float] = []
+
+    check, timed_out = github_release_gate.wait_for_required_check(
+        "owner/repo",
+        "a" * 40,
+        "token",
+        "verify",
+        wait_seconds=10,
+        poll_seconds=5,
+        fetcher=lambda *_: {
+            "check_runs": [{"id": 3, "name": "verify", "status": "queued", "conclusion": None}]
+        },
+        monotonic=lambda: next(times),
+        sleeper=sleeps.append,
+    )
+
+    assert timed_out is True
+    assert check["status"] == "queued"
+    assert sleeps == [5]


### PR DESCRIPTION
## 问题

生产发布门禁在 `CI / verify` 仍为 `queued` 或 `in_progress` 时立即失败，形成 CI 与 release ChatOps 的竞态。实际失败 run `32583454203` 已确认：目标 commit 在 main 上、verify 已存在，但状态为 `in_progress`，门禁立即 exit 1。

## 修复

- `github_release_gate.py` 对 required check 进行有界轮询
- check 尚未出现、queued、in_progress 时继续等待
- check 明确完成且失败时立即失败，不掩盖真实 CI 错误
- 默认最长等待 1 小时；production release 显式使用 30 分钟、10 秒轮询
- gate job timeout 调整为 35 分钟，避免 workflow 自身 10 分钟 timeout 抢先终止
- 增加回归测试覆盖：in-progress → success、延迟出现、明确失败、等待超时

## 安全边界

仍严格要求：目标为 main 上的精确 40 位 SHA，且 `verify` 最终必须成功。没有绕过 CI，也没有降低 production Environment 或 deployment gate。