### PR TITLE
fix(webapp): make Tencent delivery reconciliation observable

### DIFF
--- a/scripts/diagnose_email_delivery_metrics.sh
+++ b/scripts/diagnose_email_delivery_metrics.sh
@@ -20,8 +20,10 @@ SELECT
   COUNT(DISTINCT CASE WHEN status='delivered' AND provider_delivered_at >= day.start_utc THEN message_id END) AS delivered_today,
   COUNT(DISTINCT CASE WHEN status='failed' AND provider_submitted_at >= day.start_utc THEN message_id END) AS failed_today,
   COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc THEN message_id END) AS pending_today,
+  COUNT(DISTINCT CASE WHEN provider_submitted_at >= day.start_utc AND provider_checked_at IS NOT NULL THEN message_id END) AS checked_today,
   COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc AND provider_checked_at IS NULL THEN message_id END) AS never_checked_today,
   COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc AND provider_status='not_found' THEN message_id END) AS not_found_today,
+  COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc AND provider_status LIKE 'check_error:%' THEN message_id END) AS check_error_today,
   COUNT(DISTINCT CASE WHEN provider_submitted_at >= day.start_utc AND message_id LIKE 'worker:%' THEN message_id END) AS placeholder_message_ids_today
 FROM notification_outbox, day;
 "

--- a/scripts/diagnose_webapp_observation.sh
+++ b/scripts/diagnose_webapp_observation.sh
@@ -29,6 +29,7 @@ airflow_python() {
 }
 airflow_python - <<'PY'
 import json
+import time
 import urllib.error
 import urllib.request
 from urllib.parse import urlsplit, urlunsplit
@@ -51,7 +52,7 @@ if url and token:
         headers={
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
-            "User-Agent": "zacks-airflow-diagnose/4",
+            "User-Agent": "zacks-airflow-diagnose/5",
         },
         method="POST",
     )
@@ -68,28 +69,92 @@ if url and token:
         result["auth_probe_ok"] = status == 400
 
     reconcile_url = urlunsplit((parsed.scheme, parsed.netloc, "/api/internal/reconcile-deliveries", "", ""))
-    reconcile_request = urllib.request.Request(
-        reconcile_url,
-        data=b"{}",
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-            "User-Agent": "zacks-airflow-diagnose/4",
+    aggregate = {
+        "iterations": 0,
+        "notifications": {
+            "selected": 0,
+            "claimed": 0,
+            "checked": 0,
+            "delivered": 0,
+            "failed": 0,
+            "pending": 0,
+            "unavailable": 0,
+            "errors": {},
         },
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(reconcile_request, timeout=20) as response:
-            result["reconcile_status"] = response.getcode()
-            result["reconcile_ok"] = response.getcode() == 200
-    except urllib.error.HTTPError as exc:
-        result["reconcile_status"] = exc.code
-        result["reconcile_ok"] = False
-    except Exception as exc:
-        result["reconcile_ok"] = False
-        result["reconcile_error_type"] = type(exc).__name__
-        result["reconcile_error"] = str(exc)[:200]
+        "systemEmails": {
+            "selected": 0,
+            "claimed": 0,
+            "checked": 0,
+            "delivered": 0,
+            "failed": 0,
+            "pending": 0,
+            "unavailable": 0,
+            "errors": {},
+        },
+    }
+    reconcile_ok = True
+    last_status = None
+    for iteration in range(10):
+        reconcile_request = urllib.request.Request(
+            reconcile_url,
+            data=b"{}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "User-Agent": "zacks-airflow-diagnose/5",
+            },
+            method="POST",
+        )
+        payload = {}
+        try:
+            with urllib.request.urlopen(reconcile_request, timeout=60) as response:
+                last_status = response.getcode()
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            last_status = exc.code
+            try:
+                payload = json.loads(exc.read().decode("utf-8"))
+            except Exception:
+                payload = {"success": False, "errorCode": f"HTTP_{exc.code}"}
+        except Exception as exc:
+            last_status = None
+            payload = {
+                "success": False,
+                "errorCode": type(exc).__name__,
+            }
+
+        aggregate["iterations"] += 1
+        for queue in ("notifications", "systemEmails"):
+            section = payload.get(queue) if isinstance(payload, dict) else None
+            if not isinstance(section, dict):
+                continue
+            for key in ("selected", "claimed", "checked", "delivered", "failed", "pending", "unavailable"):
+                aggregate[queue][key] += int(section.get(key) or 0)
+            errors = section.get("errors") or {}
+            if isinstance(errors, dict):
+                for code, count in errors.items():
+                    aggregate[queue]["errors"][str(code)] = (
+                        aggregate[queue]["errors"].get(str(code), 0) + int(count or 0)
+                    )
+
+        if last_status != 200 or not bool(payload.get("success", False)):
+            reconcile_ok = False
+            result["reconcile_error_code"] = str(payload.get("errorCode") or "provider_status_unavailable")
+            break
+
+        selected = int((payload.get("notifications") or {}).get("selected") or 0)
+        selected += int((payload.get("systemEmails") or {}).get("selected") or 0)
+        if selected == 0:
+            break
+        time.sleep(0.5)
+
+    result["reconcile_status"] = last_status
+    result["reconcile_ok"] = reconcile_ok
+    result["reconcile_summary"] = aggregate
+
 print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+if result.get("reconcile_ok") is False:
+    raise SystemExit(2)
 PY
 printf '%s\n' '__WEBAPP_LOGS__'
 for candidate in airflow-worker worker; do
@@ -111,7 +176,7 @@ import urllib.request
 
 request = urllib.request.Request(
     "https://zacks.claude89757.cc/api/bootstrap",
-    headers={"Accept": "application/json", "User-Agent": "zacks-production-diagnose/4"},
+    headers={"Accept": "application/json", "User-Agent": "zacks-production-diagnose/5"},
 )
 with urllib.request.urlopen(request, timeout=10) as response:
     payload = json.loads(response.read().decode("utf-8"))

--- a/webapp/cloudflare/delivery-reconcile.test.ts
+++ b/webapp/cloudflare/delivery-reconcile.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { providerCheckError } from "./delivery-reconcile";
+
+describe("delivery reconciliation observability", () => {
+  it("extracts a stable provider error code", () => {
+    expect(providerCheckError(
+      new Error("AuthFailure.UnauthorizedOperation: permission denied"),
+    )).toEqual({
+      code: "AuthFailure.UnauthorizedOperation",
+      reason: "AuthFailure.UnauthorizedOperation: permission denied",
+      status: "check_error:AuthFailure.UnauthorizedOperation",
+    });
+  });
+
+  it("normalizes unexpected errors", () => {
+    expect(providerCheckError("network unavailable")).toEqual({
+      code: "unknown",
+      reason: "unknown delivery status error",
+      status: "check_error:unknown",
+    });
+  });
+});

--- a/webapp/cloudflare/delivery-reconcile.ts
+++ b/webapp/cloudflare/delivery-reconcile.ts
@@ -5,28 +5,85 @@ type ReconcileEnv = TencentSecrets & {
   DB: D1Database;
 };
 
+export type QueueReconcileSummary = {
+  selected: number;
+  claimed: number;
+  checked: number;
+  delivered: number;
+  failed: number;
+  pending: number;
+  unavailable: number;
+  errors: Record<string, number>;
+};
+
+export type DeliveryReconcileSummary = {
+  notifications: QueueReconcileSummary;
+  systemEmails: QueueReconcileSummary;
+};
+
 const REFRESH_MS = 5 * 60_000;
+
+function emptySummary(selected = 0): QueueReconcileSummary {
+  return {
+    selected,
+    claimed: 0,
+    checked: 0,
+    delivered: 0,
+    failed: 0,
+    pending: 0,
+    unavailable: 0,
+    errors: {},
+  };
+}
+
+export function providerCheckError(error: unknown): {
+  code: string;
+  reason: string;
+  status: string;
+} {
+  const reason = error instanceof Error
+    ? error.message.slice(0, 300)
+    : "unknown delivery status error";
+  const matched = reason.match(/^([A-Za-z0-9_.-]{1,80}):/);
+  const code = matched?.[1] || "unknown";
+  return {
+    code,
+    reason,
+    status: `check_error:${code}`.slice(0, 120),
+  };
+}
+
+function addError(summary: QueueReconcileSummary, code: string): void {
+  summary.errors[code] = (summary.errors[code] || 0) + 1;
+}
 
 async function claimNotificationMessages(
   env: ReconcileEnv,
   limit: number,
-): Promise<Array<{ messageId: string }>> {
+): Promise<{
+  selected: number;
+  messages: Array<{ messageId: string; email: string }>;
+}> {
   const now = Date.now();
+  const cutoff = now - REFRESH_MS;
   const candidates = (
     await env.DB.prepare(
-      `SELECT message_id
+      `SELECT DISTINCT message_id, email, provider_submitted_at
          FROM notification_outbox
         WHERE status = 'submitted'
           AND message_id IS NOT NULL
           AND message_id NOT LIKE 'worker:%'
           AND (provider_checked_at IS NULL OR provider_checked_at < ?)
-        GROUP BY message_id
-        ORDER BY MIN(provider_submitted_at)
+        ORDER BY provider_submitted_at
         LIMIT ?`,
-    ).bind(now - REFRESH_MS, limit).all<{ message_id: string }>()
+    ).bind(cutoff, limit).all<{
+      message_id: string;
+      email: string;
+      provider_submitted_at: string;
+    }>()
   ).results;
 
-  const claimed: Array<{ messageId: string }> = [];
+  const messages: Array<{ messageId: string; email: string }> = [];
   for (const candidate of candidates) {
     const result = await env.DB.prepare(
       `UPDATE notification_outbox
@@ -34,21 +91,28 @@ async function claimNotificationMessages(
         WHERE message_id = ?
           AND status = 'submitted'
           AND (provider_checked_at IS NULL OR provider_checked_at < ?)`,
-    ).bind(now, candidate.message_id, now - REFRESH_MS).run();
-    if (Number(result.meta.changes || 0) > 0) claimed.push({ messageId: candidate.message_id });
+    ).bind(now, candidate.message_id, cutoff).run();
+    if (Number(result.meta.changes || 0) > 0) {
+      messages.push({ messageId: candidate.message_id, email: candidate.email });
+    }
   }
-  return claimed;
+  return { selected: candidates.length, messages };
 }
 
-async function reconcileNotificationMessages(env: ReconcileEnv, limit: number): Promise<void> {
-  const messages = await claimNotificationMessages(env, limit);
-  for (const message of messages) {
+async function reconcileNotificationMessages(
+  env: ReconcileEnv,
+  limit: number,
+): Promise<QueueReconcileSummary> {
+  const claimed = await claimNotificationMessages(env, limit);
+  const summary = emptySummary(claimed.selected);
+  summary.claimed = claimed.messages.length;
+
+  for (const message of claimed.messages) {
     try {
-      // MessageId is globally sufficient for GetSendEmailStatus and avoids a
-      // second matching condition that can cause a valid provider record to be missed.
-      const provider = await getTencentEmailStatus(env, message.messageId);
+      const provider = await getTencentEmailStatus(env, message.messageId, message.email);
       const normalized = normalizeTencentDeliveryStatus(provider);
       const checkedAt = Date.now();
+      summary.checked += 1;
       if (normalized.state === "delivered") {
         const deliveredAt = normalized.deliveredAt || new Date().toISOString();
         const venues = (
@@ -83,6 +147,7 @@ async function reconcileNotificationMessages(env: ReconcileEnv, limit: number): 
           );
         }
         await env.DB.batch(statements);
+        summary.delivered += 1;
       } else if (normalized.state === "failed") {
         const failedAt = new Date().toISOString();
         await env.DB.prepare(
@@ -99,30 +164,46 @@ async function reconcileNotificationMessages(env: ReconcileEnv, limit: number): 
           normalized.error,
           message.messageId,
         ).run();
+        summary.failed += 1;
       } else {
         await env.DB.prepare(
           `UPDATE notification_outbox
-              SET provider_status = ?, provider_checked_at = ?
+              SET provider_status = ?, provider_checked_at = ?, provider_error = NULL
             WHERE message_id = ? AND status = 'submitted'`,
         ).bind(normalized.providerStatus, checkedAt, message.messageId).run();
+        summary.pending += 1;
       }
     } catch (error) {
+      const detail = providerCheckError(error);
+      const checkedAt = Date.now();
+      await env.DB.prepare(
+        `UPDATE notification_outbox
+            SET provider_status = ?, provider_checked_at = ?, provider_error = ?
+          WHERE message_id = ? AND status = 'submitted'`,
+      ).bind(detail.status, checkedAt, detail.reason, message.messageId).run();
+      summary.unavailable += 1;
+      addError(summary, detail.code);
       console.warn(JSON.stringify({
         event: "notification_delivery_reconcile_failed",
-        reason: error instanceof Error ? error.message.slice(0, 200) : "unknown",
+        errorCode: detail.code,
       }));
     }
   }
+  return summary;
 }
 
 async function claimSystemEmails(
   env: ReconcileEnv,
   limit: number,
-): Promise<Array<{ id: string; messageId: string }>> {
+): Promise<{
+  selected: number;
+  rows: Array<{ id: string; messageId: string; email: string }>;
+}> {
   const now = Date.now();
+  const cutoff = now - REFRESH_MS;
   const candidates = (
     await env.DB.prepare(
-      `SELECT id, provider_message_id
+      `SELECT id, provider_message_id, email
          FROM system_email_outbox
         WHERE status = 'submitted'
           AND provider_message_id IS NOT NULL
@@ -130,10 +211,14 @@ async function claimSystemEmails(
           AND (provider_checked_at IS NULL OR provider_checked_at < ?)
         ORDER BY submitted_at
         LIMIT ?`,
-    ).bind(now - REFRESH_MS, limit).all<{ id: string; provider_message_id: string }>()
+    ).bind(cutoff, limit).all<{
+      id: string;
+      provider_message_id: string;
+      email: string;
+    }>()
   ).results;
 
-  const claimed: Array<{ id: string; messageId: string }> = [];
+  const rows: Array<{ id: string; messageId: string; email: string }> = [];
   for (const candidate of candidates) {
     const result = await env.DB.prepare(
       `UPDATE system_email_outbox
@@ -141,22 +226,33 @@ async function claimSystemEmails(
         WHERE id = ?
           AND status = 'submitted'
           AND (provider_checked_at IS NULL OR provider_checked_at < ?)`,
-    ).bind(now, new Date(now).toISOString(), candidate.id, now - REFRESH_MS).run();
+    ).bind(now, new Date(now).toISOString(), candidate.id, cutoff).run();
     if (Number(result.meta.changes || 0) > 0) {
-      claimed.push({ id: candidate.id, messageId: candidate.provider_message_id });
+      rows.push({
+        id: candidate.id,
+        messageId: candidate.provider_message_id,
+        email: candidate.email,
+      });
     }
   }
-  return claimed;
+  return { selected: candidates.length, rows };
 }
 
-async function reconcileSystemEmails(env: ReconcileEnv, limit: number): Promise<void> {
-  const rows = await claimSystemEmails(env, limit);
-  for (const row of rows) {
+async function reconcileSystemEmails(
+  env: ReconcileEnv,
+  limit: number,
+): Promise<QueueReconcileSummary> {
+  const claimed = await claimSystemEmails(env, limit);
+  const summary = emptySummary(claimed.selected);
+  summary.claimed = claimed.rows.length;
+
+  for (const row of claimed.rows) {
     try {
-      const provider = await getTencentEmailStatus(env, row.messageId);
+      const provider = await getTencentEmailStatus(env, row.messageId, row.email);
       const normalized = normalizeTencentDeliveryStatus(provider);
       const checkedAt = Date.now();
       const nowIso = new Date(checkedAt).toISOString();
+      summary.checked += 1;
       if (normalized.state === "delivered") {
         await env.DB.prepare(
           `UPDATE system_email_outbox
@@ -170,6 +266,7 @@ async function reconcileSystemEmails(env: ReconcileEnv, limit: number): Promise<
           nowIso,
           row.id,
         ).run();
+        summary.delivered += 1;
       } else if (normalized.state === "failed") {
         await env.DB.prepare(
           `UPDATE system_email_outbox
@@ -184,28 +281,44 @@ async function reconcileSystemEmails(env: ReconcileEnv, limit: number): Promise<
           nowIso,
           row.id,
         ).run();
+        summary.failed += 1;
       } else {
         await env.DB.prepare(
           `UPDATE system_email_outbox
-              SET provider_status = ?, provider_checked_at = ?, updated_at = ?
+              SET provider_status = ?, provider_checked_at = ?,
+                  last_error = NULL, updated_at = ?
             WHERE id = ? AND status = 'submitted'`,
         ).bind(normalized.providerStatus, checkedAt, nowIso, row.id).run();
+        summary.pending += 1;
       }
     } catch (error) {
+      const detail = providerCheckError(error);
+      const checkedAt = Date.now();
+      const nowIso = new Date(checkedAt).toISOString();
+      await env.DB.prepare(
+        `UPDATE system_email_outbox
+            SET provider_status = ?, provider_checked_at = ?,
+                last_error = ?, updated_at = ?
+          WHERE id = ? AND status = 'submitted'`,
+      ).bind(detail.status, checkedAt, detail.reason, nowIso, row.id).run();
+      summary.unavailable += 1;
+      addError(summary, detail.code);
       console.warn(JSON.stringify({
         event: "system_email_delivery_reconcile_failed",
-        reason: error instanceof Error ? error.message.slice(0, 200) : "unknown",
+        errorCode: detail.code,
       }));
     }
   }
+  return summary;
 }
 
 export async function reconcileDeliveryStatuses(
   env: ReconcileEnv,
   limitPerQueue = 5,
-): Promise<void> {
-  await Promise.all([
+): Promise<DeliveryReconcileSummary> {
+  const [notifications, systemEmails] = await Promise.all([
     reconcileNotificationMessages(env, limitPerQueue),
     reconcileSystemEmails(env, limitPerQueue),
   ]);
+  return { notifications, systemEmails };
 }

--- a/webapp/cloudflare/deployment-entry.ts
+++ b/webapp/cloudflare/deployment-entry.ts
@@ -1,5 +1,9 @@
 import worker from "./index";
-import { reconcileDeliveryStatuses } from "./delivery-reconcile";
+import {
+  providerCheckError,
+  reconcileDeliveryStatuses,
+  type DeliveryReconcileSummary,
+} from "./delivery-reconcile";
 
 type DeploymentEnv = Env & {
   DEPLOYMENT_COMMIT?: string;
@@ -53,14 +57,31 @@ function authorizedInternalRequest(request: Request, env: DeploymentEnv): boolea
   return Boolean(token) && constantTimeEqual(token, env.AIRFLOW_PUSH_TOKEN);
 }
 
-async function reconcileSafely(env: DeploymentEnv, limit: number): Promise<void> {
+function unavailableCount(summary: DeliveryReconcileSummary): number {
+  return summary.notifications.unavailable + summary.systemEmails.unavailable;
+}
+
+async function reconcileSafely(
+  env: DeploymentEnv,
+  limit: number,
+  source: string,
+): Promise<DeliveryReconcileSummary | null> {
   try {
-    await reconcileDeliveryStatuses(withInviteSecrets(env) as never, limit);
+    const summary = await reconcileDeliveryStatuses(withInviteSecrets(env) as never, limit);
+    console.log(JSON.stringify({
+      event: "delivery_reconcile_completed",
+      source,
+      summary,
+    }));
+    return summary;
   } catch (error) {
+    const detail = providerCheckError(error);
     console.warn(JSON.stringify({
       event: "delivery_reconcile_failed",
-      reason: error instanceof Error ? error.message.slice(0, 200) : "unknown",
+      source,
+      errorCode: detail.code,
     }));
+    return null;
   }
 }
 
@@ -84,19 +105,42 @@ export default {
       if (!authorizedInternalRequest(request, env)) {
         return Response.json({ error: "未授权" }, { status: 401 });
       }
-      await reconcileSafely(env, 20);
-      return Response.json({ success: true }, {
-        headers: { "Cache-Control": "no-store" },
-      });
+      try {
+        const summary = await reconcileDeliveryStatuses(withInviteSecrets(env) as never, 20);
+        const unavailable = unavailableCount(summary);
+        return Response.json({
+          success: unavailable === 0,
+          unavailable,
+          ...summary,
+        }, {
+          status: unavailable === 0 ? 200 : 502,
+          headers: { "Cache-Control": "no-store" },
+        });
+      } catch (error) {
+        const detail = providerCheckError(error);
+        console.error(JSON.stringify({
+          event: "protected_delivery_reconcile_failed",
+          errorCode: detail.code,
+        }));
+        return Response.json({
+          success: false,
+          errorCode: detail.code,
+        }, {
+          status: 500,
+          headers: { "Cache-Control": "no-store" },
+        });
+      }
     }
 
     const response = await worker.fetch(request, withInviteSecrets(env) as never, context);
-    if (request.method === "POST" && url.pathname === "/api/internal/observations") {
-      // Run one provider reconciliation inline. The prior waitUntil-only path was
-      // not advancing provider_checked_at in production, while observations are
-      // the reliable live heartbeat. A single lookup keeps request latency bounded
-      // and guarantees eventual progress without coupling it to maintenance jobs.
-      await reconcileSafely(env, 1);
+    if (
+      response.ok
+      && request.method === "POST"
+      && url.pathname === "/api/internal/observations"
+    ) {
+      // One inline lookup guarantees bounded progress on the reliable live
+      // observation heartbeat even if another scheduled maintenance phase fails.
+      await reconcileSafely(env, 1, "observation");
     }
     return response;
   },
@@ -106,9 +150,9 @@ export default {
     env: DeploymentEnv,
     context: ExecutionContext,
   ): Promise<void> {
-    // Await reconciliation before the legacy maintenance pipeline so unrelated
-    // renewal/cleanup failures cannot prevent delivery-state refreshes.
-    await reconcileSafely(env, 20);
+    // Reconcile before the legacy maintenance chain so renewal, draining, or
+    // cleanup errors cannot starve provider delivery-state updates.
+    await reconcileSafely(env, 20, "scheduled");
     await worker.scheduled(controller, withInviteSecrets(env) as never, context);
   },
 } satisfies ExportedHandler<DeploymentEnv>;

--- a/webapp/cloudflare/tencent-ses.test.ts
+++ b/webapp/cloudflare/tencent-ses.test.ts
@@ -1,6 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { sendTencentTemplateEmail } from "./tencent-ses";
+import {
+  getTencentEmailStatus,
+  sendTencentTemplateEmail,
+  tencentStatusRequestDates,
+} from "./tencent-ses";
+
+const SECRETS = {
+  TENCENT_SECRET_ID: "secret-id",
+  TENCENT_SECRET_KEY: "secret-key",
+  TENCENT_REGION: "ap-guangzhou",
+  EMAIL_FROM_ADDRESS: "sender@example.com",
+  EMAIL_REPLY_TO: "reply@example.com",
+  EMAIL_TEMPLATE_ID: "33340",
+};
 
 describe("Tencent SES TC3 request", () => {
   afterEach(() => {
@@ -21,14 +34,7 @@ describe("Tencent SES TC3 request", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await sendTencentTemplateEmail(
-      {
-        TENCENT_SECRET_ID: "secret-id",
-        TENCENT_SECRET_KEY: "secret-key",
-        TENCENT_REGION: "ap-guangzhou",
-        EMAIL_FROM_ADDRESS: "sender@example.com",
-        EMAIL_REPLY_TO: "reply@example.com",
-        EMAIL_TEMPLATE_ID: "33340",
-      },
+      SECRETS,
       "recipient@example.com",
       "subject",
       "body",
@@ -47,5 +53,49 @@ describe("Tencent SES TC3 request", () => {
     expect(headers["Content-Type"]).toBe("application/json");
     expect(headers.Authorization).toContain("SignedHeaders=content-type;host");
     expect(headers.Authorization).not.toContain("x-tc-action");
+  });
+
+  it("prefers the send date embedded in the provider MessageId", () => {
+    expect(tencentStatusRequestDates(
+      "qcloudses-30-4123414323-date-20260824093000-syNARhMTbKI1",
+      Date.parse("2026-08-25T12:00:00.000Z"),
+    )[0]).toBe("2026-08-24");
+  });
+
+  it("queries by MessageId without combining the recipient filter", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-25T12:00:00.000Z"));
+    const messageId = "qcloudses-30-4123414323-date-20260824093000-syNARhMTbKI1";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        Response: {
+          EmailStatusList: [{
+            MessageId: messageId,
+            ToEmailAddress: "recipient@example.com",
+            SendStatus: 0,
+            DeliverStatus: 1,
+          }],
+          RequestId: "request-id",
+        },
+      }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const status = await getTencentEmailStatus(
+      SECRETS,
+      messageId,
+      "recipient@example.com",
+    );
+
+    expect(status?.DeliverStatus).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body)) as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      RequestDate: "2026-08-24",
+      MessageId: messageId,
+      Offset: 0,
+      Limit: 100,
+    });
+    expect(payload).not.toHaveProperty("ToEmailAddress");
   });
 });

--- a/webapp/cloudflare/tencent-ses.ts
+++ b/webapp/cloudflare/tencent-ses.ts
@@ -124,9 +124,43 @@ export async function sendTencentTemplateEmail(
   };
 }
 
-function shanghaiDate(offsetDays = 0): string {
-  const shifted = new Date(Date.now() + 8 * 3_600_000 + offsetDays * 86_400_000);
+function shanghaiDate(offsetDays = 0, now = Date.now()): string {
+  const shifted = new Date(now + 8 * 3_600_000 + offsetDays * 86_400_000);
   return shifted.toISOString().slice(0, 10);
+}
+
+export function tencentStatusRequestDates(
+  messageId: string,
+  now = Date.now(),
+): string[] {
+  const dates: string[] = [];
+  const append = (value: string) => {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value) && !dates.includes(value)) dates.push(value);
+  };
+
+  // Tencent MessageIds include `date-YYYYMMDDhhmmss`. RequestDate is a
+  // required single send date, so this is more reliable than guessing from the
+  // current calendar day, especially while reconciling an older backlog.
+  const embedded = messageId.match(/(?:^|-)date-(\d{4})(\d{2})(\d{2})\d{6}(?:-|$)/i);
+  if (embedded) append(`${embedded[1]}-${embedded[2]}-${embedded[3]}`);
+  for (const offsetDays of [0, -1, -2]) append(shanghaiDate(offsetDays, now));
+  return dates;
+}
+
+async function queryTencentEmailStatus(
+  env: TencentSecrets,
+  requestDate: string,
+  filter: { MessageId: string } | { ToEmailAddress: string },
+): Promise<TencentEmailStatus[]> {
+  const result = await callTencentSes<{
+    EmailStatusList?: TencentEmailStatus[];
+  }>(env, "GetSendEmailStatus", {
+    RequestDate: requestDate,
+    Offset: 0,
+    Limit: 100,
+    ...filter,
+  });
+  return result.response.EmailStatusList ?? [];
 }
 
 export async function getTencentEmailStatus(
@@ -134,20 +168,28 @@ export async function getTencentEmailStatus(
   messageId: string,
   recipient?: string,
 ): Promise<TencentEmailStatus | null> {
-  for (const offsetDays of [0, -1, -2]) {
-    const result = await callTencentSes<{
-      EmailStatusList?: TencentEmailStatus[];
-    }>(env, "GetSendEmailStatus", {
-      RequestDate: shanghaiDate(offsetDays),
-      Offset: 0,
-      Limit: 100,
-      MessageId: messageId,
-      ...(recipient ? { ToEmailAddress: recipient } : {}),
-    });
-    const match = (result.response.EmailStatusList ?? []).find(
-      (item) => item.MessageId === messageId,
-    );
+  const requestDates = tencentStatusRequestDates(messageId);
+
+  // The provider documents MessageId and recipient as alternative filters.
+  // Query by MessageId alone first; combining both optional filters can turn a
+  // valid provider record into an empty result.
+  for (const requestDate of requestDates) {
+    const match = (await queryTencentEmailStatus(env, requestDate, { MessageId: messageId }))
+      .find((item) => item.MessageId === messageId);
     if (match) return match;
+  }
+
+  // Recipient-only lookup is a compatibility fallback. The exact MessageId is
+  // still required before accepting the returned record.
+  if (recipient) {
+    for (const requestDate of requestDates) {
+      const match = (await queryTencentEmailStatus(
+        env,
+        requestDate,
+        { ToEmailAddress: recipient },
+      )).find((item) => item.MessageId === messageId);
+      if (match) return match;
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Production evidence

The protected reconciliation endpoint deployed in #80 returned HTTP 200, but the immediately following D1 read still showed all 147 provider-submitted messages with `provider_checked_at = NULL`. The endpoint was masking top-level and per-message reconciliation failures, so an operation could report success while doing no work.

## Changes

- Query Tencent `GetSendEmailStatus` using the exact send date embedded in the provider MessageId.
- Keep `MessageId` and recipient as alternative filters, matching the provider API contract.
- Return structured reconciliation summaries: selected, claimed, checked, delivered, failed, pending, unavailable, and redacted error-code counts.
- Persist `provider_checked_at` and `check_error:<code>` when provider lookup fails.
- Make the protected endpoint return a non-2xx status when reconciliation is unavailable instead of a false success.
- Make production diagnosis reconcile all bounded backlog batches and fail acceptance when provider status lookup is unavailable.
- Extend aggregate production evidence with checked and check-error counts.
- Add regression tests for MessageId dates/filters and error-code normalization.

## Safety

- This operation only reads Tencent delivery status and updates lifecycle metadata.
- It never sends an email or WeChat message.
- Provider-accepted messages are not promoted to delivered without Tencent `DeliverStatus=1` evidence.