### PR TITLE
fix(webapp): execute delivery reconciliation synchronously

### DIFF
--- a/scripts/diagnose_webapp_observation.sh
+++ b/scripts/diagnose_webapp_observation.sh
@@ -31,7 +31,7 @@ airflow_python - <<'PY'
 import json
 import urllib.error
 import urllib.request
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 from airflow.models.variable import Variable
 
 url = str(Variable.get("WEBAPP_OBSERVATION_API_URL", default_var="") or "").strip()
@@ -51,7 +51,7 @@ if url and token:
         headers={
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
-            "User-Agent": "zacks-airflow-diagnose/3",
+            "User-Agent": "zacks-airflow-diagnose/4",
         },
         method="POST",
     )
@@ -63,11 +63,32 @@ if url and token:
     except Exception as exc:
         result["probe_error_type"] = type(exc).__name__
         result["probe_error"] = str(exc)[:200]
-    else:
-        pass
     if "status" in locals():
         result["auth_probe_status"] = status
         result["auth_probe_ok"] = status == 400
+
+    reconcile_url = urlunsplit((parsed.scheme, parsed.netloc, "/api/internal/reconcile-deliveries", "", ""))
+    reconcile_request = urllib.request.Request(
+        reconcile_url,
+        data=b"{}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "zacks-airflow-diagnose/4",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(reconcile_request, timeout=20) as response:
+            result["reconcile_status"] = response.getcode()
+            result["reconcile_ok"] = response.getcode() == 200
+    except urllib.error.HTTPError as exc:
+        result["reconcile_status"] = exc.code
+        result["reconcile_ok"] = False
+    except Exception as exc:
+        result["reconcile_ok"] = False
+        result["reconcile_error_type"] = type(exc).__name__
+        result["reconcile_error"] = str(exc)[:200]
 print(json.dumps(result, ensure_ascii=False, sort_keys=True))
 PY
 printf '%s\n' '__WEBAPP_LOGS__'
@@ -90,7 +111,7 @@ import urllib.request
 
 request = urllib.request.Request(
     "https://zacks.claude89757.cc/api/bootstrap",
-    headers={"Accept": "application/json", "User-Agent": "zacks-production-diagnose/3"},
+    headers={"Accept": "application/json", "User-Agent": "zacks-production-diagnose/4"},
 )
 with urllib.request.urlopen(request, timeout=10) as response:
     payload = json.loads(response.read().decode("utf-8"))

--- a/webapp/cloudflare/deployment-entry.ts
+++ b/webapp/cloudflare/deployment-entry.ts
@@ -34,15 +34,34 @@ function withInviteSecrets(env: DeploymentEnv) {
   };
 }
 
-function reconcileInBackground(env: DeploymentEnv, context: ExecutionContext, limit = 5) {
-  context.waitUntil(
-    reconcileDeliveryStatuses(withInviteSecrets(env) as never, limit).catch((error) => {
-      console.warn(JSON.stringify({
-        event: "delivery_reconcile_background_failed",
-        reason: error instanceof Error ? error.message.slice(0, 200) : "unknown",
-      }));
-    }),
-  );
+function constantTimeEqual(left: string, right: string): boolean {
+  const encoder = new TextEncoder();
+  const leftBytes = encoder.encode(left);
+  const rightBytes = encoder.encode(right);
+  if (leftBytes.byteLength !== rightBytes.byteLength) return false;
+  let difference = 0;
+  for (let index = 0; index < leftBytes.byteLength; index += 1) {
+    difference |= leftBytes[index] ^ rightBytes[index];
+  }
+  return difference === 0;
+}
+
+function authorizedInternalRequest(request: Request, env: DeploymentEnv): boolean {
+  const authorization = request.headers.get("authorization") || "";
+  if (!authorization.startsWith("Bearer ")) return false;
+  const token = authorization.slice(7).trim();
+  return Boolean(token) && constantTimeEqual(token, env.AIRFLOW_PUSH_TOKEN);
+}
+
+async function reconcileSafely(env: DeploymentEnv, limit: number): Promise<void> {
+  try {
+    await reconcileDeliveryStatuses(withInviteSecrets(env) as never, limit);
+  } catch (error) {
+    console.warn(JSON.stringify({
+      event: "delivery_reconcile_failed",
+      reason: error instanceof Error ? error.message.slice(0, 200) : "unknown",
+    }));
+  }
 }
 
 export default {
@@ -61,12 +80,23 @@ export default {
       });
     }
 
+    if (request.method === "POST" && url.pathname === "/api/internal/reconcile-deliveries") {
+      if (!authorizedInternalRequest(request, env)) {
+        return Response.json({ error: "未授权" }, { status: 401 });
+      }
+      await reconcileSafely(env, 20);
+      return Response.json({ success: true }, {
+        headers: { "Cache-Control": "no-store" },
+      });
+    }
+
     const response = await worker.fetch(request, withInviteSecrets(env) as never, context);
-    // Observation traffic is already the live heartbeat of this service. Use it
-    // as an independent reconciliation trigger so provider-delivery metrics stay
-    // fresh even if another scheduled maintenance phase fails before reconciliation.
     if (request.method === "POST" && url.pathname === "/api/internal/observations") {
-      reconcileInBackground(env, context, 5);
+      // Run one provider reconciliation inline. The prior waitUntil-only path was
+      // not advancing provider_checked_at in production, while observations are
+      // the reliable live heartbeat. A single lookup keeps request latency bounded
+      // and guarantees eventual progress without coupling it to maintenance jobs.
+      await reconcileSafely(env, 1);
     }
     return response;
   },
@@ -76,10 +106,9 @@ export default {
     env: DeploymentEnv,
     context: ExecutionContext,
   ): Promise<void> {
-    // Schedule reconciliation independently before delegating to the legacy
-    // maintenance pipeline. One failing maintenance task must not block delivery
-    // status refreshes.
-    reconcileInBackground(env, context, 20);
+    // Await reconciliation before the legacy maintenance pipeline so unrelated
+    // renewal/cleanup failures cannot prevent delivery-state refreshes.
+    await reconcileSafely(env, 20);
     await worker.scheduled(controller, withInviteSecrets(env) as never, context);
   },
 } satisfies ExportedHandler<DeploymentEnv>;


### PR DESCRIPTION
## Production evidence
After #79 was deployed, multiple fresh observation requests arrived, but all 147 provider-submitted messages still had `provider_checked_at = NULL`. The waitUntil-only reconciliation trigger therefore did not advance production state.

## Fix
- Await one delivery reconciliation during each observation ingestion response path, bounded to one provider message per observation.
- Await a batch reconciliation before the scheduled maintenance pipeline.
- Add a protected, token-authenticated `/api/internal/reconcile-deliveries` operation for bounded operational recovery/verification. It reconciles existing provider statuses only and never sends mail.
- Extend the production diagnosis to exercise that protected reconciliation endpoint before reading aggregate D1 metrics, so we can prove the provider status path end-to-end.

This intentionally favors correctness and observability over a small amount of extra observation-request latency. No real email is sent by this change.