### PR TITLE
ops(webapp): diagnose production email delivery metrics

### DIFF
--- a/.github/workflows/production-airflow.yml
+++ b/.github/workflows/production-airflow.yml
@@ -77,6 +77,8 @@ jobs:
       AIRFLOW_SSH_PORT: ${{ secrets.AIRFLOW_SSH_PORT }}
       AIRFLOW_SSH_USER: ${{ secrets.AIRFLOW_SSH_USER }}
       AIRFLOW_REPOSITORY_PATH: ${{ secrets.AIRFLOW_REPOSITORY_PATH }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -92,8 +94,18 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: inputs.operation == 'webapp_observation_diagnose'
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: webapp/package-lock.json
       - name: Install operations dependencies
         run: python -m pip install --disable-pip-version-check PyYAML==6.0.3
+      - name: Install Web diagnostic dependencies
+        if: inputs.operation == 'webapp_observation_diagnose'
+        working-directory: webapp
+        run: npm ci
       - name: Configure production SSH identity
         env:
           SSH_PRIVATE_KEY: ${{ secrets.AIRFLOW_SSH_PRIVATE_KEY }}
@@ -135,6 +147,7 @@ jobs:
               ;;
             webapp_observation_diagnose)
               bash scripts/diagnose_webapp_observation.sh
+              bash scripts/diagnose_email_delivery_metrics.sh
               ;;
             wechat_delivery_diagnose)
               PYTHONPATH=scripts python scripts/diagnose_wechat_delivery.py --format json

--- a/scripts/diagnose_email_delivery_metrics.sh
+++ b/scripts/diagnose_email_delivery_metrics.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CLOUDFLARE_ACCOUNT_ID:?}"
+: "${CLOUDFLARE_API_TOKEN:?}"
+
+wrangler() {
+  (cd webapp && npx wrangler "$@")
+}
+
+# Keep diagnostics aggregate/redacted: no recipient addresses, subjects, bodies,
+# request IDs, provider message IDs, or delivery reasons are printed.
+printf '%s\n' '__EMAIL_DELIVERY_METRICS__'
+wrangler d1 execute zacks-tennis-alerts --remote --json --command "
+WITH day AS (
+  SELECT datetime('now','+8 hours','start of day','-8 hours') AS start_utc
+)
+SELECT
+  COUNT(DISTINCT CASE WHEN provider_submitted_at >= day.start_utc THEN message_id END) AS submitted_today,
+  COUNT(DISTINCT CASE WHEN status='delivered' AND provider_delivered_at >= day.start_utc THEN message_id END) AS delivered_today,
+  COUNT(DISTINCT CASE WHEN status='failed' AND provider_submitted_at >= day.start_utc THEN message_id END) AS failed_today,
+  COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc THEN message_id END) AS pending_today,
+  COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc AND provider_checked_at IS NULL THEN message_id END) AS never_checked_today,
+  COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc AND provider_status='not_found' THEN message_id END) AS not_found_today,
+  COUNT(DISTINCT CASE WHEN provider_submitted_at >= day.start_utc AND message_id LIKE 'worker:%' THEN message_id END) AS placeholder_message_ids_today
+FROM notification_outbox, day;
+"
+
+printf '%s\n' '__PROVIDER_STATUS_BREAKDOWN__'
+wrangler d1 execute zacks-tennis-alerts --remote --json --command "
+WITH day AS (
+  SELECT datetime('now','+8 hours','start of day','-8 hours') AS start_utc
+)
+SELECT
+  status,
+  COALESCE(provider_status,'(null)') AS provider_status,
+  COUNT(DISTINCT message_id) AS messages
+FROM notification_outbox, day
+WHERE provider_submitted_at >= day.start_utc
+GROUP BY status, COALESCE(provider_status,'(null)')
+ORDER BY messages DESC, status, provider_status;
+"
+
+printf '%s\n' '__PENDING_AGE__'
+wrangler d1 execute zacks-tennis-alerts --remote --json --command "
+WITH day AS (
+  SELECT datetime('now','+8 hours','start of day','-8 hours') AS start_utc
+)
+SELECT
+  MIN(provider_submitted_at) AS oldest_submitted_at,
+  MAX(provider_submitted_at) AS newest_submitted_at,
+  MIN(provider_checked_at) AS oldest_checked_epoch_ms,
+  MAX(provider_checked_at) AS newest_checked_epoch_ms,
+  COUNT(DISTINCT message_id) AS pending_messages
+FROM notification_outbox, day
+WHERE status='submitted' AND provider_submitted_at >= day.start_utc;
+"
+
+printf '%s\n' '__VENUE_NOTIFICATION_COVERAGE__'
+wrangler d1 execute zacks-tennis-alerts --remote --json --command "
+SELECT
+  COUNT(*) AS venues,
+  SUM(CASE WHEN last_notification_at IS NOT NULL THEN 1 ELSE 0 END) AS venues_with_confirmed_delivery,
+  MAX(last_notification_at) AS latest_confirmed_delivery_at
+FROM venue_status;
+"


### PR DESCRIPTION
## Why
The delivery-status parser fix is deployed, but production still reports `remindersToday=0`. We need read-only production evidence from D1 to distinguish pending provider state, missing provider matches, placeholder message IDs, or stale reconciliation.

## Changes
- Add a redacted D1 diagnostic for today's submitted/delivered/failed/pending counts.
- Break down `provider_status` without exposing recipients, message IDs, subjects, bodies, request IDs, or delivery reasons.
- Report placeholder `worker:*` message-ID count, reconciliation check coverage, pending age, and venue confirmed-delivery coverage.
- Extend the existing protected `/ops webapp-observation-diagnose` path to run this diagnostic with production Cloudflare credentials.

No email is sent and no production data is mutated.