### PR TITLE
fix(webapp): correct today reminder count and backlog priority

### DIFF
--- a/scripts/diagnose_email_delivery_metrics.sh
+++ b/scripts/diagnose_email_delivery_metrics.sh
@@ -58,6 +58,33 @@ FROM notification_outbox, day
 WHERE status='submitted' AND provider_submitted_at >= day.start_utc;
 "
 
+printf '%s\n' '__RECONCILIATION_BACKLOG__'
+wrangler d1 execute zacks-tennis-alerts --remote --json --command "
+WITH bounds AS (
+  SELECT
+    datetime('now','-48 hours') AS recent_cutoff,
+    datetime('now','-30 days') AS retention_cutoff
+)
+SELECT
+  COUNT(DISTINCT CASE
+    WHEN provider_submitted_at >= bounds.recent_cutoff THEN message_id END
+  ) AS recent_pending,
+  COUNT(DISTINCT CASE
+    WHEN provider_submitted_at >= bounds.retention_cutoff
+     AND provider_submitted_at < bounds.recent_cutoff THEN message_id END
+  ) AS queryable_backlog,
+  COUNT(DISTINCT CASE
+    WHEN provider_submitted_at < bounds.retention_cutoff THEN message_id END
+  ) AS retention_expired,
+  COUNT(DISTINCT message_id) AS total_pending,
+  MIN(provider_submitted_at) AS oldest_pending_at,
+  MAX(provider_submitted_at) AS newest_pending_at
+FROM notification_outbox, bounds
+WHERE status='submitted'
+  AND message_id IS NOT NULL
+  AND message_id NOT LIKE 'worker:%';
+"
+
 printf '%s\n' '__VENUE_NOTIFICATION_COVERAGE__'
 wrangler d1 execute zacks-tennis-alerts --remote --json --command "
 SELECT

--- a/scripts/diagnose_email_delivery_metrics.sh
+++ b/scripts/diagnose_email_delivery_metrics.sh
@@ -24,8 +24,30 @@ SELECT
   COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc AND provider_checked_at IS NULL THEN message_id END) AS never_checked_today,
   COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc AND provider_status='not_found' THEN message_id END) AS not_found_today,
   COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc AND provider_status LIKE 'check_error:%' THEN message_id END) AS check_error_today,
-  COUNT(DISTINCT CASE WHEN provider_submitted_at >= day.start_utc AND message_id LIKE 'worker:%' THEN message_id END) AS placeholder_message_ids_today
+  COUNT(DISTINCT CASE WHEN provider_submitted_at >= day.start_utc AND message_id LIKE 'worker:%' THEN message_id END) AS placeholder_message_ids_today,
+  COUNT(DISTINCT CASE WHEN provider_submitted_at >= day.start_utc THEN email END) AS recipients_today
 FROM notification_outbox, day;
+"
+
+printf '%s\n' '__ADMIN_IDENTITY_DELIVERY_METRICS__'
+wrangler d1 execute zacks-tennis-alerts --remote --json --command "
+WITH day AS (
+  SELECT datetime('now','+8 hours','start of day','-8 hours') AS start_utc
+)
+SELECT
+  COUNT(DISTINCT CASE WHEN n.provider_submitted_at >= day.start_utc THEN n.message_id END) AS submitted_today,
+  COUNT(DISTINCT CASE WHEN n.status='delivered' AND n.provider_delivered_at >= day.start_utc THEN n.message_id END) AS delivered_today,
+  COUNT(DISTINCT CASE WHEN n.status='failed' AND n.provider_submitted_at >= day.start_utc THEN n.message_id END) AS failed_today,
+  COUNT(DISTINCT CASE WHEN n.status='submitted' AND n.provider_submitted_at >= day.start_utc THEN n.message_id END) AS pending_today,
+  COUNT(DISTINCT CASE WHEN n.provider_submitted_at >= day.start_utc AND n.provider_checked_at IS NOT NULL THEN n.message_id END) AS checked_today
+FROM notification_outbox n, day
+WHERE EXISTS (
+  SELECT 1
+    FROM user_roles roles
+   WHERE roles.email = n.email
+     AND roles.role = 'admin'
+     AND roles.revoked_at IS NULL
+);
 "
 
 printf '%s\n' '__PROVIDER_STATUS_BREAKDOWN__'

--- a/webapp/cloudflare/delivery-reconcile.test.ts
+++ b/webapp/cloudflare/delivery-reconcile.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { providerCheckError } from "./delivery-reconcile";
+import {
+  providerCheckError,
+  reconciliationLanePlan,
+  selectReconciliationCandidates,
+} from "./delivery-reconcile";
 
 describe("delivery reconciliation observability", () => {
   it("extracts a stable provider error code", () => {
@@ -19,5 +23,41 @@ describe("delivery reconciliation observability", () => {
       reason: "unknown delivery status error",
       status: "check_error:unknown",
     });
+  });
+});
+
+describe("delivery reconciliation lane selection", () => {
+  it("reserves most capacity for recent messages while advancing backlog", () => {
+    expect(reconciliationLanePlan(20)).toEqual({ recent: 16, backlog: 4 });
+    expect(reconciliationLanePlan(1)).toEqual({ recent: 1, backlog: 0 });
+  });
+
+  it("selects current messages before the historical backlog", () => {
+    const recent = Array.from({ length: 20 }, (_, index) => `recent-${index}`);
+    const backlog = Array.from({ length: 20 }, (_, index) => `backlog-${index}`);
+    const selected = selectReconciliationCandidates(recent, backlog, 20);
+
+    expect(selected.recentCount).toBe(16);
+    expect(selected.backlogCount).toBe(4);
+    expect(selected.items).toEqual([
+      ...recent.slice(0, 16),
+      ...backlog.slice(0, 4),
+    ]);
+  });
+
+  it("fills unused recent capacity from the queryable backlog", () => {
+    const recent = ["recent-0", "recent-1"];
+    const backlog = Array.from({ length: 10 }, (_, index) => `backlog-${index}`);
+    const selected = selectReconciliationCandidates(recent, backlog, 5);
+
+    expect(selected.recentCount).toBe(2);
+    expect(selected.backlogCount).toBe(3);
+    expect(selected.items).toEqual([
+      "recent-0",
+      "recent-1",
+      "backlog-0",
+      "backlog-1",
+      "backlog-2",
+    ]);
   });
 });

--- a/webapp/cloudflare/delivery-reconcile.ts
+++ b/webapp/cloudflare/delivery-reconcile.ts
@@ -5,8 +5,23 @@ type ReconcileEnv = TencentSecrets & {
   DB: D1Database;
 };
 
+type NotificationCandidate = {
+  messageId: string;
+  email: string;
+  submittedAt: string;
+};
+
+type SystemEmailCandidate = {
+  id: string;
+  messageId: string;
+  email: string;
+  submittedAt: string;
+};
+
 export type QueueReconcileSummary = {
   selected: number;
+  selectedRecent: number;
+  selectedBacklog: number;
   claimed: number;
   checked: number;
   delivered: number;
@@ -22,10 +37,15 @@ export type DeliveryReconcileSummary = {
 };
 
 const REFRESH_MS = 5 * 60_000;
+const RECENT_PRIORITY_MS = 48 * 60 * 60_000;
+const PROVIDER_STATUS_RETENTION_MS = 30 * 86_400_000;
+const BACKLOG_RESERVE_RATIO = 0.2;
 
-function emptySummary(selected = 0): QueueReconcileSummary {
+function emptySummary(): QueueReconcileSummary {
   return {
-    selected,
+    selected: 0,
+    selectedRecent: 0,
+    selectedBacklog: 0,
     claimed: 0,
     checked: 0,
     delivered: 0,
@@ -33,6 +53,42 @@ function emptySummary(selected = 0): QueueReconcileSummary {
     pending: 0,
     unavailable: 0,
     errors: {},
+  };
+}
+
+export function reconciliationLanePlan(limit: number): {
+  recent: number;
+  backlog: number;
+} {
+  const bounded = Math.max(1, Math.floor(limit));
+  if (bounded < 5) return { recent: bounded, backlog: 0 };
+  const backlog = Math.max(1, Math.floor(bounded * BACKLOG_RESERVE_RATIO));
+  return { recent: bounded - backlog, backlog };
+}
+
+export function selectReconciliationCandidates<T>(
+  recent: T[],
+  backlog: T[],
+  limit: number,
+): { items: T[]; recentCount: number; backlogCount: number } {
+  const bounded = Math.max(1, Math.floor(limit));
+  const plan = reconciliationLanePlan(bounded);
+  const selectedRecent = recent.slice(0, plan.recent);
+  const selectedBacklog = backlog.slice(0, plan.backlog);
+  let remaining = bounded - selectedRecent.length - selectedBacklog.length;
+
+  if (remaining > 0) {
+    selectedRecent.push(...recent.slice(plan.recent, plan.recent + remaining));
+    remaining = bounded - selectedRecent.length - selectedBacklog.length;
+  }
+  if (remaining > 0) {
+    selectedBacklog.push(...backlog.slice(plan.backlog, plan.backlog + remaining));
+  }
+
+  return {
+    items: [...selectedRecent, ...selectedBacklog],
+    recentCount: selectedRecent.length,
+    backlogCount: selectedBacklog.length,
   };
 }
 
@@ -57,46 +113,108 @@ function addError(summary: QueueReconcileSummary, code: string): void {
   summary.errors[code] = (summary.errors[code] || 0) + 1;
 }
 
-async function claimNotificationMessages(
+function reconciliationWindow(now = Date.now()): {
+  recentCutoff: string;
+  retentionCutoff: string;
+} {
+  return {
+    recentCutoff: new Date(now - RECENT_PRIORITY_MS).toISOString(),
+    retentionCutoff: new Date(now - PROVIDER_STATUS_RETENTION_MS).toISOString(),
+  };
+}
+
+async function notificationCandidates(
   env: ReconcileEnv,
   limit: number,
+  cutoff: number,
 ): Promise<{
-  selected: number;
-  messages: Array<{ messageId: string; email: string }>;
+  items: NotificationCandidate[];
+  recentCount: number;
+  backlogCount: number;
 }> {
-  const now = Date.now();
-  const cutoff = now - REFRESH_MS;
-  const candidates = (
-    await env.DB.prepare(
-      `SELECT DISTINCT message_id, email, provider_submitted_at
+  const window = reconciliationWindow();
+  const [recentResult, backlogResult] = await Promise.all([
+    env.DB.prepare(
+      `SELECT message_id, MIN(email) AS email,
+              MIN(provider_submitted_at) AS submitted_at
          FROM notification_outbox
         WHERE status = 'submitted'
           AND message_id IS NOT NULL
           AND message_id NOT LIKE 'worker:%'
+          AND provider_submitted_at >= ?
           AND (provider_checked_at IS NULL OR provider_checked_at < ?)
-        ORDER BY provider_submitted_at
+        GROUP BY message_id
+        ORDER BY submitted_at
         LIMIT ?`,
-    ).bind(cutoff, limit).all<{
+    ).bind(window.recentCutoff, cutoff, limit).all<{
       message_id: string;
       email: string;
-      provider_submitted_at: string;
-    }>()
-  ).results;
+      submitted_at: string;
+    }>(),
+    env.DB.prepare(
+      `SELECT message_id, MIN(email) AS email,
+              MIN(provider_submitted_at) AS submitted_at
+         FROM notification_outbox
+        WHERE status = 'submitted'
+          AND message_id IS NOT NULL
+          AND message_id NOT LIKE 'worker:%'
+          AND provider_submitted_at >= ?
+          AND provider_submitted_at < ?
+          AND (provider_checked_at IS NULL OR provider_checked_at < ?)
+        GROUP BY message_id
+        ORDER BY submitted_at
+        LIMIT ?`,
+    ).bind(
+      window.retentionCutoff,
+      window.recentCutoff,
+      cutoff,
+      limit,
+    ).all<{
+      message_id: string;
+      email: string;
+      submitted_at: string;
+    }>(),
+  ]);
+  const recent = recentResult.results.map((row) => ({
+    messageId: row.message_id,
+    email: row.email,
+    submittedAt: row.submitted_at,
+  }));
+  const backlog = backlogResult.results.map((row) => ({
+    messageId: row.message_id,
+    email: row.email,
+    submittedAt: row.submitted_at,
+  }));
+  return selectReconciliationCandidates(recent, backlog, limit);
+}
 
-  const messages: Array<{ messageId: string; email: string }> = [];
-  for (const candidate of candidates) {
+async function claimNotificationMessages(
+  env: ReconcileEnv,
+  limit: number,
+): Promise<{
+  selectedRecent: number;
+  selectedBacklog: number;
+  messages: NotificationCandidate[];
+}> {
+  const now = Date.now();
+  const cutoff = now - REFRESH_MS;
+  const candidates = await notificationCandidates(env, limit, cutoff);
+  const messages: NotificationCandidate[] = [];
+  for (const candidate of candidates.items) {
     const result = await env.DB.prepare(
       `UPDATE notification_outbox
           SET provider_checked_at = ?
         WHERE message_id = ?
           AND status = 'submitted'
           AND (provider_checked_at IS NULL OR provider_checked_at < ?)`,
-    ).bind(now, candidate.message_id, cutoff).run();
-    if (Number(result.meta.changes || 0) > 0) {
-      messages.push({ messageId: candidate.message_id, email: candidate.email });
-    }
+    ).bind(now, candidate.messageId, cutoff).run();
+    if (Number(result.meta.changes || 0) > 0) messages.push(candidate);
   }
-  return { selected: candidates.length, messages };
+  return {
+    selectedRecent: candidates.recentCount,
+    selectedBacklog: candidates.backlogCount,
+    messages,
+  };
 }
 
 async function reconcileNotificationMessages(
@@ -104,7 +222,10 @@ async function reconcileNotificationMessages(
   limit: number,
 ): Promise<QueueReconcileSummary> {
   const claimed = await claimNotificationMessages(env, limit);
-  const summary = emptySummary(claimed.selected);
+  const summary = emptySummary();
+  summary.selectedRecent = claimed.selectedRecent;
+  summary.selectedBacklog = claimed.selectedBacklog;
+  summary.selected = claimed.selectedRecent + claimed.selectedBacklog;
   summary.claimed = claimed.messages.length;
 
   for (const message of claimed.messages) {
@@ -122,35 +243,34 @@ async function reconcileNotificationMessages(
               WHERE message_id = ?`,
           ).bind(message.messageId).all<{ venue_id: string }>()
         ).results;
-        const statements: D1PreparedStatement[] = [
-          env.DB.prepare(
-            `UPDATE notification_outbox
-                SET status = 'delivered', provider_status = ?,
-                    provider_delivered_at = ?, provider_checked_at = ?,
-                    provider_error = NULL, sent_at = ?
-              WHERE message_id = ? AND status = 'submitted'`,
-          ).bind(
-            normalized.providerStatus,
-            deliveredAt,
-            checkedAt,
-            deliveredAt,
-            message.messageId,
-          ),
-        ];
-        for (const venue of venues) {
-          statements.push(
-            env.DB.prepare(
-              `UPDATE venue_status
-                  SET last_notification_at = ?, updated_at = ?
-                WHERE venue_id = ?`,
-            ).bind(deliveredAt, deliveredAt, venue.venue_id),
-          );
+        const update = await env.DB.prepare(
+          `UPDATE notification_outbox
+              SET status = 'delivered', provider_status = ?,
+                  provider_delivered_at = ?, provider_checked_at = ?,
+                  provider_error = NULL, sent_at = ?
+            WHERE message_id = ? AND status = 'submitted'`,
+        ).bind(
+          normalized.providerStatus,
+          deliveredAt,
+          checkedAt,
+          deliveredAt,
+          message.messageId,
+        ).run();
+        if (Number(update.meta.changes || 0) > 0) {
+          if (venues.length) {
+            await env.DB.batch(venues.map((venue) =>
+              env.DB.prepare(
+                `UPDATE venue_status
+                    SET last_notification_at = ?, updated_at = ?
+                  WHERE venue_id = ?`,
+              ).bind(deliveredAt, deliveredAt, venue.venue_id)
+            ));
+          }
+          summary.delivered += 1;
         }
-        await env.DB.batch(statements);
-        summary.delivered += 1;
       } else if (normalized.state === "failed") {
         const failedAt = new Date().toISOString();
-        await env.DB.prepare(
+        const update = await env.DB.prepare(
           `UPDATE notification_outbox
               SET status = 'failed', provider_status = ?,
                   provider_failed_at = ?, provider_checked_at = ?,
@@ -164,14 +284,14 @@ async function reconcileNotificationMessages(
           normalized.error,
           message.messageId,
         ).run();
-        summary.failed += 1;
+        if (Number(update.meta.changes || 0) > 0) summary.failed += 1;
       } else {
-        await env.DB.prepare(
+        const update = await env.DB.prepare(
           `UPDATE notification_outbox
               SET provider_status = ?, provider_checked_at = ?, provider_error = NULL
             WHERE message_id = ? AND status = 'submitted'`,
         ).bind(normalized.providerStatus, checkedAt, message.messageId).run();
-        summary.pending += 1;
+        if (Number(update.meta.changes || 0) > 0) summary.pending += 1;
       }
     } catch (error) {
       const detail = providerCheckError(error);
@@ -192,34 +312,84 @@ async function reconcileNotificationMessages(
   return summary;
 }
 
-async function claimSystemEmails(
+async function systemEmailCandidates(
   env: ReconcileEnv,
   limit: number,
+  cutoff: number,
 ): Promise<{
-  selected: number;
-  rows: Array<{ id: string; messageId: string; email: string }>;
+  items: SystemEmailCandidate[];
+  recentCount: number;
+  backlogCount: number;
 }> {
-  const now = Date.now();
-  const cutoff = now - REFRESH_MS;
-  const candidates = (
-    await env.DB.prepare(
-      `SELECT id, provider_message_id, email
+  const window = reconciliationWindow();
+  const [recentResult, backlogResult] = await Promise.all([
+    env.DB.prepare(
+      `SELECT id, provider_message_id, email, submitted_at
          FROM system_email_outbox
         WHERE status = 'submitted'
           AND provider_message_id IS NOT NULL
           AND provider_message_id NOT LIKE 'worker:%'
+          AND submitted_at >= ?
           AND (provider_checked_at IS NULL OR provider_checked_at < ?)
         ORDER BY submitted_at
         LIMIT ?`,
-    ).bind(cutoff, limit).all<{
+    ).bind(window.recentCutoff, cutoff, limit).all<{
       id: string;
       provider_message_id: string;
       email: string;
-    }>()
-  ).results;
+      submitted_at: string;
+    }>(),
+    env.DB.prepare(
+      `SELECT id, provider_message_id, email, submitted_at
+         FROM system_email_outbox
+        WHERE status = 'submitted'
+          AND provider_message_id IS NOT NULL
+          AND provider_message_id NOT LIKE 'worker:%'
+          AND submitted_at >= ?
+          AND submitted_at < ?
+          AND (provider_checked_at IS NULL OR provider_checked_at < ?)
+        ORDER BY submitted_at
+        LIMIT ?`,
+    ).bind(
+      window.retentionCutoff,
+      window.recentCutoff,
+      cutoff,
+      limit,
+    ).all<{
+      id: string;
+      provider_message_id: string;
+      email: string;
+      submitted_at: string;
+    }>(),
+  ]);
+  const recent = recentResult.results.map((row) => ({
+    id: row.id,
+    messageId: row.provider_message_id,
+    email: row.email,
+    submittedAt: row.submitted_at,
+  }));
+  const backlog = backlogResult.results.map((row) => ({
+    id: row.id,
+    messageId: row.provider_message_id,
+    email: row.email,
+    submittedAt: row.submitted_at,
+  }));
+  return selectReconciliationCandidates(recent, backlog, limit);
+}
 
-  const rows: Array<{ id: string; messageId: string; email: string }> = [];
-  for (const candidate of candidates) {
+async function claimSystemEmails(
+  env: ReconcileEnv,
+  limit: number,
+): Promise<{
+  selectedRecent: number;
+  selectedBacklog: number;
+  rows: SystemEmailCandidate[];
+}> {
+  const now = Date.now();
+  const cutoff = now - REFRESH_MS;
+  const candidates = await systemEmailCandidates(env, limit, cutoff);
+  const rows: SystemEmailCandidate[] = [];
+  for (const candidate of candidates.items) {
     const result = await env.DB.prepare(
       `UPDATE system_email_outbox
           SET provider_checked_at = ?, updated_at = ?
@@ -227,15 +397,13 @@ async function claimSystemEmails(
           AND status = 'submitted'
           AND (provider_checked_at IS NULL OR provider_checked_at < ?)`,
     ).bind(now, new Date(now).toISOString(), candidate.id, cutoff).run();
-    if (Number(result.meta.changes || 0) > 0) {
-      rows.push({
-        id: candidate.id,
-        messageId: candidate.provider_message_id,
-        email: candidate.email,
-      });
-    }
+    if (Number(result.meta.changes || 0) > 0) rows.push(candidate);
   }
-  return { selected: candidates.length, rows };
+  return {
+    selectedRecent: candidates.recentCount,
+    selectedBacklog: candidates.backlogCount,
+    rows,
+  };
 }
 
 async function reconcileSystemEmails(
@@ -243,7 +411,10 @@ async function reconcileSystemEmails(
   limit: number,
 ): Promise<QueueReconcileSummary> {
   const claimed = await claimSystemEmails(env, limit);
-  const summary = emptySummary(claimed.selected);
+  const summary = emptySummary();
+  summary.selectedRecent = claimed.selectedRecent;
+  summary.selectedBacklog = claimed.selectedBacklog;
+  summary.selected = claimed.selectedRecent + claimed.selectedBacklog;
   summary.claimed = claimed.rows.length;
 
   for (const row of claimed.rows) {
@@ -254,7 +425,7 @@ async function reconcileSystemEmails(
       const nowIso = new Date(checkedAt).toISOString();
       summary.checked += 1;
       if (normalized.state === "delivered") {
-        await env.DB.prepare(
+        const update = await env.DB.prepare(
           `UPDATE system_email_outbox
               SET status = 'delivered', provider_status = ?, delivered_at = ?,
                   provider_checked_at = ?, last_error = NULL, updated_at = ?
@@ -266,9 +437,9 @@ async function reconcileSystemEmails(
           nowIso,
           row.id,
         ).run();
-        summary.delivered += 1;
+        if (Number(update.meta.changes || 0) > 0) summary.delivered += 1;
       } else if (normalized.state === "failed") {
-        await env.DB.prepare(
+        const update = await env.DB.prepare(
           `UPDATE system_email_outbox
               SET status = 'failed', provider_status = ?, failed_at = ?,
                   provider_checked_at = ?, last_error = ?, updated_at = ?
@@ -281,15 +452,15 @@ async function reconcileSystemEmails(
           nowIso,
           row.id,
         ).run();
-        summary.failed += 1;
+        if (Number(update.meta.changes || 0) > 0) summary.failed += 1;
       } else {
-        await env.DB.prepare(
+        const update = await env.DB.prepare(
           `UPDATE system_email_outbox
               SET provider_status = ?, provider_checked_at = ?,
                   last_error = NULL, updated_at = ?
             WHERE id = ? AND status = 'submitted'`,
         ).bind(normalized.providerStatus, checkedAt, nowIso, row.id).run();
-        summary.pending += 1;
+        if (Number(update.meta.changes || 0) > 0) summary.pending += 1;
       }
     } catch (error) {
       const detail = providerCheckError(error);

--- a/webapp/cloudflare/deployment-entry.test.ts
+++ b/webapp/cloudflare/deployment-entry.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { deploymentHealth } from "./deployment-entry";
+import {
+  applyGlobalSubmittedReminderMetric,
+  deploymentHealth,
+  shanghaiDayStartIso,
+} from "./deployment-entry";
 
 describe("deployment entry health", () => {
   it("reports only an exact deployed commit", () => {
@@ -11,5 +15,38 @@ describe("deployment entry health", () => {
       deploymentCommit: commit,
     });
     expect(deploymentHealth("main").deploymentCommit).toBe("unknown");
+  });
+});
+
+describe("aggregate reminder metric", () => {
+  it("uses the Shanghai calendar-day boundary", () => {
+    expect(shanghaiDayStartIso(new Date("2026-08-25T15:30:00.000Z")))
+      .toBe("2026-08-24T16:00:00.000Z");
+  });
+
+  it("replaces only the aggregate reminder count", () => {
+    expect(applyGlobalSubmittedReminderMetric({
+      metrics: {
+        activeSubscriptions: 18,
+        remindersToday: 0,
+        healthyVenues: 8,
+        totalVenues: 8,
+      },
+      identity: {
+        submittedToday: 24,
+        deliveredToday: 0,
+      },
+    }, 156)).toEqual({
+      metrics: {
+        activeSubscriptions: 18,
+        remindersToday: 156,
+        healthyVenues: 8,
+        totalVenues: 8,
+      },
+      identity: {
+        submittedToday: 24,
+        deliveredToday: 0,
+      },
+    });
   });
 });

--- a/webapp/cloudflare/deployment-entry.ts
+++ b/webapp/cloudflare/deployment-entry.ts
@@ -30,6 +30,38 @@ export function deploymentHealth(deploymentCommit?: string) {
   };
 }
 
+export function shanghaiDayStartIso(now = new Date()): string {
+  const shifted = new Date(now.getTime() + 8 * 3_600_000);
+  return new Date(
+    Date.UTC(
+      shifted.getUTCFullYear(),
+      shifted.getUTCMonth(),
+      shifted.getUTCDate(),
+    ) - 8 * 3_600_000,
+  ).toISOString();
+}
+
+export function applyGlobalSubmittedReminderMetric(
+  payload: unknown,
+  submittedToday: number,
+): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return payload;
+  const root = payload as Record<string, unknown>;
+  if (!root.metrics || typeof root.metrics !== "object" || Array.isArray(root.metrics)) {
+    return payload;
+  }
+  const count = Number.isFinite(submittedToday)
+    ? Math.max(0, Math.trunc(submittedToday))
+    : 0;
+  return {
+    ...root,
+    metrics: {
+      ...(root.metrics as Record<string, unknown>),
+      remindersToday: count,
+    },
+  };
+}
+
 function withInviteSecrets(env: DeploymentEnv) {
   return {
     ...env,
@@ -85,6 +117,42 @@ async function reconcileSafely(
   }
 }
 
+async function rewriteBootstrapReminderMetric(
+  response: Response,
+  env: DeploymentEnv,
+): Promise<Response> {
+  try {
+    const [payload, row] = await Promise.all([
+      response.clone().json<unknown>(),
+      env.DB.prepare(
+        `SELECT COUNT(DISTINCT message_id) AS count
+           FROM notification_outbox
+          WHERE provider_submitted_at >= ?`,
+      ).bind(shanghaiDayStartIso()).first<{ count?: number }>(),
+    ]);
+    const corrected = applyGlobalSubmittedReminderMetric(
+      payload,
+      Number(row?.count || 0),
+    );
+    const headers = new Headers(response.headers);
+    headers.delete("Content-Length");
+    headers.delete("Content-Encoding");
+    headers.set("Cache-Control", "no-store");
+    headers.set("Content-Type", "application/json; charset=utf-8");
+    return new Response(JSON.stringify(corrected), {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  } catch (error) {
+    console.warn(JSON.stringify({
+      event: "bootstrap_reminder_metric_correction_failed",
+      reason: error instanceof Error ? error.message.slice(0, 160) : "unknown",
+    }));
+    return response;
+  }
+}
+
 export default {
   async fetch(
     request: Request,
@@ -133,6 +201,12 @@ export default {
     }
 
     const response = await worker.fetch(request, withInviteSecrets(env) as never, context);
+    if (response.ok && request.method === "GET" && url.pathname === "/api/bootstrap") {
+      // The home metric is aggregate, like active subscriptions and venue health.
+      // Count provider-accepted reminder digests for the Shanghai calendar day;
+      // provider-confirmed delivery remains available in the signed-in quota card.
+      return rewriteBootstrapReminderMetric(response, env);
+    }
     if (
       response.ok
       && request.method === "POST"


### PR DESCRIPTION
## Production evidence

A fresh protected production diagnosis at 23:31 Shanghai time showed two contradictory views:

- the reconciliation endpoint reported 196 provider records checked and delivered;
- immediately afterward, every one of today's 156 submitted reminder messages still had `provider_checked_at = NULL`, and the public dashboard still showed `今日提醒 0`.

The venue delivery watermark advanced only into early August. This proves the reconciler was spending all capacity on the oldest historical backlog and starving current-day messages.

## Root causes

1. Delivery reconciliation ordered the entire historical `submitted` queue oldest-first with a fixed batch limit. A backlog larger than one batch prevented today's messages from ever being queried.
2. The aggregate home metric labeled `今日提醒` counted provider-confirmed deliveries, while the signed-in quota card and reminder animation counted provider-accepted submissions. This produced a misleading global zero even when the service had submitted many reminders.

## Fix

- Split reconciliation into a recent lane (last 48 hours) and a queryable backlog lane (2–30 days).
- Reserve 80% of each normal batch for recent messages and 20% for backlog, filling unused capacity from the other lane.
- Exclude messages older than Tencent's 30-day status-query window from repeated provider calls.
- Apply the same scheduling policy to reminder and system-email queues.
- Count reconciliation results only when the corresponding D1 lifecycle update actually changed rows.
- Define the aggregate `今日提醒` metric as distinct provider-accepted reminder digests for the current Shanghai calendar day.
- Preserve the signed-in user's detailed `已提交 / 确认送达 / 发送失败` metrics.
- Add diagnostics for recent, queryable-backlog, and retention-expired pending messages.
- Add unit coverage for Shanghai day boundaries and recent/backlog capacity allocation.

## Safety

- No email or WeChat message is sent by this change.
- Provider-confirmed delivery remains strict and is not inferred from submission.
- Historical backlog continues to progress without blocking current-day accuracy.