### PR TITLE
fix(webapp): keep delivery reconciliation live

### DIFF
--- a/webapp/cloudflare/delivery-reconcile.ts
+++ b/webapp/cloudflare/delivery-reconcile.ts
@@ -1,0 +1,211 @@
+import { normalizeTencentDeliveryStatus } from "./email-lifecycle";
+import { getTencentEmailStatus, type TencentSecrets } from "./tencent-ses";
+
+type ReconcileEnv = TencentSecrets & {
+  DB: D1Database;
+};
+
+const REFRESH_MS = 5 * 60_000;
+
+async function claimNotificationMessages(
+  env: ReconcileEnv,
+  limit: number,
+): Promise<Array<{ messageId: string }>> {
+  const now = Date.now();
+  const candidates = (
+    await env.DB.prepare(
+      `SELECT message_id
+         FROM notification_outbox
+        WHERE status = 'submitted'
+          AND message_id IS NOT NULL
+          AND message_id NOT LIKE 'worker:%'
+          AND (provider_checked_at IS NULL OR provider_checked_at < ?)
+        GROUP BY message_id
+        ORDER BY MIN(provider_submitted_at)
+        LIMIT ?`,
+    ).bind(now - REFRESH_MS, limit).all<{ message_id: string }>()
+  ).results;
+
+  const claimed: Array<{ messageId: string }> = [];
+  for (const candidate of candidates) {
+    const result = await env.DB.prepare(
+      `UPDATE notification_outbox
+          SET provider_checked_at = ?
+        WHERE message_id = ?
+          AND status = 'submitted'
+          AND (provider_checked_at IS NULL OR provider_checked_at < ?)`,
+    ).bind(now, candidate.message_id, now - REFRESH_MS).run();
+    if (Number(result.meta.changes || 0) > 0) claimed.push({ messageId: candidate.message_id });
+  }
+  return claimed;
+}
+
+async function reconcileNotificationMessages(env: ReconcileEnv, limit: number): Promise<void> {
+  const messages = await claimNotificationMessages(env, limit);
+  for (const message of messages) {
+    try {
+      // MessageId is globally sufficient for GetSendEmailStatus and avoids a
+      // second matching condition that can cause a valid provider record to be missed.
+      const provider = await getTencentEmailStatus(env, message.messageId);
+      const normalized = normalizeTencentDeliveryStatus(provider);
+      const checkedAt = Date.now();
+      if (normalized.state === "delivered") {
+        const deliveredAt = normalized.deliveredAt || new Date().toISOString();
+        const venues = (
+          await env.DB.prepare(
+            `SELECT DISTINCT venue_id
+               FROM notification_outbox
+              WHERE message_id = ?`,
+          ).bind(message.messageId).all<{ venue_id: string }>()
+        ).results;
+        const statements: D1PreparedStatement[] = [
+          env.DB.prepare(
+            `UPDATE notification_outbox
+                SET status = 'delivered', provider_status = ?,
+                    provider_delivered_at = ?, provider_checked_at = ?,
+                    provider_error = NULL, sent_at = ?
+              WHERE message_id = ? AND status = 'submitted'`,
+          ).bind(
+            normalized.providerStatus,
+            deliveredAt,
+            checkedAt,
+            deliveredAt,
+            message.messageId,
+          ),
+        ];
+        for (const venue of venues) {
+          statements.push(
+            env.DB.prepare(
+              `UPDATE venue_status
+                  SET last_notification_at = ?, updated_at = ?
+                WHERE venue_id = ?`,
+            ).bind(deliveredAt, deliveredAt, venue.venue_id),
+          );
+        }
+        await env.DB.batch(statements);
+      } else if (normalized.state === "failed") {
+        const failedAt = new Date().toISOString();
+        await env.DB.prepare(
+          `UPDATE notification_outbox
+              SET status = 'failed', provider_status = ?,
+                  provider_failed_at = ?, provider_checked_at = ?,
+                  provider_error = ?, last_error = ?
+            WHERE message_id = ? AND status = 'submitted'`,
+        ).bind(
+          normalized.providerStatus,
+          failedAt,
+          checkedAt,
+          normalized.error,
+          normalized.error,
+          message.messageId,
+        ).run();
+      } else {
+        await env.DB.prepare(
+          `UPDATE notification_outbox
+              SET provider_status = ?, provider_checked_at = ?
+            WHERE message_id = ? AND status = 'submitted'`,
+        ).bind(normalized.providerStatus, checkedAt, message.messageId).run();
+      }
+    } catch (error) {
+      console.warn(JSON.stringify({
+        event: "notification_delivery_reconcile_failed",
+        reason: error instanceof Error ? error.message.slice(0, 200) : "unknown",
+      }));
+    }
+  }
+}
+
+async function claimSystemEmails(
+  env: ReconcileEnv,
+  limit: number,
+): Promise<Array<{ id: string; messageId: string }>> {
+  const now = Date.now();
+  const candidates = (
+    await env.DB.prepare(
+      `SELECT id, provider_message_id
+         FROM system_email_outbox
+        WHERE status = 'submitted'
+          AND provider_message_id IS NOT NULL
+          AND provider_message_id NOT LIKE 'worker:%'
+          AND (provider_checked_at IS NULL OR provider_checked_at < ?)
+        ORDER BY submitted_at
+        LIMIT ?`,
+    ).bind(now - REFRESH_MS, limit).all<{ id: string; provider_message_id: string }>()
+  ).results;
+
+  const claimed: Array<{ id: string; messageId: string }> = [];
+  for (const candidate of candidates) {
+    const result = await env.DB.prepare(
+      `UPDATE system_email_outbox
+          SET provider_checked_at = ?, updated_at = ?
+        WHERE id = ?
+          AND status = 'submitted'
+          AND (provider_checked_at IS NULL OR provider_checked_at < ?)`,
+    ).bind(now, new Date(now).toISOString(), candidate.id, now - REFRESH_MS).run();
+    if (Number(result.meta.changes || 0) > 0) {
+      claimed.push({ id: candidate.id, messageId: candidate.provider_message_id });
+    }
+  }
+  return claimed;
+}
+
+async function reconcileSystemEmails(env: ReconcileEnv, limit: number): Promise<void> {
+  const rows = await claimSystemEmails(env, limit);
+  for (const row of rows) {
+    try {
+      const provider = await getTencentEmailStatus(env, row.messageId);
+      const normalized = normalizeTencentDeliveryStatus(provider);
+      const checkedAt = Date.now();
+      const nowIso = new Date(checkedAt).toISOString();
+      if (normalized.state === "delivered") {
+        await env.DB.prepare(
+          `UPDATE system_email_outbox
+              SET status = 'delivered', provider_status = ?, delivered_at = ?,
+                  provider_checked_at = ?, last_error = NULL, updated_at = ?
+            WHERE id = ? AND status = 'submitted'`,
+        ).bind(
+          normalized.providerStatus,
+          normalized.deliveredAt || nowIso,
+          checkedAt,
+          nowIso,
+          row.id,
+        ).run();
+      } else if (normalized.state === "failed") {
+        await env.DB.prepare(
+          `UPDATE system_email_outbox
+              SET status = 'failed', provider_status = ?, failed_at = ?,
+                  provider_checked_at = ?, last_error = ?, updated_at = ?
+            WHERE id = ? AND status = 'submitted'`,
+        ).bind(
+          normalized.providerStatus,
+          nowIso,
+          checkedAt,
+          normalized.error,
+          nowIso,
+          row.id,
+        ).run();
+      } else {
+        await env.DB.prepare(
+          `UPDATE system_email_outbox
+              SET provider_status = ?, provider_checked_at = ?, updated_at = ?
+            WHERE id = ? AND status = 'submitted'`,
+        ).bind(normalized.providerStatus, checkedAt, nowIso, row.id).run();
+      }
+    } catch (error) {
+      console.warn(JSON.stringify({
+        event: "system_email_delivery_reconcile_failed",
+        reason: error instanceof Error ? error.message.slice(0, 200) : "unknown",
+      }));
+    }
+  }
+}
+
+export async function reconcileDeliveryStatuses(
+  env: ReconcileEnv,
+  limitPerQueue = 5,
+): Promise<void> {
+  await Promise.all([
+    reconcileNotificationMessages(env, limitPerQueue),
+    reconcileSystemEmails(env, limitPerQueue),
+  ]);
+}

--- a/webapp/cloudflare/deployment-entry.ts
+++ b/webapp/cloudflare/deployment-entry.ts
@@ -1,4 +1,5 @@
 import worker from "./index";
+import { reconcileDeliveryStatuses } from "./delivery-reconcile";
 
 type DeploymentEnv = Env & {
   DEPLOYMENT_COMMIT?: string;
@@ -6,6 +7,12 @@ type DeploymentEnv = Env & {
   AIRFLOW_PUSH_TOKEN: string;
   INVITE_CODE_PEPPER?: string;
   INVITE_ADMIN_TOKEN?: string;
+  TENCENT_SECRET_ID: string;
+  TENCENT_SECRET_KEY: string;
+  TENCENT_REGION: string;
+  EMAIL_FROM_ADDRESS: string;
+  EMAIL_REPLY_TO: string;
+  EMAIL_TEMPLATE_ID: string;
 };
 
 export function deploymentHealth(deploymentCommit?: string) {
@@ -27,6 +34,17 @@ function withInviteSecrets(env: DeploymentEnv) {
   };
 }
 
+function reconcileInBackground(env: DeploymentEnv, context: ExecutionContext, limit = 5) {
+  context.waitUntil(
+    reconcileDeliveryStatuses(withInviteSecrets(env) as never, limit).catch((error) => {
+      console.warn(JSON.stringify({
+        event: "delivery_reconcile_background_failed",
+        reason: error instanceof Error ? error.message.slice(0, 200) : "unknown",
+      }));
+    }),
+  );
+}
+
 export default {
   async fetch(
     request: Request,
@@ -42,7 +60,15 @@ export default {
         },
       });
     }
-    return worker.fetch(request, withInviteSecrets(env) as never, context);
+
+    const response = await worker.fetch(request, withInviteSecrets(env) as never, context);
+    // Observation traffic is already the live heartbeat of this service. Use it
+    // as an independent reconciliation trigger so provider-delivery metrics stay
+    // fresh even if another scheduled maintenance phase fails before reconciliation.
+    if (request.method === "POST" && url.pathname === "/api/internal/observations") {
+      reconcileInBackground(env, context, 5);
+    }
+    return response;
   },
 
   async scheduled(
@@ -50,6 +76,10 @@ export default {
     env: DeploymentEnv,
     context: ExecutionContext,
   ): Promise<void> {
+    // Schedule reconciliation independently before delegating to the legacy
+    // maintenance pipeline. One failing maintenance task must not block delivery
+    // status refreshes.
+    reconcileInBackground(env, context, 20);
     await worker.scheduled(controller, withInviteSecrets(env) as never, context);
   },
 } satisfies ExportedHandler<DeploymentEnv>;


### PR DESCRIPTION
## Root cause confirmed in production
A redacted D1 diagnosis found 147 provider-submitted messages today, all 147 still `submitted`, and all 147 had `provider_checked_at = NULL`. This proves the provider reconciliation stage was not being reached, so the dashboard could never transition messages to delivered/failed regardless of the Tencent status-code fix.

## Fix
- Add an independent delivery-status reconciler with a lightweight D1 claim/lease to avoid duplicate provider queries.
- Reconcile by Tencent `MessageId` only; the provider API documents `MessageId` as a sufficient lookup key, so an extra recipient match can no longer hide a valid record.
- Trigger reconciliation from every successful observation ingestion, which is already the live heartbeat of the service.
- Trigger reconciliation independently at the start of every scheduled event before the legacy maintenance pipeline, so an unrelated maintenance failure cannot block delivery metrics.
- Reconcile system emails through the same independent path.
- Keep provider query failures non-fatal and retryable after the five-minute refresh interval.

No real email is sent by this change.