### PR TITLE
chore(deps): resolve stale Airflow, cryptography and CI action updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           cache: npm

--- a/.github/workflows/production-airflow.yml
+++ b/.github/workflows/production-airflow.yml
@@ -89,7 +89,7 @@ jobs:
           test "$(git rev-parse HEAD)" = "$TARGET_COMMIT"
           git fetch --quiet origin main
           git merge-base --is-ancestor "$TARGET_COMMIT" origin/main
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Install operations dependencies

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           ref: ${{ inputs.target_commit }}
           fetch-depth: 0
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Validate release mode

--- a/.github/workflows/production-webapp.yml
+++ b/.github/workflows/production-webapp.yml
@@ -60,10 +60,10 @@ jobs:
           test "$(git rev-parse HEAD)" = "$TARGET_COMMIT"
           git fetch --quiet origin main
           git merge-base --is-ancestor "$TARGET_COMMIT" origin/main
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: inputs.operation != 'health'
         with:
           node-version: "24"

--- a/.github/workflows/production-wechat-sender.yml
+++ b/.github/workflows/production-wechat-sender.yml
@@ -64,7 +64,7 @@ jobs:
           test "$(git rev-parse HEAD)" = "$TARGET_COMMIT"
           git fetch --quiet origin main
           git merge-base --is-ancestor "$TARGET_COMMIT" origin/main
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Install operations dependencies

--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -1,6 +1,6 @@
-FROM apache/airflow:3.3.0-python3.12@sha256:b572e9241d7b09b295c9ea97adeb7b3dfc932e2fbcdebec59256dad69061bb29
+FROM apache/airflow:3.3.1-python3.12@sha256:b01a795dfbd113bbbfdf3ee169b8f27e9a0090ccef105f1a452b3594a11ed316
 
-ARG AIRFLOW_VERSION=3.3.0
+ARG AIRFLOW_VERSION=3.3.1
 ARG PYTHON_VERSION=3.12
 ARG CONSTRAINTS_URL=https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt
 

--- a/docker/airflow/requirements.txt
+++ b/docker/airflow/requirements.txt
@@ -1,7 +1,7 @@
-apache-airflow-providers-celery==3.21.0
-apache-airflow-providers-fab==3.7.1
+apache-airflow-providers-celery==3.23.1
+apache-airflow-providers-fab==3.8.0
 apache-airflow-providers-redis==4.5.0
-apache-airflow-providers-standard==1.15.0
+apache-airflow-providers-standard==1.17.0
 cryptography==50.0.0
-paramiko==3.5.1
+paramiko==5.0.0
 requests==2.34.2

--- a/docker/airflow/requirements.txt
+++ b/docker/airflow/requirements.txt
@@ -2,6 +2,6 @@ apache-airflow-providers-celery==3.21.0
 apache-airflow-providers-fab==3.7.1
 apache-airflow-providers-redis==4.5.0
 apache-airflow-providers-standard==1.15.0
-cryptography==48.0.1
+cryptography==50.0.0
 paramiko==3.5.1
 requests==2.34.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.12,<3.13"
 license = { file = "LICENSE" }
 authors = [{ name = "claude89757" }]
 dependencies = [
-  "cryptography==48.0.1",
+  "cryptography==50.0.0",
   "paramiko==3.5.1",
   "PyYAML==6.0.3",
   "requests==2.34.2",


### PR DESCRIPTION
Consolidates and corrects stale dependency PRs #18, #19, #20, #31 and #32.

Changes:
- upgrade the Airflow Python 3.12 image from 3.3.0 to 3.3.1 using the pinned digest proposed by Dependabot;
- align `AIRFLOW_VERSION`, Airflow provider pins and container dependencies with the official Airflow 3.3.1 Python 3.12 constraints;
- upgrade `cryptography` from 48.0.1 to 50.0.0 in both project and Airflow-container dependency sets;
- upgrade pinned `actions/setup-python` and `actions/setup-node` SHAs to v7 across CI and production workflows.

Why consolidated:
- the original #18 changed the image but left the constraints at 3.3.0;
- #31 could not pass against Airflow 3.3.0 constraints, which pin cryptography 48.0.1;
- changing the Airflow constraint set also requires provider and Paramiko pins to move together;
- merging each old PR separately would repeatedly invalidate the required `verify` check as main advances.

The Web lockfile updates #21 and #29 remain isolated for separate verification.