### PR TITLE
ops(test): one-time Tt WeChat acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,20 @@ jobs:
         run: make sender-image
       - name: Airflow 3 DAG imports
         run: make test-dags
+
+  one_time_wechat_tt_acceptance:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'opened' &&
+      github.actor == github.repository_owner &&
+      github.head_ref == 'agent/one-time-wechat-tt-acceptance-20260823' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    needs: verify
+    uses: ./.github/workflows/production-airflow.yml
+    with:
+      operation: wechat_delivery_probe
+      target_commit: 78557fdeb87987bade4fc50364ab11d6fa9dd011
+      request_id: one-time-tt-${{ github.run_id }}
+      confirm_real_send: true
+      probe_target_membership: direct:Tt
+    secrets: inherit


### PR DESCRIPTION
## Purpose

Run exactly one real, fixed-text acceptance message through the merged `wechat-on-airflow` production sender to the WeChat contact `Tt`.

## Guardrails

- this PR is operational and will **not be merged**
- the one-time job only runs for this exact same-repository owner branch and only on the PR `opened` event
- it waits for the repository's full `verify` job
- it targets immutable main commit `78557fdeb87987bade4fc50364ab11d6fa9dd011`
- the reusable production workflow validates that the target is on `main`, uses the protected `production` Environment, requires `confirm_real_send=true`, and sends the hard-coded acceptance text only
- target selector is fixed to `direct:Tt`

After evidence is collected, close this PR and delete the branch without merging.