### PR TITLE
fix(ci): repair admin acceptance output path

### DIFF
--- a/scripts/accept_webapp_admin.sh
+++ b/scripts/accept_webapp_admin.sh
@@ -39,7 +39,7 @@ wrangler d1 execute zacks-tennis-alerts --remote --command \
 
 wrangler d1 execute zacks-tennis-alerts --remote --json --command \
   "SELECT email,role,revoked_at FROM user_roles WHERE email='claudexzt@gmail.com' AND role='admin';" \
-  > "../$output_dir/d1-admin.json"
+  > "$output_dir/d1-admin.json"
 
 base="https://zacks.claude89757.cc"
 curl -fsS "$base/api/healthz" > "$output_dir/health.json"


### PR DESCRIPTION
Fix the production admin acceptance harness so Wrangler D1 evidence is redirected into the repository-local acceptance directory. The previous `../$output_dir` redirect was resolved by the outer shell before the `wrangler()` subshell changed into `webapp`, causing the acceptance run to fail before API/browser checks. No production business logic changes.