### PR TITLE
fix(runtime): restore supported Airflow 3.3.0 contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and operational changes.
 
 ### Changed
 
+- Restore the Airflow image and provider pins to the supported 3.3.0 runtime
+  contract, and make CI reject Dockerfile, provider, Compose, or manifest
+  version drift before deployment.
 - Reduce the standard subscriber reminder cap from 30 to 10 digest emails per
   Shanghai calendar day; the priority cap remains 100.
 - Make GitHub the only production delivery control plane: workstations keep

--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -1,6 +1,6 @@
-FROM apache/airflow:3.3.1-python3.12@sha256:b01a795dfbd113bbbfdf3ee169b8f27e9a0090ccef105f1a452b3594a11ed316
+FROM apache/airflow:3.3.0-python3.12@sha256:b572e9241d7b09b295c9ea97adeb7b3dfc932e2fbcdebec59256dad69061bb29
 
-ARG AIRFLOW_VERSION=3.3.1
+ARG AIRFLOW_VERSION=3.3.0
 ARG PYTHON_VERSION=3.12
 ARG CONSTRAINTS_URL=https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt
 

--- a/docker/airflow/requirements.txt
+++ b/docker/airflow/requirements.txt
@@ -1,7 +1,7 @@
-apache-airflow-providers-celery==3.23.1
-apache-airflow-providers-fab==3.8.0
+apache-airflow-providers-celery==3.21.0
+apache-airflow-providers-fab==3.7.1
 apache-airflow-providers-redis==4.5.0
-apache-airflow-providers-standard==1.17.0
-cryptography==50.0.0
-paramiko==5.0.0
+apache-airflow-providers-standard==1.15.0
+cryptography==48.0.1
+paramiko==3.5.1
 requests==2.34.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.12,<3.13"
 license = { file = "LICENSE" }
 authors = [{ name = "claude89757" }]
 dependencies = [
-  "cryptography==50.0.0",
+  "cryptography==48.0.1",
   "paramiko==3.5.1",
   "PyYAML==6.0.3",
   "requests==2.34.2",

--- a/scripts/check_active_components.py
+++ b/scripts/check_active_components.py
@@ -54,6 +54,81 @@ def imported_modules(path: Path) -> set[str]:
     return modules
 
 
+def validate_airflow_runtime_contract(
+    *,
+    target: object,
+    production: object,
+    dockerfile: str,
+    airflow_requirements_text: str,
+    compose_image: object,
+) -> None:
+    if not isinstance(target, dict) or not isinstance(production, dict):
+        fail("Airflow runtime target version contract is incomplete")
+
+    airflow_version = str(target.get("airflow") or "")
+    python_version = str(target.get("python") or "")
+    base_image = str(target.get("base_image") or "")
+    providers = target.get("providers")
+    if (
+        not airflow_version
+        or not python_version
+        or not base_image
+        or not isinstance(providers, dict)
+        or not providers
+    ):
+        fail("Airflow runtime target version contract is incomplete")
+    if production.get("target_airflow") != airflow_version:
+        fail("active component target Airflow version must match the runtime target")
+    if production.get("python") != python_version:
+        fail("active component Python version must match the runtime target")
+
+    base_image_pattern = re.compile(
+        rf"apache/airflow:{re.escape(airflow_version)}-python"
+        rf"{re.escape(python_version)}@sha256:[0-9a-f]{{64}}"
+    )
+    if base_image_pattern.fullmatch(base_image) is None:
+        fail("Airflow base image must encode the declared Airflow and Python versions")
+
+    docker_instructions = {
+        line.strip()
+        for line in dockerfile.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    if f"FROM {base_image}" not in docker_instructions:
+        fail("Airflow Dockerfile base image must match the runtime target")
+    if f"ARG AIRFLOW_VERSION={airflow_version}" not in docker_instructions:
+        fail("Airflow Dockerfile version must match the runtime target")
+    if f"ARG PYTHON_VERSION={python_version}" not in docker_instructions:
+        fail("Airflow Dockerfile Python version must match the runtime target")
+
+    airflow_requirements = {
+        name: version
+        for raw_line in airflow_requirements_text.splitlines()
+        if (line := raw_line.strip()) and not line.startswith("#") and "==" in line
+        for name, version in [line.split("==", maxsplit=1)]
+    }
+    declared_provider_names = {str(name) for name in providers}
+    pinned_provider_names = {
+        name for name in airflow_requirements if name.startswith("apache-airflow-providers-")
+    }
+    if declared_provider_names != pinned_provider_names:
+        fail("Airflow provider requirement names must match the runtime target")
+    mismatched_providers = sorted(
+        name
+        for name, version in providers.items()
+        if airflow_requirements.get(str(name)) != str(version)
+    )
+    if mismatched_providers:
+        fail(
+            "Airflow provider requirements must match the runtime target: "
+            + ", ".join(mismatched_providers)
+        )
+
+    expected_compose_image = "${AIRFLOW_IMAGE_NAME:-wechat-on-airflow:" + airflow_version + "}"
+    if compose_image != expected_compose_image:
+        fail("Compose Airflow image default must match the runtime target")
+
+
 def dag_schedule_contract(path: Path) -> str:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     schedule_nodes = [
@@ -203,47 +278,18 @@ def main() -> None:
     if runtime_target.get("target", {}).get("dag_distribution") != "image":
         fail("Airflow DAG distribution must be declared as image")
     target = runtime_target.get("target", {})
-    airflow_version = str(target.get("airflow") or "")
-    python_version = str(target.get("python") or "")
-    base_image = str(target.get("base_image") or "")
-    providers = target.get("providers") or {}
-    if not airflow_version or not python_version or not isinstance(providers, dict):
-        fail("Airflow runtime target version contract is incomplete")
-    if (
-        production.get("current_airflow") != airflow_version
-        or production.get("target_airflow") != airflow_version
-    ):
-        fail("active component Airflow versions must match the runtime target")
-
     dockerfile = AIRFLOW_DOCKERFILE.read_text(encoding="utf-8")
-    if f"FROM {base_image}" not in dockerfile:
-        fail("Airflow Dockerfile base image must match the runtime target")
-    if f"ARG AIRFLOW_VERSION={airflow_version}" not in dockerfile:
-        fail("Airflow Dockerfile version must match the runtime target")
+    airflow_requirements_text = AIRFLOW_REQUIREMENTS.read_text(encoding="utf-8")
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    validate_airflow_runtime_contract(
+        target=target,
+        production=production,
+        dockerfile=dockerfile,
+        airflow_requirements_text=airflow_requirements_text,
+        compose_image=compose.get("x-airflow-common", {}).get("image"),
+    )
     if "dags /opt/airflow/dags" not in dockerfile:
         fail("Airflow image must copy dags/ into /opt/airflow/dags")
-
-    airflow_requirements = {
-        name: version
-        for line in AIRFLOW_REQUIREMENTS.read_text(encoding="utf-8").splitlines()
-        if line and not line.startswith("#") and "==" in line
-        for name, version in [line.split("==", maxsplit=1)]
-    }
-    mismatched_providers = sorted(
-        name
-        for name, version in providers.items()
-        if airflow_requirements.get(name) != str(version)
-    )
-    if mismatched_providers:
-        fail(
-            "Airflow provider requirements must match the runtime target: "
-            + ", ".join(mismatched_providers)
-        )
-    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
-    compose_image = compose.get("x-airflow-common", {}).get("image")
-    expected_compose_image = "${AIRFLOW_IMAGE_NAME:-wechat-on-airflow:" + airflow_version + "}"
-    if compose_image != expected_compose_image:
-        fail("Compose Airflow image default must match the runtime target")
     airflow_volumes = compose.get("x-airflow-common", {}).get("volumes", [])
     if any("/opt/airflow/dags" in str(volume) for volume in airflow_volumes):
         fail("Airflow services must use image-bundled DAGs, not a host DAG mount")

--- a/scripts/check_active_components.py
+++ b/scripts/check_active_components.py
@@ -14,6 +14,7 @@ MANIFEST = ROOT / "config" / "active-components.yaml"
 CONTRACTS = ROOT / "config" / "config-contracts.yaml"
 RUNTIME_TARGET = ROOT / "config" / "runtime-target.yaml"
 AIRFLOW_DOCKERFILE = ROOT / "docker" / "airflow" / "Dockerfile"
+AIRFLOW_REQUIREMENTS = ROOT / "docker" / "airflow" / "requirements.txt"
 COMPOSE_FILE = ROOT / "docker-compose.yml"
 SENDER_SERVICE_FILE = ROOT / "deploy" / "systemd" / "wechat-sender.service"
 SENDER_INSTALL_SCRIPT = ROOT / "scripts" / "install_wechat_sender.sh"
@@ -201,10 +202,48 @@ def main() -> None:
 
     if runtime_target.get("target", {}).get("dag_distribution") != "image":
         fail("Airflow DAG distribution must be declared as image")
+    target = runtime_target.get("target", {})
+    airflow_version = str(target.get("airflow") or "")
+    python_version = str(target.get("python") or "")
+    base_image = str(target.get("base_image") or "")
+    providers = target.get("providers") or {}
+    if not airflow_version or not python_version or not isinstance(providers, dict):
+        fail("Airflow runtime target version contract is incomplete")
+    if (
+        production.get("current_airflow") != airflow_version
+        or production.get("target_airflow") != airflow_version
+    ):
+        fail("active component Airflow versions must match the runtime target")
+
     dockerfile = AIRFLOW_DOCKERFILE.read_text(encoding="utf-8")
+    if f"FROM {base_image}" not in dockerfile:
+        fail("Airflow Dockerfile base image must match the runtime target")
+    if f"ARG AIRFLOW_VERSION={airflow_version}" not in dockerfile:
+        fail("Airflow Dockerfile version must match the runtime target")
     if "dags /opt/airflow/dags" not in dockerfile:
         fail("Airflow image must copy dags/ into /opt/airflow/dags")
+
+    airflow_requirements = {
+        name: version
+        for line in AIRFLOW_REQUIREMENTS.read_text(encoding="utf-8").splitlines()
+        if line and not line.startswith("#") and "==" in line
+        for name, version in [line.split("==", maxsplit=1)]
+    }
+    mismatched_providers = sorted(
+        name
+        for name, version in providers.items()
+        if airflow_requirements.get(name) != str(version)
+    )
+    if mismatched_providers:
+        fail(
+            "Airflow provider requirements must match the runtime target: "
+            + ", ".join(mismatched_providers)
+        )
     compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    compose_image = compose.get("x-airflow-common", {}).get("image")
+    expected_compose_image = "${AIRFLOW_IMAGE_NAME:-wechat-on-airflow:" + airflow_version + "}"
+    if compose_image != expected_compose_image:
+        fail("Compose Airflow image default must match the runtime target")
     airflow_volumes = compose.get("x-airflow-common", {}).get("volumes", [])
     if any("/opt/airflow/dags" in str(volume) for volume in airflow_volumes):
         fail("Airflow services must use image-bundled DAGs, not a host DAG mount")
@@ -220,7 +259,6 @@ def main() -> None:
         fail("Airflow API server must trust Cloudflare Tunnel proxy headers")
     if api_server.get("ports") != ["127.0.0.1:8080:8080"]:
         fail("Airflow API server must expose port 8080 on loopback only")
-    target = runtime_target.get("target", {})
     if target.get("execution_api_server_url") != ("http://airflow-api-server:8080/execution/"):
         fail("Airflow Execution API runtime target must use the internal root path")
     runtime_secrets = target.get("runtime_secrets", {})

--- a/tests/active_components_contract_test.py
+++ b/tests/active_components_contract_test.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import TestCase
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import check_active_components  # noqa: E402
+
+
+class AirflowRuntimeContractTest(TestCase):
+    def setUp(self) -> None:
+        self.target = {
+            "airflow": "3.3.0",
+            "python": "3.12",
+            "base_image": "apache/airflow:3.3.0-python3.12@sha256:" + "a" * 64,
+            "providers": {
+                "apache-airflow-providers-celery": "3.21.0",
+                "apache-airflow-providers-standard": "1.15.0",
+            },
+        }
+        self.production = {
+            "current_airflow": "2.10.5",
+            "target_airflow": "3.3.0",
+            "python": "3.12",
+        }
+        self.dockerfile = "\n".join(
+            (
+                f"FROM {self.target['base_image']}",
+                "ARG AIRFLOW_VERSION=3.3.0",
+                "ARG PYTHON_VERSION=3.12",
+            )
+        )
+        self.requirements = "\n".join(
+            (
+                "apache-airflow-providers-celery==3.21.0",
+                "apache-airflow-providers-standard==1.15.0",
+            )
+        )
+        self.compose_image = "${AIRFLOW_IMAGE_NAME:-wechat-on-airflow:3.3.0}"
+
+    def validate(self, **overrides: object) -> None:
+        values = {
+            "target": self.target,
+            "production": self.production,
+            "dockerfile": self.dockerfile,
+            "airflow_requirements_text": self.requirements,
+            "compose_image": self.compose_image,
+        }
+        values.update(overrides)
+        check_active_components.validate_airflow_runtime_contract(**values)
+
+    def test_allows_staged_upgrade_when_current_version_differs(self) -> None:
+        self.validate()
+
+    def test_rejects_missing_base_image(self) -> None:
+        target = {**self.target, "base_image": ""}
+
+        with self.assertRaises(SystemExit):
+            self.validate(target=target)
+
+    def test_rejects_python_version_drift(self) -> None:
+        production = {**self.production, "python": "3.11"}
+
+        with self.assertRaises(SystemExit):
+            self.validate(production=production)
+
+    def test_rejects_extra_provider_requirement(self) -> None:
+        requirements = self.requirements + "\napache-airflow-providers-fab==3.7.1\n"
+
+        with self.assertRaises(SystemExit):
+            self.validate(airflow_requirements_text=requirements)
+
+    def test_rejects_commented_dockerfile_contract(self) -> None:
+        dockerfile = "\n".join(f"# {line}" for line in self.dockerfile.splitlines())
+
+        with self.assertRaises(SystemExit):
+            self.validate(dockerfile=dockerfile)


### PR DESCRIPTION
## Summary

- restore the Airflow base image and provider pins to the repository's supported 3.3.0 runtime
- restore matching project dependency pins
- fail CI when Dockerfile, provider, Compose, or active-component versions drift from `config/runtime-target.yaml`

## Production context

Release apply for `3236f7a` exposed a pre-existing mismatch introduced by #64: the built image ran Airflow 3.3.1 while the supported runtime contract and generated image tag remained 3.3.0. The application containers and natural DAG cycles were healthy, but the exact post-deploy health gate correctly failed. This patch restores the previously verified runtime combination before re-release.

## Verification

- `ruff check .`
- `ruff format --check .`
- `mypy`
- `pytest -m 'not airflow'` — 214 passed
- `python scripts/check_active_components.py`