### PR TITLE
fix(webapp): correct Tencent SES delivery metrics

### DIFF
--- a/webapp/cloudflare/email-lifecycle.test.ts
+++ b/webapp/cloudflare/email-lifecycle.test.ts
@@ -5,10 +5,53 @@ import {
 } from "./email-lifecycle";
 
 describe("email lifecycle", () => {
-  it("does not call an accepted request delivered", () => {
-    expect(normalizeTencentDeliveryStatus({ MessageId: "m1" }).state).toBe("submitted");
+  it("keeps Tencent accepted queue status pending", () => {
+    expect(normalizeTencentDeliveryStatus({
+      MessageId: "m1",
+      SendStatus: 0,
+      DeliverStatus: 0,
+      DeliverTime: "2026-08-23T01:00:00.000Z",
+    })).toMatchObject({ state: "submitted", deliveredAt: null });
   });
-  it("requires provider delivery evidence", () => {
+
+  it("maps Tencent numeric delivery success to delivered", () => {
+    const status = normalizeTencentDeliveryStatus({
+      MessageId: "m1",
+      SendStatus: 0,
+      DeliverStatus: 1,
+      DeliverTime: "2026-08-23T01:00:00.000Z",
+    });
+    expect(status.state).toBe("delivered");
+    expect(status.deliveredAt).toBe("2026-08-23T01:00:00.000Z");
+  });
+
+  it("keeps Tencent delayed delivery pending even with a reason", () => {
+    expect(normalizeTencentDeliveryStatus({
+      MessageId: "m1",
+      SendStatus: 0,
+      DeliverStatus: 8,
+      DeliverMessage: "recipient server temporarily delayed the message",
+    })).toMatchObject({ state: "submitted", error: null });
+  });
+
+  it.each([2, 3])("maps Tencent terminal delivery status %s to failed", (code) => {
+    expect(normalizeTencentDeliveryStatus({
+      MessageId: "m1",
+      SendStatus: 0,
+      DeliverStatus: code,
+      DeliverMessage: "mailbox unavailable",
+    })).toMatchObject({ state: "failed", error: "mailbox unavailable" });
+  });
+
+  it("maps non-zero Tencent processing status to failed", () => {
+    expect(normalizeTencentDeliveryStatus({
+      MessageId: "m1",
+      SendStatus: 1007,
+      DeliverStatus: 0,
+    })).toMatchObject({ state: "failed" });
+  });
+
+  it("accepts DeliverTime as compatibility evidence only when status is absent", () => {
     const status = normalizeTencentDeliveryStatus({
       MessageId: "m1",
       DeliverTime: "2026-08-23T01:00:00.000Z",
@@ -16,12 +59,14 @@ describe("email lifecycle", () => {
     expect(status.state).toBe("delivered");
     expect(status.deliveredAt).toBe("2026-08-23T01:00:00.000Z");
   });
-  it("recognizes provider failures", () => {
+
+  it("recognizes textual provider failures", () => {
     expect(normalizeTencentDeliveryStatus({
       DeliverStatus: "failed",
       DeliverMessage: "mailbox unavailable",
     })).toMatchObject({ state: "failed", error: "mailbox unavailable" });
   });
+
   it("queues fixed subscriptions only in their final day", () => {
     const now = new Date("2026-08-23T00:00:00.000Z");
     expect(shouldEnqueueExpiryReminder("2026-08-23T20:00:00.000Z", now)).toBe(true);

--- a/webapp/cloudflare/email-lifecycle.ts
+++ b/webapp/cloudflare/email-lifecycle.ts
@@ -25,6 +25,39 @@ function validDate(value: unknown): string | null {
   return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
+function isNumericCode(value: string): boolean {
+  return /^\d+$/.test(value);
+}
+
+function indicatesSendFailure(value: string): boolean {
+  if (!value || value === "0") return false;
+  if (isNumericCode(value)) return true;
+  return ["failed", "failure", "rejected", "blocked", "error"].includes(value);
+}
+
+function indicatesDeliveryFailure(value: string): boolean {
+  return [
+    "2",
+    "3",
+    "failed",
+    "failure",
+    "bounced",
+    "rejected",
+    "blocked",
+    "discarded",
+    "dropped",
+    "退信",
+    "拒信",
+    "丢弃",
+  ].includes(value);
+}
+
+function failureMessage(value: string): boolean {
+  return /mailbox unavailable|access denied|bounce|bounced|reject|rejected|blocked|discard|dropped|failed|failure|退信|拒信|丢弃|失败/i.test(
+    value,
+  );
+}
+
 export function normalizeTencentDeliveryStatus(
   record: TencentEmailStatusRecord | null,
 ): NormalizedDeliveryStatus {
@@ -40,32 +73,50 @@ export function normalizeTencentDeliveryStatus(
   const deliver = String(record.DeliverStatus ?? "").trim().toLowerCase();
   const send = String(record.SendStatus ?? "").trim().toLowerCase();
   const message = String(record.DeliverMessage ?? "").trim();
-  const explicitDelivered = deliveredAt !== null
+  const providerStatus = `send=${send || "unknown"};deliver=${deliver || "pending"}`;
+
+  // Tencent SES documents DeliverStatus=1 as the only numeric terminal
+  // delivery-success state. DeliverStatus=0 is merely accepted/queued and 8 is
+  // delayed, so neither may be promoted to delivered just because a timestamp
+  // or explanatory message is present.
+  const explicitDelivered = deliver === "1"
     || ["delivered", "success", "succeeded", "投递成功"].includes(deliver);
   if (explicitDelivered) {
     return {
       state: "delivered",
-      providerStatus: `send=${send || "unknown"};deliver=${deliver || "delivered"}`,
+      providerStatus,
       deliveredAt: deliveredAt ?? new Date().toISOString(),
       error: null,
     };
   }
-  const explicitFailure = [
-    "failed", "failure", "bounced", "rejected", "blocked", "2", "3", "4", "5",
-  ].includes(deliver)
-    || ["failed", "failure", "rejected", "2", "3", "4", "5"].includes(send)
-    || Boolean(message && !/success|deliver|投递成功/i.test(message));
-  if (explicitFailure) {
+
+  const sendFailed = indicatesSendFailure(send);
+  const deliveryFailed = indicatesDeliveryFailure(deliver);
+  const messageFailedWithoutProviderState = !deliver && failureMessage(message);
+  if (sendFailed || deliveryFailed || messageFailedWithoutProviderState) {
     return {
       state: "failed",
-      providerStatus: `send=${send || "unknown"};deliver=${deliver || "failed"}`,
+      providerStatus,
       deliveredAt: null,
-      error: message || "腾讯云报告邮件投递失败",
+      error: message || "腾讯云报告邮件发送或投递失败",
     };
   }
+
+  // Older or partial provider records can omit DeliverStatus while still
+  // returning DeliverTime. Keep this compatibility fallback, but never let it
+  // override an explicit queued (0), failed (2/3), or delayed (8) status.
+  if (!deliver && deliveredAt) {
+    return {
+      state: "delivered",
+      providerStatus,
+      deliveredAt,
+      error: null,
+    };
+  }
+
   return {
     state: "submitted",
-    providerStatus: `send=${send || "unknown"};deliver=${deliver || "pending"}`,
+    providerStatus,
     deliveredAt: null,
     error: null,
   };


### PR DESCRIPTION
## Root cause

The dashboard distinguishes provider submission from confirmed delivery, but the Tencent SES lifecycle normalizer did not implement the provider's documented numeric status contract:

- `DeliverStatus=0`: accepted and queued
- `DeliverStatus=1`: delivered
- `DeliverStatus=2/3`: discarded or rejected
- `DeliverStatus=8`: delayed
- `SendStatus=0`: Tencent processing succeeded; non-zero codes are processing failures

Because numeric `1` was not recognized as delivered, successfully delivered reminder digests stayed in `submitted`. That kept the global `今日提醒` count at `0` and left venue cards at `今日未确认送达` / `暂无发送`, even though the quota card correctly counted provider-accepted messages.

## Fix

- Map the documented Tencent numeric lifecycle states explicitly.
- Do not mistake queued (`0`) or delayed (`8`) records for delivery failures.
- Do not use `DeliverTime` to override an explicit queued/delayed/failed state.
- Treat non-zero Tencent processing codes as failures.
- Add regression coverage for accepted, delivered, delayed, discarded/rejected, processing failure, and partial legacy records.

## Metric contract after this change

- `已提交`: distinct digest messages accepted by Tencent SES today (Shanghai calendar day).
- `确认送达` / top-level `今日提醒`: distinct digest messages Tencent reports as delivered.
- `发送失败`: distinct provider-submitted messages Tencent reports as terminal failures.
- Venue `最近提醒`: updated only after provider-confirmed delivery.

The one-minute Worker schedule will reconcile existing `submitted` rows after deployment; no real test email is sent by this change.