### PR TITLE
fix(release): harden main-CI handoff and report resolved component scope

### DIFF
--- a/.github/workflows/ops-chatops.yml
+++ b/.github/workflows/ops-chatops.yml
@@ -219,9 +219,17 @@ jobs:
           MODE: ${{ needs.route.outputs.mode }}
           VERSION: ${{ needs.route.outputs.version }}
           TARGET_COMMIT: ${{ needs.route.outputs.target_commit }}
-          SCOPE: ${{ needs.route.outputs.scope }}
+          REQUESTED_SCOPE: ${{ needs.route.outputs.scope }}
           RELEASE_RESULT: ${{ needs.release.result }}
+          RELEASE_RESOLVED_SCOPE: ${{ needs.release.outputs.resolved_scope }}
+          RELEASE_WEBAPP: ${{ needs.release.outputs.deploy_webapp }}
+          RELEASE_AIRFLOW: ${{ needs.release.outputs.deploy_airflow }}
+          RELEASE_SENDER: ${{ needs.release.outputs.deploy_sender }}
           SHIP_RESULT: ${{ needs.ship.result }}
+          SHIP_RESOLVED_SCOPE: ${{ needs.ship.outputs.resolved_scope }}
+          SHIP_WEBAPP: ${{ needs.ship.outputs.deploy_webapp }}
+          SHIP_AIRFLOW: ${{ needs.ship.outputs.deploy_airflow }}
+          SHIP_SENDER: ${{ needs.ship.outputs.deploy_sender }}
           TAG_RESULT: ${{ needs.tag.result }}
           WEB_DIAG_RESULT: ${{ needs.webapp_observation_diagnose.result }}
           WECHAT_PROBE_RESULT: ${{ needs.wechat_contact_probe.result }}
@@ -229,18 +237,72 @@ jobs:
         run: |
           set -euo pipefail
           case "$ACTION" in
-            release) result="$RELEASE_RESULT"; label="release $MODE" ;;
-            ship) result="$SHIP_RESULT"; label="ship $VERSION" ;;
-            tag) result="$TAG_RESULT"; label="tag $VERSION" ;;
-            webapp_observation_diagnose) result="$WEB_DIAG_RESULT"; label="Web observation diagnosis" ;;
-            wechat_contact_probe) result="$WECHAT_PROBE_RESULT"; label="one-contact WeChat probe" ;;
+            release)
+              result="$RELEASE_RESULT"
+              label="release $MODE"
+              resolved="$RELEASE_RESOLVED_SCOPE"
+              webapp="$RELEASE_WEBAPP"
+              airflow="$RELEASE_AIRFLOW"
+              sender="$RELEASE_SENDER"
+              ;;
+            ship)
+              result="$SHIP_RESULT"
+              label="ship $VERSION"
+              resolved="$SHIP_RESOLVED_SCOPE"
+              webapp="$SHIP_WEBAPP"
+              airflow="$SHIP_AIRFLOW"
+              sender="$SHIP_SENDER"
+              ;;
+            tag)
+              result="$TAG_RESULT"
+              label="tag $VERSION"
+              resolved="n/a"
+              webapp=""
+              airflow=""
+              sender=""
+              ;;
+            webapp_observation_diagnose)
+              result="$WEB_DIAG_RESULT"
+              label="Web observation diagnosis"
+              resolved="n/a"
+              webapp=""
+              airflow=""
+              sender=""
+              ;;
+            wechat_contact_probe)
+              result="$WECHAT_PROBE_RESULT"
+              label="one-contact WeChat probe"
+              resolved="n/a"
+              webapp=""
+              airflow=""
+              sender=""
+              ;;
             *) echo "Unknown routed action: $ACTION" >&2; exit 2 ;;
           esac
+
           if [ "$result" = success ]; then
             marker="✅"
           else
             marker="❌"
           fi
+
+          if [ "$resolved" = n/a ]; then
+            components="n/a"
+          elif [ -z "$webapp$airflow$sender" ]; then
+            components="unknown"
+          else
+            selected=()
+            [ "$webapp" = true ] && selected+=(webapp)
+            [ "$airflow" = true ] && selected+=(airflow)
+            [ "$sender" = true ] && selected+=(sender)
+            if [ "${#selected[@]}" -eq 0 ]; then
+              components="none"
+            else
+              components="$(IFS=,; echo "${selected[*]}")"
+            fi
+          fi
+          resolved="${resolved:-unknown}"
+
           gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body \
-            "$marker Production control \`$label\`: \`$result\`; target=\`$TARGET_COMMIT\`; scope=\`$SCOPE\`. Run: $RUN_URL"
+            "$marker Production control \`$label\`: \`$result\`; target=\`$TARGET_COMMIT\`; requested_scope=\`$REQUESTED_SCOPE\`; resolved_scope=\`$resolved\`; components=\`$components\`. Run: $RUN_URL"
           test "$result" = success

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -22,6 +22,22 @@ on:
         required: false
         default: false
         type: boolean
+    outputs:
+      base_commit:
+        description: Semantic release base used for component planning
+        value: ${{ jobs.gate.outputs.base_commit }}
+      resolved_scope:
+        description: Resolved component scope
+        value: ${{ jobs.gate.outputs.resolved_scope }}
+      deploy_webapp:
+        description: Whether Web deployment was planned
+        value: ${{ jobs.gate.outputs.deploy_webapp }}
+      deploy_airflow:
+        description: Whether Airflow deployment was planned
+        value: ${{ jobs.gate.outputs.deploy_airflow }}
+      deploy_sender:
+        description: Whether sender deployment was planned
+        value: ${{ jobs.gate.outputs.deploy_sender }}
   workflow_dispatch:
     inputs:
       mode:
@@ -90,17 +106,6 @@ jobs:
             preflight|apply) ;;
             *) echo "Unsupported release mode: $MODE" >&2; exit 2 ;;
           esac
-      - name: Require exact main commit and successful CI
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          PYTHONPATH=scripts python scripts/github_release_gate.py \
-            --target-commit "${{ inputs.target_commit }}" \
-            --required-check verify \
-            --wait-seconds 1800 \
-            --missing-check-wait-seconds 0 \
-            --poll-seconds 10 \
-            --format json
       - name: Plan component-scoped release
         id: plan
         env:
@@ -126,6 +131,18 @@ jobs:
             cat /tmp/release-plan.json
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+      - name: Require exact main commit and successful CI
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          PYTHONPATH=scripts python scripts/github_release_gate.py \
+            --target-commit "${{ inputs.target_commit }}" \
+            --required-check verify \
+            --wait-seconds 1800 \
+            --missing-check-wait-seconds 0 \
+            --main-head-missing-check-wait-seconds 60 \
+            --poll-seconds 10 \
+            --format json
 
   webapp:
     if: needs.gate.outputs.deploy_webapp == 'true'

--- a/.github/workflows/production-ship.yml
+++ b/.github/workflows/production-ship.yml
@@ -18,6 +18,19 @@ on:
         required: false
         default: false
         type: boolean
+    outputs:
+      resolved_scope:
+        description: Resolved component scope
+        value: ${{ jobs.deploy.outputs.resolved_scope }}
+      deploy_webapp:
+        description: Whether Web deployment was planned
+        value: ${{ jobs.deploy.outputs.deploy_webapp }}
+      deploy_airflow:
+        description: Whether Airflow deployment was planned
+        value: ${{ jobs.deploy.outputs.deploy_airflow }}
+      deploy_sender:
+        description: Whether sender deployment was planned
+        value: ${{ jobs.deploy.outputs.deploy_sender }}
   workflow_dispatch:
     inputs:
       version:
@@ -96,7 +109,11 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           TARGET_COMMIT: ${{ inputs.target_commit }}
-          SCOPE: ${{ inputs.scope }}
+          REQUESTED_SCOPE: ${{ inputs.scope }}
+          RESOLVED_SCOPE: ${{ needs.deploy.outputs.resolved_scope }}
+          WEBAPP_PLANNED: ${{ needs.deploy.outputs.deploy_webapp }}
+          AIRFLOW_PLANNED: ${{ needs.deploy.outputs.deploy_airflow }}
+          SENDER_PLANNED: ${{ needs.deploy.outputs.deploy_sender }}
           CONTRACT_RESULT: ${{ needs.contract.result }}
           DEPLOY_RESULT: ${{ needs.deploy.result }}
           TAG_RESULT: ${{ needs.tag.result }}
@@ -106,7 +123,9 @@ jobs:
             echo
             echo "- Version: \`$VERSION\`"
             echo "- Commit: \`$TARGET_COMMIT\`"
-            echo "- Requested scope: \`$SCOPE\`"
+            echo "- Requested scope: \`$REQUESTED_SCOPE\`"
+            echo "- Resolved scope: \`$RESOLVED_SCOPE\`"
+            echo "- Components: webapp=\`$WEBAPP_PLANNED\`, airflow=\`$AIRFLOW_PLANNED\`, sender=\`$SENDER_PLANNED\`"
             echo "- Release contract: \`$CONTRACT_RESULT\`"
             echo "- Deployment: \`$DEPLOY_RESULT\`"
             echo "- Immutable tag and GitHub Release: \`$TAG_RESULT\`"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ and operational changes.
 
 ## Unreleased
 
+## [0.2.3] - 2026-08-23
+
+### Changed
+
+- Plan and validate release scope before waiting for CI, so a missing sender
+  approval or unsafe manually narrowed scope fails immediately instead of after
+  a potentially long queued check.
+- Expose requested scope, resolved scope, and the actual Web, Airflow, and sender
+  component operations in the one authoritative production-control report.
+
+### Fixed
+
+- Give only the exact current `main` head a short 60-second check-registration
+  grace, avoiding a race immediately after merge while historical SHAs with no
+  CI record continue to fail immediately.
+
 ## [0.2.2] - 2026-08-23
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wechat-on-airflow"
-version = "0.2.2"
+version = "0.2.3"
 description = "Airflow workflows for Shenzhen tennis availability notifications."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/scripts/github_release_gate.py
+++ b/scripts/github_release_gate.py
@@ -57,6 +57,24 @@ def fetch_check_runs(repository: str, commit: str, token: str) -> Any:
         raise OpsError("GitHub check-runs API returned invalid JSON") from exc
 
 
+def effective_missing_check_wait_seconds(
+    *,
+    target_commit: str,
+    main_head: str,
+    missing_check_wait_seconds: float,
+    main_head_missing_check_wait_seconds: float,
+) -> float:
+    """Return a short discovery grace only for the exact current main head.
+
+    Historical commits keep the normal fail-fast behavior when no CI record
+    exists. A just-merged main head may race GitHub's check-run registration, so
+    it can receive a small, separately bounded visibility grace.
+    """
+    if target_commit == main_head:
+        return max(missing_check_wait_seconds, main_head_missing_check_wait_seconds)
+    return missing_check_wait_seconds
+
+
 def wait_for_required_check(
     repository: str,
     commit: str,
@@ -100,6 +118,8 @@ def release_payload(
     target_commit: str,
     required_check: str,
     on_main: bool,
+    target_is_main_head: bool,
+    effective_missing_check_wait: float,
     check: dict[str, Any],
     timed_out: bool,
     missing_check_wait_expired: bool,
@@ -113,9 +133,11 @@ def release_payload(
     return {
         "ok": all(checks.values()),
         "target_commit": target_commit,
+        "target_is_main_head": target_is_main_head,
         "required_check": required_check,
         "check_status": check["status"],
         "check_conclusion": check["conclusion"],
+        "effective_missing_check_wait_seconds": effective_missing_check_wait,
         "timed_out_waiting_for_check": timed_out,
         "missing_check_wait_expired": missing_check_wait_expired,
         "checks": checks,
@@ -136,7 +158,13 @@ def main() -> None:
         "--missing-check-wait-seconds",
         type=float,
         default=0,
-        help="Optional short grace period for a required check that is not visible yet.",
+        help="Visibility grace for a missing required check on historical commits.",
+    )
+    parser.add_argument(
+        "--main-head-missing-check-wait-seconds",
+        type=float,
+        default=0,
+        help="Additional bounded visibility grace only when the target is the exact main head.",
     )
     parser.add_argument(
         "--poll-seconds",
@@ -159,16 +187,26 @@ def main() -> None:
         raise OpsError("wait seconds must be non-negative")
     if args.missing_check_wait_seconds < 0:
         raise OpsError("missing check wait seconds must be non-negative")
+    if args.main_head_missing_check_wait_seconds < 0:
+        raise OpsError("main-head missing check wait seconds must be non-negative")
     if args.poll_seconds <= 0:
         raise OpsError("poll seconds must be positive")
 
     run(["git", "fetch", "--quiet", "origin", "main"])
+    main_head = run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    target_is_main_head = args.target_commit == main_head
     on_main = (
         run(
             ["git", "merge-base", "--is-ancestor", args.target_commit, "origin/main"],
             check=False,
         ).returncode
         == 0
+    )
+    effective_missing_check_wait = effective_missing_check_wait_seconds(
+        target_commit=args.target_commit,
+        main_head=main_head,
+        missing_check_wait_seconds=args.missing_check_wait_seconds,
+        main_head_missing_check_wait_seconds=args.main_head_missing_check_wait_seconds,
     )
 
     if on_main:
@@ -179,7 +217,7 @@ def main() -> None:
             args.required_check,
             wait_seconds=args.wait_seconds,
             poll_seconds=args.poll_seconds,
-            missing_check_wait_seconds=args.missing_check_wait_seconds,
+            missing_check_wait_seconds=effective_missing_check_wait,
         )
     else:
         check = required_check_result({}, args.required_check)
@@ -190,6 +228,8 @@ def main() -> None:
         target_commit=args.target_commit,
         required_check=args.required_check,
         on_main=on_main,
+        target_is_main_head=target_is_main_head,
+        effective_missing_check_wait=effective_missing_check_wait,
         check=check,
         timed_out=timed_out,
         missing_check_wait_expired=missing_check_wait_expired,

--- a/src/wechat_airflow/__init__.py
+++ b/src/wechat_airflow/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime code for the production Airflow workflows."""
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/tests/github_release_gate_test.py
+++ b/tests/github_release_gate_test.py
@@ -114,6 +114,42 @@ def test_optional_visibility_grace_allows_new_verify_to_appear():
     assert check["ok"] is True
 
 
+def test_current_main_head_gets_discovery_grace_but_historical_commit_does_not():
+    main_head = "a" * 40
+    historical = "b" * 40
+
+    assert (
+        github_release_gate.effective_missing_check_wait_seconds(
+            target_commit=main_head,
+            main_head=main_head,
+            missing_check_wait_seconds=0,
+            main_head_missing_check_wait_seconds=60,
+        )
+        == 60
+    )
+    assert (
+        github_release_gate.effective_missing_check_wait_seconds(
+            target_commit=historical,
+            main_head=main_head,
+            missing_check_wait_seconds=0,
+            main_head_missing_check_wait_seconds=60,
+        )
+        == 0
+    )
+
+
+def test_explicit_historical_grace_is_preserved():
+    assert (
+        github_release_gate.effective_missing_check_wait_seconds(
+            target_commit="b" * 40,
+            main_head="a" * 40,
+            missing_check_wait_seconds=5,
+            main_head_missing_check_wait_seconds=60,
+        )
+        == 5
+    )
+
+
 def test_terminal_failed_verify_fails_without_sleeping():
     sleeps: list[float] = []
     clock = iter([0.0, 0.0])

--- a/tests/release_workflow_contract_test.py
+++ b/tests/release_workflow_contract_test.py
@@ -24,20 +24,28 @@ def test_single_router_supports_mutually_exclusive_release_commands():
     assert "release-tag-chatops.yml" in workflow
     assert "Publish one authoritative result" in workflow
     assert "Wait for main CI verify" not in workflow
+    assert "RELEASE_RESOLVED_SCOPE" in workflow
+    assert "SHIP_RESOLVED_SCOPE" in workflow
+    assert "components=\\`$components\\`" in workflow
 
 
-def test_release_gate_fails_fast_when_ci_record_is_missing_and_plans_scope():
+def test_release_gate_plans_before_waiting_and_handles_ci_registration_race():
     workflow = (WORKFLOWS / "production-release.yml").read_text(encoding="utf-8")
 
     assert "--missing-check-wait-seconds 0" in workflow
+    assert "--main-head-missing-check-wait-seconds 60" in workflow
     assert "scripts/release_plan.py" in workflow
     assert "deploy_webapp" in workflow
     assert "deploy_airflow" in workflow
     assert "deploy_sender" in workflow
     assert "planned=\\`$WEBAPP_PLANNED\\`" in workflow
+    assert workflow.index("Plan component-scoped release") < workflow.index(
+        "Require exact main commit and successful CI"
+    )
+    assert "value: ${{ jobs.gate.outputs.resolved_scope }}" in workflow
 
 
-def test_one_command_ship_applies_then_tags_exact_commit():
+def test_one_command_ship_applies_then_tags_exact_commit_and_exports_plan():
     workflow = (WORKFLOWS / "production-ship.yml").read_text(encoding="utf-8")
 
     assert "scripts/release_contract.py" in workflow
@@ -45,6 +53,8 @@ def test_one_command_ship_applies_then_tags_exact_commit():
     assert "mode: apply" in workflow
     assert "release-tag-chatops.yml" in workflow
     assert workflow.index("production-release.yml") < workflow.index("release-tag-chatops.yml")
+    assert "value: ${{ jobs.deploy.outputs.resolved_scope }}" in workflow
+    assert "Components: webapp=" in workflow
 
 
 def test_airflow_apply_uses_transactional_health_and_restore_wrapper():


### PR DESCRIPTION
## Follow-up findings from the live 0.2.2 release

The 0.2.2 control-plane refactor worked: one `/release ship` command produced one successful Action run, resolved to `control`, skipped all runtime deployments, and published the immutable release. The live run also exposed three smaller efficiency and clarity gaps worth closing before the next application release.

## Changes

- give only the exact current `main` head a bounded 60-second check-registration grace;
- keep historical SHAs with no CI record fail-fast at zero seconds;
- resolve and validate component scope before waiting for CI, so missing sender approval or an unsafe narrow scope fails immediately;
- export the resolved release plan from reusable workflows;
- include requested scope, resolved scope, and actual Web/Airflow/sender operations in the one authoritative control comment;
- add tests for current-main versus historical CI visibility behavior and workflow ordering;
- release as 0.2.3.

## Safety properties retained

- an existing queued or in-progress `verify` check remains bounded by the production gate;
- a completed unsuccessful check fails immediately;
- historical commits without a CI record do not wait;
- Airflow deployment and full health remain transactional with automatic restore;
- runtime/version drift checks remain part of `CI / verify`;
- sender deployment still requires explicit `sender=true`.

## Verification

- full PR `CI / verify`;
- workflow contract tests for planner-before-wait and reusable outputs;
- unit tests for main-head-only registration grace;
- after merge, exercise `/release ship 0.2.3 <merge-sha> scope=auto sender=false` and confirm `resolved_scope=control`, `components=none`, and no runtime deployment jobs.

## Rollback

Revert the merge commit. No application runtime, database schema, DAG, or sender behavior is changed by this PR.