### PR TITLE
fix(web): keep venue polling while reducing Cloudflare D1 and CPU usage

### DIFF
--- a/docs/incidents/cloudflare-free-tier-2026-08-27.md
+++ b/docs/incidents/cloudflare-free-tier-2026-08-27.md
@@ -26,8 +26,10 @@ latency contract and remain unchanged.
 - The other active venue watchers remain every 30 seconds unless their existing
   repository contract already specifies another value.
 - Every real slot, venue-health, or error change is forwarded immediately.
-- An unchanged venue scope still forwards a heartbeat every five minutes, below
-  the Web application's ten-minute freshness threshold.
+- An unchanged venue/task scope still forwards a heartbeat every five minutes,
+  below the Web application's ten-minute freshness threshold.
+- Availability that disappears and then reappears is forwarded on the first
+  matching poll.
 - Subscriber email remains Web-owned and continues to drain after a forwarded
   observation.
 - No production database records are deleted by this repair.
@@ -37,11 +39,18 @@ latency contract and remain unchanged.
 ### Observation ingest
 
 `observation_ingest_state` stores one indexed fingerprint and last-forwarded
-time for each venue/date scope. `checked_at` is deliberately excluded from the
-fingerprint; venue health, error state, and normalized slot identity remain in
-it. A changed fingerprint bypasses the throttle immediately. An unchanged
-fingerprint receives a successful deduplicated response until the five-minute
-heartbeat expires.
+time for each venue/Airflow-task scope. The shared publisher obtains the current
+Airflow task ID without changing any watcher schedule or watcher call site.
+`checked_at` is deliberately excluded from the fingerprint; venue health, error
+state, and normalized slot identity remain in it. A changed fingerprint bypasses
+the throttle immediately. An unchanged fingerprint receives a successful
+deduplicated response until the five-minute heartbeat expires.
+
+A stable task scope is required for correctness. It prevents parallel day tasks
+from overwriting one another and ensures an available → empty → available state
+transition is never hidden by a recent fingerprint from a different task.
+Older Airflow publishers without the new field are accepted through a fail-open
+compatibility scope until the matching Airflow commit is deployed.
 
 This keeps all Airflow API polling intact while replacing repeated full
 subscription scans, slot upserts, outbox dedupe writes, and outbox drains with a
@@ -58,10 +67,11 @@ the same bounded batch.
 ### Dashboard
 
 Bootstrap responses are cached in the Cloudflare Cache API for at most 120
-seconds under a synthetic key derived from the verification receipt and the
-existing pepper. Receipt tokens never appear in the cache URL. Browser responses
-remain `no-store`, and subscription mutations invalidate both the caller's
-private cache entry and the anonymous aggregate entry.
+seconds under a private URL on the Worker custom-domain origin. The path contains
+only a one-way digest derived from the verification receipt and the existing
+pepper; receipt tokens never appear in the cache URL. Browser responses remain
+`no-store`, and subscription mutations invalidate both the caller's private
+cache entry and the anonymous aggregate entry.
 
 The global submitted-reminder metric now counts one `sent`
 `email_delivery_claims` row per digest for the Shanghai delivery day, backed by
@@ -71,14 +81,18 @@ deduplicating notification rows.
 ## Acceptance
 
 Before any production apply, the exact branch commit must pass `CI / verify` and
-Web deployment preflight. After an approved exact-commit deploy, observe at least
-three natural venue cycles and a full 24-hour Cloudflare window.
+protected release preflight. The Worker migration and the Airflow shared
+publisher must ship from the same exact commit. After an approved exact-commit
+deploy, observe at least three natural venue cycles and a full 24-hour Cloudflare
+window.
 
 Target outcomes:
 
 - no change to any active venue DAG schedule;
 - changed availability appears in the Web notification pipeline on the first
   matching poll;
+- an available → empty → available transition is visible without waiting for the
+  five-minute heartbeat;
 - venue health never becomes stale because of deduplication;
 - delivery-status confirmation normally updates within ten minutes;
 - Workers `exceededCpu` remains zero during the observation window;
@@ -93,6 +107,6 @@ Do not reduce Airflow venue polling frequency as a fallback.
 
 ## Rollback
 
-Rollback is the previous exact Worker commit. The new D1 table and index are
-additive and can remain unused after a Worker rollback; no destructive reverse
-migration is required.
+Rollback is the previous exact Worker and Airflow commit. The new D1 table and
+index are additive and can remain unused after a rollback; no destructive
+reverse migration is required.

--- a/docs/incidents/cloudflare-free-tier-2026-08-27.md
+++ b/docs/incidents/cloudflare-free-tier-2026-08-27.md
@@ -1,0 +1,98 @@
+# Cloudflare Free-Tier Remediation — 2026-08-27
+
+## Incident
+
+The production account reported repeated Workers CPU-limit events and recurring
+D1 free-tier overage. The affected runtime is the single Cloudflare Worker that
+owns the public Web application, subscription matching, D1 notification outbox,
+and Tencent SES delivery lifecycle.
+
+The investigation found three independent amplifiers:
+
+1. every Airflow venue poll performed a full D1 ingest even when the normalized
+   availability payload had not changed;
+2. every successful observation synchronously launched delivery reconciliation,
+   while the one-minute cron also ran both the new and legacy reconcilers;
+3. the front-end refresh loop repeatedly executed personalized bootstrap queries
+   and identity activity writes, and the aggregate submitted metric scanned the
+   notification outbox by provider timestamp.
+
+The venue polling schedules are not the problem to solve. They are a product
+latency contract and remain unchanged.
+
+## Invariants
+
+- Shenzhen Bay remains every 15 seconds.
+- The other active venue watchers remain every 30 seconds unless their existing
+  repository contract already specifies another value.
+- Every real slot, venue-health, or error change is forwarded immediately.
+- An unchanged venue scope still forwards a heartbeat every five minutes, below
+  the Web application's ten-minute freshness threshold.
+- Subscriber email remains Web-owned and continues to drain after a forwarded
+  observation.
+- No production database records are deleted by this repair.
+
+## Repair
+
+### Observation ingest
+
+`observation_ingest_state` stores one indexed fingerprint and last-forwarded
+time for each venue/date scope. `checked_at` is deliberately excluded from the
+fingerprint; venue health, error state, and normalized slot identity remain in
+it. A changed fingerprint bypasses the throttle immediately. An unchanged
+fingerprint receives a successful deduplicated response until the five-minute
+heartbeat expires.
+
+This keeps all Airflow API polling intact while replacing repeated full
+subscription scans, slot upserts, outbox dedupe writes, and outbox drains with a
+single primary-key D1 lookup.
+
+### Delivery lifecycle
+
+The synchronous reconciliation attached to every observation is removed. The
+recent-first reconciler runs every five minutes with a batch of five per queue.
+Legacy housekeeping runs separately at minute 17 of each hour, so it no longer
+overlaps the five-minute path. The protected manual reconciliation endpoint uses
+the same bounded batch.
+
+### Dashboard
+
+Bootstrap responses are cached in the Cloudflare Cache API for at most 120
+seconds under a synthetic key derived from the verification receipt and the
+existing pepper. Receipt tokens never appear in the cache URL. Browser responses
+remain `no-store`, and subscription mutations invalidate both the caller's
+private cache entry and the anonymous aggregate entry.
+
+The global submitted-reminder metric now counts one `sent`
+`email_delivery_claims` row per digest for the Shanghai delivery day, backed by
+`email_delivery_claims_day_status_idx`, instead of repeatedly scanning and
+deduplicating notification rows.
+
+## Acceptance
+
+Before any production apply, the exact branch commit must pass `CI / verify` and
+Web deployment preflight. After an approved exact-commit deploy, observe at least
+three natural venue cycles and a full 24-hour Cloudflare window.
+
+Target outcomes:
+
+- no change to any active venue DAG schedule;
+- changed availability appears in the Web notification pipeline on the first
+  matching poll;
+- venue health never becomes stale because of deduplication;
+- delivery-status confirmation normally updates within ten minutes;
+- Workers `exceededCpu` remains zero during the observation window;
+- D1 rows read remain below 2,000,000 per day;
+- D1 rows written remain below 30,000 per day;
+- no real verification, venue email, or WeChat probe is sent without separate
+  approval.
+
+If the usage targets are not met, use D1 query metrics and Worker invocation
+status to identify the remaining query before considering a paid-plan upgrade.
+Do not reduce Airflow venue polling frequency as a fallback.
+
+## Rollback
+
+Rollback is the previous exact Worker commit. The new D1 table and index are
+additive and can remain unused after a Worker rollback; no destructive reverse
+migration is required.

--- a/docs/incidents/cloudflare-free-tier-2026-08-27.md
+++ b/docs/incidents/cloudflare-free-tier-2026-08-27.md
@@ -22,9 +22,10 @@ latency contract and remain unchanged.
 
 ## Invariants
 
-- Shenzhen Bay remains every 15 seconds.
-- The other active venue watchers remain every 30 seconds unless their existing
-  repository contract already specifies another value.
+- Shenzhen Bay remains every 15 seconds with four parallel day tasks.
+- Greater Bay Area remains every 30 seconds with three parallel day tasks.
+- The five existing single-task 30-second venue watchers remain every 30 seconds.
+- Shenzhen Sports Center remains every minute.
 - Every real slot, venue-health, or error change is forwarded immediately.
 - An unchanged venue/task scope still forwards a heartbeat every five minutes,
   below the Web application's ten-minute freshness threshold.
@@ -33,6 +34,29 @@ latency contract and remain unchanged.
 - Subscriber email remains Web-owned and continues to drain after a forwarded
   observation.
 - No production database records are deleted by this repair.
+
+## Request budget
+
+At the configured schedules, the theoretical maximum observation publication
+rate is 47,520 Worker requests per day before task runtime and scheduler overlap
+reduce it:
+
+- Shenzhen Bay: `4 × 86,400 / 15 = 23,040`;
+- Greater Bay Area: `3 × 86,400 / 30 = 8,640`;
+- five single-task 30-second watchers: `5 × 86,400 / 30 = 14,400`;
+- Shenzhen Sports Center: `86,400 / 60 = 1,440`.
+
+This intentionally preserves the product polling contract and leaves 52,480
+requests of the Workers Free 100,000-request daily allowance for the UI, cron,
+and other API traffic. A continuously open browser identity previously issued
+up to 2,880 bootstrap requests per day. The client now coalesces that to at most
+720 network requests per day, reuses cached data while the document is hidden,
+and invalidates immediately after subscription or priority-tier changes.
+
+The Worker Cache API and client cache reduce D1/CPU work and UI request volume;
+they do not change the Airflow polling schedules. Production request metrics
+must still be monitored because many simultaneously open browser identities can
+consume the remaining Workers request allowance even when D1 is healthy.
 
 ## Repair
 
@@ -73,6 +97,13 @@ pepper; receipt tokens never appear in the cache URL. Browser responses remain
 `no-store`, and subscription mutations invalidate both the caller's private
 cache entry and the anonymous aggregate entry.
 
+The browser client also coalesces bootstrap requests for the same identity for
+120 seconds. It retains the existing UI refresh loop, serves the in-memory value
+without a network call during the cache window, reuses the last value while the
+page is hidden, and invalidates immediately after any dashboard-changing user
+action. Dashboard counters can therefore be up to two minutes old; venue polling
+and notification generation remain real-time at their original schedules.
+
 The global submitted-reminder metric now counts one `sent`
 `email_delivery_claims` row per digest for the Shanghai delivery day, backed by
 `email_delivery_claims_day_status_idx`, instead of repeatedly scanning and
@@ -96,6 +127,8 @@ Target outcomes:
 - venue health never becomes stale because of deduplication;
 - delivery-status confirmation normally updates within ten minutes;
 - Workers `exceededCpu` remains zero during the observation window;
+- total Worker requests remain below 80,000 per day as an operational warning
+  threshold, leaving margin below the Free hard limit;
 - D1 rows read remain below 2,000,000 per day;
 - D1 rows written remain below 30,000 per day;
 - no real verification, venue email, or WeChat probe is sent without separate

--- a/docs/runbooks/webapp-deployment.md
+++ b/docs/runbooks/webapp-deployment.md
@@ -15,6 +15,12 @@ five minutes so the ten-minute venue-health freshness contract remains
 satisfied. Older publishers without an explicit scope fail open to a shared
 compatibility scope until the matching Airflow commit is deployed.
 
+The configured venue schedules produce at most 47,520 observation requests per
+day before task runtime and scheduler overlap reduce the actual count. This is a
+request-budget constraint, not a reason to slow venue polling. Alert at 80,000
+total Worker requests per day so the production account retains margin below the
+Workers Free daily hard limit.
+
 The Worker cron paths are intentionally separated:
 
 - `*/5 * * * *` runs the recent-first delivery-status reconciler with a batch of
@@ -28,6 +34,12 @@ for at most 120 seconds. The receipt never appears in the cache URL. Browser
 responses remain `Cache-Control: no-store`; the edge cache exists only to avoid
 repeating the same personalized D1 dashboard queries and identity writes during
 the UI's refresh loop.
+
+The browser client independently coalesces bootstrap network requests for the
+same identity for 120 seconds and reuses the last value while the page is hidden.
+Subscription create/cancel and priority redemption invalidate both client and
+edge caches. Dashboard counters can be up to two minutes old; venue polling and
+notification generation are unaffected.
 
 ## Local Verification
 
@@ -88,13 +100,18 @@ D1 migration commands are intentionally unsupported.
 - `/api/healthz` returns `ok: true` and the exact release commit.
 - `/api/bootstrap` returns eight venues and no email addresses.
 - An unauthenticated observation write returns HTTP 401.
-- Natural venue DAG runs keep their existing 15-second or 30-second schedules.
+- Natural venue DAG runs keep their existing 15-second, 30-second, and one-minute
+  schedules.
 - A changed slot set reaches D1 immediately; an unchanged set produces at most
   one full ingest per venue/task observation scope every five minutes.
 - A slot set that disappears and then reappears is forwarded on the first
   matching poll rather than suppressed by the heartbeat throttle.
+- A continuously open visible browser identity makes no more than 720 bootstrap
+  network requests per 24 hours; a hidden page stops periodic network refreshes
+  after it has a cached dashboard.
 - Browser layout and the create-subscription flow pass mobile visual checks.
 - Cloudflare Worker `exceededCpu` stays at zero during the observation window.
+- Total Worker requests stay below the 80,000/day operational warning threshold.
 - D1 daily rows read and written remain below the configured free-tier safety
   thresholds documented in the incident record.
 - A controlled verification email can be sent only when explicitly authorized.

--- a/docs/runbooks/webapp-deployment.md
+++ b/docs/runbooks/webapp-deployment.md
@@ -7,11 +7,13 @@ API routes, a D1 binding, and two bounded cron paths. Its custom domain is
 `zacks.claude89757.cc`.
 
 Venue DAG polling frequency is an Airflow contract and must not be reduced to
-control Cloudflare usage. The Worker instead suppresses identical observation
-payloads after an indexed D1 fingerprint lookup, while forwarding every real
-availability or health change immediately. An unchanged observation is still
-forwarded at least every five minutes so the ten-minute venue-health freshness
-contract remains satisfied.
+control Cloudflare usage. Each Airflow task publishes a stable observation
+scope. The Worker suppresses an identical payload after an indexed D1
+fingerprint lookup, while forwarding every real availability, health, or error
+change immediately. An unchanged observation is still forwarded at least every
+five minutes so the ten-minute venue-health freshness contract remains
+satisfied. Older publishers without an explicit scope fail open to a shared
+compatibility scope until the matching Airflow commit is deployed.
 
 The Worker cron paths are intentionally separated:
 
@@ -20,10 +22,12 @@ The Worker cron paths are intentionally separated:
 - `17 * * * *` runs legacy housekeeping, expiry reminders, outbox maintenance,
   and cleanup once per hour without overlapping the five-minute cron.
 
-`/api/bootstrap` responses use a private synthetic Cloudflare Cache API key,
-separated by verification receipt, for at most 120 seconds. Browser responses
-remain `Cache-Control: no-store`; the cache exists only to avoid repeating the
-same personalized D1 dashboard queries during the UI's refresh loop.
+`/api/bootstrap` responses use a private Cloudflare Cache API key on the Worker
+custom-domain origin, separated by a one-way digest of the verification receipt,
+for at most 120 seconds. The receipt never appears in the cache URL. Browser
+responses remain `Cache-Control: no-store`; the edge cache exists only to avoid
+repeating the same personalized D1 dashboard queries and identity writes during
+the UI's refresh loop.
 
 ## Local Verification
 
@@ -69,6 +73,10 @@ must never be downloaded to a workstation.
    read-only production probes before Airflow deployment begins.
 5. Observe natural Airflow publication cycles and record the GitHub run.
 
+The Worker and Airflow publisher changes in this repair must ship from the same
+exact commit. The short Web-before-Airflow interval is safe: an older publisher
+without `observation_scope` is accepted and forwarded rather than rejected.
+
 For isolated diagnosis, `production-webapp.yml` supports `health`,
 `deploy_preflight`, and `deploy_apply`. `make webapp-deploy` and
 `make webapp-health` only dispatch those GitHub operations; they do not use
@@ -82,7 +90,9 @@ D1 migration commands are intentionally unsupported.
 - An unauthenticated observation write returns HTTP 401.
 - Natural venue DAG runs keep their existing 15-second or 30-second schedules.
 - A changed slot set reaches D1 immediately; an unchanged set produces at most
-  one full ingest per observation scope every five minutes.
+  one full ingest per venue/task observation scope every five minutes.
+- A slot set that disappears and then reappears is forwarded on the first
+  matching poll rather than suppressed by the heartbeat throttle.
 - Browser layout and the create-subscription flow pass mobile visual checks.
 - Cloudflare Worker `exceededCpu` stays at zero during the observation window.
 - D1 daily rows read and written remain below the configured free-tier safety

--- a/docs/runbooks/webapp-deployment.md
+++ b/docs/runbooks/webapp-deployment.md
@@ -3,8 +3,27 @@
 ## Scope
 
 The production application is a single Cloudflare Worker with static assets,
-API routes, a D1 binding, and a one-minute outbox cron. Its custom domain is
+API routes, a D1 binding, and two bounded cron paths. Its custom domain is
 `zacks.claude89757.cc`.
+
+Venue DAG polling frequency is an Airflow contract and must not be reduced to
+control Cloudflare usage. The Worker instead suppresses identical observation
+payloads after an indexed D1 fingerprint lookup, while forwarding every real
+availability or health change immediately. An unchanged observation is still
+forwarded at least every five minutes so the ten-minute venue-health freshness
+contract remains satisfied.
+
+The Worker cron paths are intentionally separated:
+
+- `*/5 * * * *` runs the recent-first delivery-status reconciler with a batch of
+  five per queue;
+- `17 * * * *` runs legacy housekeeping, expiry reminders, outbox maintenance,
+  and cleanup once per hour without overlapping the five-minute cron.
+
+`/api/bootstrap` responses use a private synthetic Cloudflare Cache API key,
+separated by verification receipt, for at most 120 seconds. Browser responses
+remain `Cache-Control: no-store`; the cache exists only to avoid repeating the
+same personalized D1 dashboard queries during the UI's refresh loop.
 
 ## Local Verification
 
@@ -58,12 +77,16 @@ D1 migration commands are intentionally unsupported.
 
 ## Verify
 
-- `/api/healthz` returns `ok: true`.
-- `/api/healthz` reports the exact release commit.
+- `/api/healthz` returns `ok: true` and the exact release commit.
 - `/api/bootstrap` returns eight venues and no email addresses.
 - An unauthenticated observation write returns HTTP 401.
-- Natural venue DAG runs publish fresh inspection timestamps.
+- Natural venue DAG runs keep their existing 15-second or 30-second schedules.
+- A changed slot set reaches D1 immediately; an unchanged set produces at most
+  one full ingest per observation scope every five minutes.
 - Browser layout and the create-subscription flow pass mobile visual checks.
+- Cloudflare Worker `exceededCpu` stays at zero during the observation window.
+- D1 daily rows read and written remain below the configured free-tier safety
+  thresholds documented in the incident record.
 - A controlled verification email can be sent only when explicitly authorized.
 
 Do not create a fake subscription or inject a production slot during routine

--- a/src/wechat_airflow/notifications/webapp.py
+++ b/src/wechat_airflow/notifications/webapp.py
@@ -110,9 +110,10 @@ def publish_venue_observation(
             }
         )
 
-    normalized_scope = str(
-        observation_scope or _current_observation_scope() or "default"
-    ).strip()[:120] or "default"
+    normalized_scope = (
+        str(observation_scope or _current_observation_scope() or "default").strip()[:120]
+        or "default"
+    )
     payload = {
         "venue_id": venue_id,
         "venue_name": venue_name,

--- a/src/wechat_airflow/notifications/webapp.py
+++ b/src/wechat_airflow/notifications/webapp.py
@@ -18,6 +18,28 @@ def _get_variable(key: str, default: Any = None) -> Any:
     return Variable.get(key, default=default)
 
 
+def _current_observation_scope() -> str | None:
+    """Return a stable Airflow task scope without coupling callers to task IDs."""
+    try:
+        from airflow.sdk import get_current_context
+
+        context = get_current_context()
+    except Exception:
+        return None
+
+    task_instance = context.get("task_instance") or context.get("ti")
+    task = context.get("task")
+    task_id = str(
+        getattr(task_instance, "task_id", "") or getattr(task, "task_id", "") or ""
+    ).strip()
+    if not task_id:
+        return None
+    map_index = getattr(task_instance, "map_index", -1)
+    if isinstance(map_index, int) and map_index >= 0:
+        return f"{task_id}:{map_index}"
+    return task_id
+
+
 def flatten_court_slots(
     booking_date: str,
     court_data: Mapping[str, Iterable[Iterable[object]]],
@@ -57,6 +79,7 @@ def publish_venue_observation(
     healthy: bool,
     error: str | None = None,
     checked_at: datetime | None = None,
+    observation_scope: str | None = None,
 ) -> dict[str, Any]:
     """Publish venue state without failing the calling DAG."""
     api_url = str(_get_variable(WEBAPP_OBSERVATION_API_URL_VAR, default="")).strip()
@@ -87,9 +110,13 @@ def publish_venue_observation(
             }
         )
 
+    normalized_scope = str(
+        observation_scope or _current_observation_scope() or "default"
+    ).strip()[:120] or "default"
     payload = {
         "venue_id": venue_id,
         "venue_name": venue_name,
+        "observation_scope": normalized_scope,
         "healthy": bool(healthy),
         "checked_at": (checked_at or datetime.now(UTC)).isoformat(),
         "error": str(error or "")[:300] or None,
@@ -109,13 +136,18 @@ def publish_venue_observation(
         response.raise_for_status()
         print(
             f"[WEBAPP] observation published venue={venue_id}, "
-            f"healthy={healthy}, slots={slot_count}"
+            f"scope={normalized_scope}, healthy={healthy}, slots={slot_count}"
         )
-        return {"success": True, "slot_count": slot_count}
+        return {
+            "success": True,
+            "slot_count": slot_count,
+            "observation_scope": normalized_scope,
+        }
     except Exception as exc:
         print(f"[WEBAPP] observation publishing failed venue={venue_id}, error={str(exc)[:300]}")
         return {
             "success": False,
             "error": str(exc)[:300],
             "slot_count": slot_count,
+            "observation_scope": normalized_scope,
         }

--- a/tests/webapp_cloudflare_quota_migration_test.py
+++ b/tests/webapp_cloudflare_quota_migration_test.py
@@ -37,15 +37,11 @@ class WebappCloudflareQuotaMigrationTest(TestCase):
     def test_migration_creates_observation_state_and_delivery_day_index(self) -> None:
         tables = {
             row[0]
-            for row in self.database.execute(
-                "SELECT name FROM sqlite_master WHERE type = 'table'"
-            )
+            for row in self.database.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
         }
         indexes = {
             row[0]
-            for row in self.database.execute(
-                "SELECT name FROM sqlite_master WHERE type = 'index'"
-            )
+            for row in self.database.execute("SELECT name FROM sqlite_master WHERE type = 'index'")
         }
         self.assertIn("observation_ingest_state", tables)
         self.assertIn("email_delivery_claims_day_status_idx", indexes)
@@ -55,7 +51,7 @@ class WebappCloudflareQuotaMigrationTest(TestCase):
             """
             INSERT INTO observation_ingest_state
                 (observation_key, fingerprint, last_forwarded_at)
-            VALUES ('v1:szw:empty', 'old', 100)
+            VALUES ('v2:szw:check_and_notify_day_0', 'old', 100)
             ON CONFLICT(observation_key) DO UPDATE SET
                 fingerprint = excluded.fingerprint,
                 last_forwarded_at = excluded.last_forwarded_at
@@ -65,7 +61,7 @@ class WebappCloudflareQuotaMigrationTest(TestCase):
             """
             INSERT INTO observation_ingest_state
                 (observation_key, fingerprint, last_forwarded_at)
-            VALUES ('v1:szw:empty', 'new', 200)
+            VALUES ('v2:szw:check_and_notify_day_0', 'new', 200)
             ON CONFLICT(observation_key) DO UPDATE SET
                 fingerprint = excluded.fingerprint,
                 last_forwarded_at = excluded.last_forwarded_at
@@ -76,7 +72,7 @@ class WebappCloudflareQuotaMigrationTest(TestCase):
                 """
                 SELECT fingerprint, last_forwarded_at
                   FROM observation_ingest_state
-                 WHERE observation_key = 'v1:szw:empty'
+                 WHERE observation_key = 'v2:szw:check_and_notify_day_0'
                 """
             ).fetchone(),
             ("new", 200),

--- a/tests/webapp_cloudflare_quota_migration_test.py
+++ b/tests/webapp_cloudflare_quota_migration_test.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest import TestCase
+
+
+class WebappCloudflareQuotaMigrationTest(TestCase):
+    """Validate the D1 state used to suppress unchanged observations."""
+
+    def setUp(self) -> None:
+        self.database = sqlite3.connect(":memory:")
+        self.database.executescript(
+            """
+            CREATE TABLE email_delivery_claims (
+                id TEXT PRIMARY KEY,
+                email TEXT NOT NULL,
+                delivery_day TEXT NOT NULL,
+                status TEXT NOT NULL CHECK (status IN ('reserved', 'sent', 'released')),
+                message_id TEXT,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            );
+            """
+        )
+        migration = (
+            Path(__file__).parents[1]
+            / "webapp"
+            / "migrations"
+            / "0009_reduce_cloudflare_free_tier_usage.sql"
+        ).read_text(encoding="utf-8")
+        self.database.executescript(migration)
+
+    def tearDown(self) -> None:
+        self.database.close()
+
+    def test_migration_creates_observation_state_and_delivery_day_index(self) -> None:
+        tables = {
+            row[0]
+            for row in self.database.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        indexes = {
+            row[0]
+            for row in self.database.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index'"
+            )
+        }
+        self.assertIn("observation_ingest_state", tables)
+        self.assertIn("email_delivery_claims_day_status_idx", indexes)
+
+    def test_observation_state_upsert_replaces_only_the_latest_snapshot(self) -> None:
+        self.database.execute(
+            """
+            INSERT INTO observation_ingest_state
+                (observation_key, fingerprint, last_forwarded_at)
+            VALUES ('v1:szw:empty', 'old', 100)
+            ON CONFLICT(observation_key) DO UPDATE SET
+                fingerprint = excluded.fingerprint,
+                last_forwarded_at = excluded.last_forwarded_at
+            """
+        )
+        self.database.execute(
+            """
+            INSERT INTO observation_ingest_state
+                (observation_key, fingerprint, last_forwarded_at)
+            VALUES ('v1:szw:empty', 'new', 200)
+            ON CONFLICT(observation_key) DO UPDATE SET
+                fingerprint = excluded.fingerprint,
+                last_forwarded_at = excluded.last_forwarded_at
+            """
+        )
+        self.assertEqual(
+            self.database.execute(
+                """
+                SELECT fingerprint, last_forwarded_at
+                  FROM observation_ingest_state
+                 WHERE observation_key = 'v1:szw:empty'
+                """
+            ).fetchone(),
+            ("new", 200),
+        )

--- a/tests/webapp_notification_test.py
+++ b/tests/webapp_notification_test.py
@@ -114,9 +114,11 @@ class WebappNotificationTest(TestCase):
             ],
             healthy=True,
             checked_at=datetime(2026, 7, 29, 2, 0, tzinfo=UTC),
+            observation_scope="check_and_notify_day_0",
         )
 
         self.assertTrue(result["success"])
+        self.assertEqual(result["observation_scope"], "check_and_notify_day_0")
         request = post.call_args
         self.assertEqual(request.kwargs["timeout"], 3)
         self.assertEqual(
@@ -124,7 +126,46 @@ class WebappNotificationTest(TestCase):
             "Bearer secret-token",
         )
         self.assertEqual(request.kwargs["json"]["venue_id"], "szw")
+        self.assertEqual(
+            request.kwargs["json"]["observation_scope"],
+            "check_and_notify_day_0",
+        )
         self.assertEqual(len(request.kwargs["json"]["slots"]), 1)
+
+    @patch("wechat_airflow.notifications.webapp.requests.post")
+    @patch(
+        "wechat_airflow.notifications.webapp._current_observation_scope",
+        return_value="check_and_notify_day_2",
+    )
+    @patch("wechat_airflow.notifications.webapp._get_variable")
+    def test_uses_current_airflow_task_as_default_scope(
+        self,
+        get_variable,
+        _current_observation_scope,
+        post,
+    ):
+        values = {
+            webapp.WEBAPP_OBSERVATION_API_URL_VAR: "https://example.test/api/internal/observations",
+            webapp.WEBAPP_OBSERVATION_API_TOKEN_VAR: "secret-token",
+        }
+        get_variable.side_effect = lambda key, default=None: values.get(key, default)
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        post.return_value = response
+
+        result = webapp.publish_venue_observation(
+            "szw",
+            "深圳湾",
+            [],
+            healthy=True,
+        )
+
+        self.assertTrue(result["success"])
+        _current_observation_scope.assert_called_once_with()
+        self.assertEqual(
+            post.call_args.kwargs["json"]["observation_scope"],
+            "check_and_notify_day_2",
+        )
 
     @patch("wechat_airflow.notifications.webapp.requests.post")
     @patch("wechat_airflow.notifications.webapp._get_variable")

--- a/webapp/cloudflare/bootstrap-cache.test.ts
+++ b/webapp/cloudflare/bootstrap-cache.test.ts
@@ -5,21 +5,35 @@ import {
   bootstrapCacheRequest,
 } from "./bootstrap-cache";
 
+const requestUrl = "https://zacks.claude89757.cc/api/bootstrap?ignored=1";
+
 describe("bootstrap edge cache", () => {
   it("uses a short bounded freshness window", () => {
     expect(BOOTSTRAP_CACHE_TTL_SECONDS).toBe(120);
   });
 
   it("separates anonymous and verified dashboard payloads", async () => {
-    const anonymous = await bootstrapCacheRequest(null, "pepper");
-    const verified = await bootstrapCacheRequest("receipt-token", "pepper");
+    const anonymous = await bootstrapCacheRequest(requestUrl, null, "pepper");
+    const verified = await bootstrapCacheRequest(
+      requestUrl,
+      "receipt-token",
+      "pepper",
+    );
     expect(anonymous.url).not.toBe(verified.url);
   });
 
-  it("never exposes a receipt token in the synthetic cache URL", async () => {
+  it("never exposes a receipt token in the cache URL", async () => {
     const token = "secret-receipt-token";
-    const key = await bootstrapCacheRequest(token, "pepper");
+    const key = await bootstrapCacheRequest(requestUrl, token, "pepper");
     expect(key.url).not.toContain(token);
-    expect(key.url).toMatch(/^https:\/\/bootstrap-cache\.invalid\/v1\/[0-9a-f]{64}$/);
+    expect(key.url).toMatch(
+      /^https:\/\/zacks\.claude89757\.cc\/__zacks_edge_cache\/bootstrap\/[0-9a-f]{64}$/,
+    );
+  });
+
+  it("keeps the cache key inside the Worker custom-domain zone", async () => {
+    const key = await bootstrapCacheRequest(requestUrl, null, "pepper");
+    expect(new URL(key.url).origin).toBe("https://zacks.claude89757.cc");
+    expect(new URL(key.url).search).toBe("");
   });
 });

--- a/webapp/cloudflare/bootstrap-cache.test.ts
+++ b/webapp/cloudflare/bootstrap-cache.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BOOTSTRAP_CACHE_TTL_SECONDS,
+  bootstrapCacheRequest,
+} from "./bootstrap-cache";
+
+describe("bootstrap edge cache", () => {
+  it("uses a short bounded freshness window", () => {
+    expect(BOOTSTRAP_CACHE_TTL_SECONDS).toBe(120);
+  });
+
+  it("separates anonymous and verified dashboard payloads", async () => {
+    const anonymous = await bootstrapCacheRequest(null, "pepper");
+    const verified = await bootstrapCacheRequest("receipt-token", "pepper");
+    expect(anonymous.url).not.toBe(verified.url);
+  });
+
+  it("never exposes a receipt token in the synthetic cache URL", async () => {
+    const token = "secret-receipt-token";
+    const key = await bootstrapCacheRequest(token, "pepper");
+    expect(key.url).not.toContain(token);
+    expect(key.url).toMatch(/^https:\/\/bootstrap-cache\.invalid\/v1\/[0-9a-f]{64}$/);
+  });
+});

--- a/webapp/cloudflare/bootstrap-cache.ts
+++ b/webapp/cloudflare/bootstrap-cache.ts
@@ -1,0 +1,96 @@
+const BOOTSTRAP_CACHE_NAMESPACE = "https://bootstrap-cache.invalid/v1";
+
+export const BOOTSTRAP_CACHE_TTL_SECONDS = 120;
+
+type BootstrapCacheEnv = {
+  VERIFICATION_PEPPER: string;
+};
+
+function requestToken(request: Request): string | null {
+  const authorization = request.headers.get("authorization") || "";
+  return authorization.startsWith("Bearer ")
+    ? authorization.slice(7).trim() || null
+    : null;
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function bootstrapCacheRequest(
+  token: string | null,
+  pepper: string,
+): Promise<Request> {
+  const identity = token ? `receipt:${token}` : "anonymous";
+  const digest = await sha256Hex(`zacks-bootstrap:${pepper}:${identity}`);
+  return new Request(`${BOOTSTRAP_CACHE_NAMESPACE}/${digest}`, { method: "GET" });
+}
+
+function defaultCache(): Cache {
+  return (caches as unknown as { default: Cache }).default;
+}
+
+function clientResponse(response: Response, cacheStatus: "hit" | "miss"): Response {
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", "no-store");
+  headers.set("X-Zacks-Bootstrap-Cache", cacheStatus);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export async function matchBootstrapCache(
+  request: Request,
+  env: BootstrapCacheEnv,
+): Promise<Response | null> {
+  const cached = await defaultCache().match(
+    await bootstrapCacheRequest(requestToken(request), env.VERIFICATION_PEPPER),
+  );
+  return cached ? clientResponse(cached, "hit") : null;
+}
+
+export async function storeBootstrapCache(
+  request: Request,
+  env: BootstrapCacheEnv,
+  response: Response,
+): Promise<void> {
+  if (!response.ok) return;
+  const headers = new Headers(response.headers);
+  headers.delete("Set-Cookie");
+  headers.delete("Vary");
+  headers.set("Cache-Control", `public, max-age=${BOOTSTRAP_CACHE_TTL_SECONDS}`);
+  headers.set("X-Zacks-Bootstrap-Cache", "miss");
+  await defaultCache().put(
+    await bootstrapCacheRequest(requestToken(request), env.VERIFICATION_PEPPER),
+    new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    }),
+  );
+}
+
+export async function invalidateBootstrapCache(
+  request: Request,
+  env: BootstrapCacheEnv,
+  includeAnonymous = false,
+): Promise<void> {
+  const token = requestToken(request);
+  const keys = [await bootstrapCacheRequest(token, env.VERIFICATION_PEPPER)];
+  if (includeAnonymous && token) {
+    keys.push(await bootstrapCacheRequest(null, env.VERIFICATION_PEPPER));
+  }
+  await Promise.all(keys.map((key) => defaultCache().delete(key)));
+}
+
+export function bootstrapCacheMiss(response: Response): Response {
+  return clientResponse(response, "miss");
+}

--- a/webapp/cloudflare/bootstrap-cache.ts
+++ b/webapp/cloudflare/bootstrap-cache.ts
@@ -1,4 +1,4 @@
-const BOOTSTRAP_CACHE_NAMESPACE = "https://bootstrap-cache.invalid/v1";
+const BOOTSTRAP_CACHE_PATH = "/__zacks_edge_cache/bootstrap";
 
 export const BOOTSTRAP_CACHE_TTL_SECONDS = 120;
 
@@ -24,12 +24,17 @@ async function sha256Hex(value: string): Promise<string> {
 }
 
 export async function bootstrapCacheRequest(
+  requestUrl: string,
   token: string | null,
   pepper: string,
 ): Promise<Request> {
   const identity = token ? `receipt:${token}` : "anonymous";
   const digest = await sha256Hex(`zacks-bootstrap:${pepper}:${identity}`);
-  return new Request(`${BOOTSTRAP_CACHE_NAMESPACE}/${digest}`, { method: "GET" });
+  const url = new URL(requestUrl);
+  url.pathname = `${BOOTSTRAP_CACHE_PATH}/${digest}`;
+  url.search = "";
+  url.hash = "";
+  return new Request(url.toString(), { method: "GET" });
 }
 
 function defaultCache(): Cache {
@@ -47,13 +52,19 @@ function clientResponse(response: Response, cacheStatus: "hit" | "miss"): Respon
   });
 }
 
+async function cacheKey(
+  request: Request,
+  env: BootstrapCacheEnv,
+  token = requestToken(request),
+): Promise<Request> {
+  return bootstrapCacheRequest(request.url, token, env.VERIFICATION_PEPPER);
+}
+
 export async function matchBootstrapCache(
   request: Request,
   env: BootstrapCacheEnv,
 ): Promise<Response | null> {
-  const cached = await defaultCache().match(
-    await bootstrapCacheRequest(requestToken(request), env.VERIFICATION_PEPPER),
-  );
+  const cached = await defaultCache().match(await cacheKey(request, env));
   return cached ? clientResponse(cached, "hit") : null;
 }
 
@@ -69,7 +80,7 @@ export async function storeBootstrapCache(
   headers.set("Cache-Control", `public, max-age=${BOOTSTRAP_CACHE_TTL_SECONDS}`);
   headers.set("X-Zacks-Bootstrap-Cache", "miss");
   await defaultCache().put(
-    await bootstrapCacheRequest(requestToken(request), env.VERIFICATION_PEPPER),
+    await cacheKey(request, env),
     new Response(response.body, {
       status: response.status,
       statusText: response.statusText,
@@ -84,9 +95,9 @@ export async function invalidateBootstrapCache(
   includeAnonymous = false,
 ): Promise<void> {
   const token = requestToken(request);
-  const keys = [await bootstrapCacheRequest(token, env.VERIFICATION_PEPPER)];
+  const keys = [await cacheKey(request, env, token)];
   if (includeAnonymous && token) {
-    keys.push(await bootstrapCacheRequest(null, env.VERIFICATION_PEPPER));
+    keys.push(await cacheKey(request, env, null));
   }
   await Promise.all(keys.map((key) => defaultCache().delete(key)));
 }

--- a/webapp/cloudflare/deployment-entry.test.ts
+++ b/webapp/cloudflare/deployment-entry.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   applyGlobalSubmittedReminderMetric,
   deploymentHealth,
+  invalidatesBootstrap,
+  scheduledWorkForCron,
   shanghaiDayStartIso,
+  shanghaiDeliveryDay,
 } from "./deployment-entry";
 
 describe("deployment entry health", () => {
@@ -20,8 +23,9 @@ describe("deployment entry health", () => {
 
 describe("aggregate reminder metric", () => {
   it("uses the Shanghai calendar-day boundary", () => {
-    expect(shanghaiDayStartIso(new Date("2026-08-25T15:30:00.000Z")))
-      .toBe("2026-08-24T16:00:00.000Z");
+    const now = new Date("2026-08-25T15:30:00.000Z");
+    expect(shanghaiDayStartIso(now)).toBe("2026-08-24T16:00:00.000Z");
+    expect(shanghaiDeliveryDay(now)).toBe("2026-08-25");
   });
 
   it("replaces only the aggregate reminder count", () => {
@@ -48,5 +52,23 @@ describe("aggregate reminder metric", () => {
         deliveredToday: 0,
       },
     });
+  });
+});
+
+describe("free-tier scheduling", () => {
+  it("keeps recent delivery reconciliation separate from hourly maintenance", () => {
+    expect(scheduledWorkForCron("*/5 * * * *")).toBe("delivery_reconcile");
+    expect(scheduledWorkForCron("17 * * * *")).toBe("maintenance");
+  });
+
+  it("invalidates dashboard cache only for state-changing subscription actions", () => {
+    expect(invalidatesBootstrap("POST", "/api/subscriptions")).toBe(true);
+    expect(invalidatesBootstrap(
+      "DELETE",
+      "/api/subscriptions/9d1aca70-e4de-4c91-b3eb-1f4b26ce9181",
+    )).toBe(true);
+    expect(invalidatesBootstrap("POST", "/api/priority/redeem")).toBe(true);
+    expect(invalidatesBootstrap("GET", "/api/bootstrap")).toBe(false);
+    expect(invalidatesBootstrap("POST", "/api/internal/observations")).toBe(false);
   });
 });

--- a/webapp/cloudflare/deployment-entry.ts
+++ b/webapp/cloudflare/deployment-entry.ts
@@ -1,9 +1,20 @@
 import worker from "./index";
 import {
+  bootstrapCacheMiss,
+  invalidateBootstrapCache,
+  matchBootstrapCache,
+  storeBootstrapCache,
+} from "./bootstrap-cache";
+import {
   providerCheckError,
   reconcileDeliveryStatuses,
   type DeliveryReconcileSummary,
 } from "./delivery-reconcile";
+import {
+  decideObservationDedupe,
+  recordForwardedObservation,
+  type ObservationSnapshot,
+} from "./observation-dedupe";
 
 type DeploymentEnv = Env & {
   DEPLOYMENT_COMMIT?: string;
@@ -18,6 +29,10 @@ type DeploymentEnv = Env & {
   EMAIL_REPLY_TO: string;
   EMAIL_TEMPLATE_ID: string;
 };
+
+export const DELIVERY_RECONCILE_CRON = "*/5 * * * *";
+export const MAINTENANCE_CRON = "17 * * * *";
+const DELIVERY_RECONCILE_BATCH = 5;
 
 export function deploymentHealth(deploymentCommit?: string) {
   return {
@@ -41,6 +56,10 @@ export function shanghaiDayStartIso(now = new Date()): string {
   ).toISOString();
 }
 
+export function shanghaiDeliveryDay(now = new Date()): string {
+  return new Date(now.getTime() + 8 * 3_600_000).toISOString().slice(0, 10);
+}
+
 export function applyGlobalSubmittedReminderMetric(
   payload: unknown,
   submittedToday: number,
@@ -60,6 +79,20 @@ export function applyGlobalSubmittedReminderMetric(
       remindersToday: count,
     },
   };
+}
+
+export function scheduledWorkForCron(
+  cron: string | undefined,
+): "delivery_reconcile" | "maintenance" {
+  return cron === MAINTENANCE_CRON ? "maintenance" : "delivery_reconcile";
+}
+
+export function invalidatesBootstrap(method: string, pathname: string): boolean {
+  return (
+    (method === "POST" && pathname === "/api/subscriptions")
+    || (method === "POST" && pathname === "/api/priority/redeem")
+    || (method === "DELETE" && /^\/api\/subscriptions\/[0-9a-f-]{36}$/i.test(pathname))
+  );
 }
 
 function withInviteSecrets(env: DeploymentEnv) {
@@ -125,10 +158,11 @@ async function rewriteBootstrapReminderMetric(
     const [payload, row] = await Promise.all([
       response.clone().json<unknown>(),
       env.DB.prepare(
-        `SELECT COUNT(DISTINCT message_id) AS count
-           FROM notification_outbox
-          WHERE provider_submitted_at >= ?`,
-      ).bind(shanghaiDayStartIso()).first<{ count?: number }>(),
+        `SELECT COUNT(*) AS count
+           FROM email_delivery_claims
+          WHERE delivery_day = ?
+            AND status = 'sent'`,
+      ).bind(shanghaiDeliveryDay()).first<{ count?: number }>(),
     ]);
     const corrected = applyGlobalSubmittedReminderMetric(
       payload,
@@ -153,6 +187,103 @@ async function rewriteBootstrapReminderMetric(
   }
 }
 
+async function cachedBootstrap(
+  request: Request,
+  env: DeploymentEnv,
+): Promise<Response | null> {
+  try {
+    return await matchBootstrapCache(request, env);
+  } catch (error) {
+    console.warn(JSON.stringify({
+      event: "bootstrap_cache_read_failed",
+      reason: error instanceof Error ? error.message.slice(0, 160) : "unknown",
+    }));
+    return null;
+  }
+}
+
+function storeBootstrapSafely(
+  request: Request,
+  env: DeploymentEnv,
+  response: Response,
+): Promise<void> {
+  return storeBootstrapCache(request, env, response).catch((error) => {
+    console.warn(JSON.stringify({
+      event: "bootstrap_cache_write_failed",
+      reason: error instanceof Error ? error.message.slice(0, 160) : "unknown",
+    }));
+  });
+}
+
+async function invalidateBootstrapSafely(
+  request: Request,
+  env: DeploymentEnv,
+): Promise<void> {
+  try {
+    await invalidateBootstrapCache(request, env, true);
+  } catch (error) {
+    console.warn(JSON.stringify({
+      event: "bootstrap_cache_invalidation_failed",
+      reason: error instanceof Error ? error.message.slice(0, 160) : "unknown",
+    }));
+  }
+}
+
+async function observationDecision(
+  request: Request,
+  env: DeploymentEnv,
+): Promise<{ skip: Response | null; snapshot: ObservationSnapshot | null }> {
+  try {
+    const decision = await decideObservationDedupe(
+      env.DB,
+      await request.clone().json<unknown>(),
+    );
+    if (decision.action === "skip" && decision.snapshot) {
+      console.log(JSON.stringify({
+        event: "venue_observation_deduplicated",
+        venueId: decision.snapshot.venueId,
+        slotCount: decision.snapshot.slotCount,
+      }));
+      return {
+        skip: Response.json({
+          success: true,
+          venueId: decision.snapshot.venueId,
+          slotsAccepted: decision.snapshot.slotCount,
+          deduplicated: true,
+        }, {
+          headers: {
+            "Cache-Control": "no-store",
+            "Content-Type": "application/json; charset=utf-8",
+          },
+        }),
+        snapshot: decision.snapshot,
+      };
+    }
+    return { skip: null, snapshot: decision.snapshot };
+  } catch (error) {
+    console.warn(JSON.stringify({
+      event: "venue_observation_dedupe_failed_open",
+      reason: error instanceof Error ? error.message.slice(0, 160) : "unknown",
+    }));
+    return { skip: null, snapshot: null };
+  }
+}
+
+async function recordObservationSafely(
+  env: DeploymentEnv,
+  snapshot: ObservationSnapshot,
+): Promise<void> {
+  try {
+    await recordForwardedObservation(env.DB, snapshot);
+  } catch (error) {
+    console.warn(JSON.stringify({
+      event: "venue_observation_dedupe_record_failed",
+      venueId: snapshot.venueId,
+      reason: error instanceof Error ? error.message.slice(0, 160) : "unknown",
+    }));
+  }
+}
+
 export default {
   async fetch(
     request: Request,
@@ -174,7 +305,10 @@ export default {
         return Response.json({ error: "未授权" }, { status: 401 });
       }
       try {
-        const summary = await reconcileDeliveryStatuses(withInviteSecrets(env) as never, 20);
+        const summary = await reconcileDeliveryStatuses(
+          withInviteSecrets(env) as never,
+          DELIVERY_RECONCILE_BATCH,
+        );
         const unavailable = unavailableCount(summary);
         return Response.json({
           success: unavailable === 0,
@@ -200,21 +334,35 @@ export default {
       }
     }
 
+    if (request.method === "GET" && url.pathname === "/api/bootstrap") {
+      const cached = await cachedBootstrap(request, env);
+      if (cached) return cached;
+    }
+
+    let observationSnapshot: ObservationSnapshot | null = null;
+    if (
+      request.method === "POST"
+      && url.pathname === "/api/internal/observations"
+      && authorizedInternalRequest(request, env)
+    ) {
+      const decision = await observationDecision(request, env);
+      if (decision.skip) return decision.skip;
+      observationSnapshot = decision.snapshot;
+    }
+
     const response = await worker.fetch(request, withInviteSecrets(env) as never, context);
     if (response.ok && request.method === "GET" && url.pathname === "/api/bootstrap") {
-      // The home metric is aggregate, like active subscriptions and venue health.
-      // Count provider-accepted reminder digests for the Shanghai calendar day;
-      // provider-confirmed delivery remains available in the signed-in quota card.
-      return rewriteBootstrapReminderMetric(response, env);
+      const corrected = await rewriteBootstrapReminderMetric(response, env);
+      context.waitUntil(storeBootstrapSafely(request, env, corrected.clone()));
+      return bootstrapCacheMiss(corrected);
     }
-    if (
-      response.ok
-      && request.method === "POST"
-      && url.pathname === "/api/internal/observations"
-    ) {
-      // One inline lookup guarantees bounded progress on the reliable live
-      // observation heartbeat even if another scheduled maintenance phase fails.
-      await reconcileSafely(env, 1, "observation");
+
+    if (response.ok && observationSnapshot) {
+      await recordObservationSafely(env, observationSnapshot);
+    }
+
+    if (response.ok && invalidatesBootstrap(request.method, url.pathname)) {
+      await invalidateBootstrapSafely(request, env);
     }
     return response;
   },
@@ -224,9 +372,11 @@ export default {
     env: DeploymentEnv,
     context: ExecutionContext,
   ): Promise<void> {
-    // Reconcile before the legacy maintenance chain so renewal, draining, or
-    // cleanup errors cannot starve provider delivery-state updates.
-    await reconcileSafely(env, 20, "scheduled");
-    await worker.scheduled(controller, withInviteSecrets(env) as never, context);
+    const cron = (controller as ScheduledController & { cron?: string }).cron;
+    if (scheduledWorkForCron(cron) === "maintenance") {
+      await worker.scheduled(controller, withInviteSecrets(env) as never, context);
+      return;
+    }
+    await reconcileSafely(env, DELIVERY_RECONCILE_BATCH, `scheduled:${cron || "unknown"}`);
   },
 } satisfies ExportedHandler<DeploymentEnv>;

--- a/webapp/cloudflare/observation-dedupe.test.ts
+++ b/webapp/cloudflare/observation-dedupe.test.ts
@@ -9,6 +9,7 @@ import {
 const baseObservation = {
   venue_id: "szw",
   venue_name: "深圳湾",
+  observation_scope: "check_and_notify_day_0",
   healthy: true,
   checked_at: "2026-08-27T01:00:00.000Z",
   error: null,
@@ -51,6 +52,27 @@ describe("observation fingerprint", () => {
     expect(first?.fingerprint).not.toBe(second?.fingerprint);
   });
 
+  it("forwards availability that disappears and then reappears", async () => {
+    const available = await observationSnapshot(baseObservation);
+    const empty = await observationSnapshot({
+      ...baseObservation,
+      slots: [],
+    });
+    const restored = await observationSnapshot({
+      ...baseObservation,
+      checked_at: "2026-08-27T01:01:00.000Z",
+    });
+    expect(available?.key).toBe(empty?.key);
+    expect(restored?.key).toBe(empty?.key);
+    expect(available?.fingerprint).not.toBe(empty?.fingerprint);
+    expect(restored?.fingerprint).toBe(available?.fingerprint);
+    if (!restored || !empty) throw new Error("expected valid snapshots");
+    expect(shouldSkipObservation(restored, {
+      fingerprint: empty.fingerprint,
+      last_forwarded_at: 1_000_000,
+    }, 1_015_000)).toBe(false);
+  });
+
   it("keeps an unchanged heartbeat inside the venue freshness window", async () => {
     const snapshot = await observationSnapshot(baseObservation);
     if (!snapshot) throw new Error("expected a valid snapshot");
@@ -67,15 +89,19 @@ describe("observation fingerprint", () => {
     )).toBe(false);
   });
 
-  it("uses a stable empty scope without merging different venues", async () => {
-    const first = await observationSnapshot({ ...baseObservation, slots: [] });
+  it("separates parallel day tasks for the same venue", async () => {
+    const first = await observationSnapshot(baseObservation);
     const second = await observationSnapshot({
       ...baseObservation,
-      venue_id: "gba",
-      venue_name: "大湾区网球场",
-      slots: [],
+      observation_scope: "check_and_notify_day_1",
     });
-    expect(first?.key).toBe("v1:szw:empty");
-    expect(second?.key).toBe("v1:gba:empty");
+    expect(first?.key).toBe("v2:szw:check_and_notify_day_0");
+    expect(second?.key).toBe("v2:szw:check_and_notify_day_1");
+  });
+
+  it("uses a safe compatibility scope for old publishers", async () => {
+    const { observation_scope: _scope, ...legacyObservation } = baseObservation;
+    const snapshot = await observationSnapshot(legacyObservation);
+    expect(snapshot?.key).toBe("v2:szw:default");
   });
 });

--- a/webapp/cloudflare/observation-dedupe.test.ts
+++ b/webapp/cloudflare/observation-dedupe.test.ts
@@ -6,6 +6,7 @@ import {
   shouldSkipObservation,
 } from "./observation-dedupe";
 
+const OBSERVATION_NOW = Date.parse("2026-08-27T01:00:30.000Z");
 const baseObservation = {
   venue_id: "szw",
   venue_name: "深圳湾",
@@ -29,10 +30,14 @@ const baseObservation = {
   ],
 };
 
+function snapshot(payload: unknown) {
+  return observationSnapshot(payload, OBSERVATION_NOW);
+}
+
 describe("observation fingerprint", () => {
   it("ignores checked_at and slot ordering", async () => {
-    const first = await observationSnapshot(baseObservation);
-    const second = await observationSnapshot({
+    const first = await snapshot(baseObservation);
+    const second = await snapshot({
       ...baseObservation,
       checked_at: "2026-08-27T01:00:15.000Z",
       slots: [...baseObservation.slots].reverse(),
@@ -44,8 +49,8 @@ describe("observation fingerprint", () => {
   });
 
   it("forwards a real availability change immediately", async () => {
-    const first = await observationSnapshot(baseObservation);
-    const second = await observationSnapshot({
+    const first = await snapshot(baseObservation);
+    const second = await snapshot({
       ...baseObservation,
       slots: baseObservation.slots.slice(0, 1),
     });
@@ -53,12 +58,12 @@ describe("observation fingerprint", () => {
   });
 
   it("forwards availability that disappears and then reappears", async () => {
-    const available = await observationSnapshot(baseObservation);
-    const empty = await observationSnapshot({
+    const available = await snapshot(baseObservation);
+    const empty = await snapshot({
       ...baseObservation,
       slots: [],
     });
-    const restored = await observationSnapshot({
+    const restored = await snapshot({
       ...baseObservation,
       checked_at: "2026-08-27T01:01:00.000Z",
     });
@@ -74,24 +79,24 @@ describe("observation fingerprint", () => {
   });
 
   it("keeps an unchanged heartbeat inside the venue freshness window", async () => {
-    const snapshot = await observationSnapshot(baseObservation);
-    if (!snapshot) throw new Error("expected a valid snapshot");
+    const observation = await snapshot(baseObservation);
+    if (!observation) throw new Error("expected a valid snapshot");
     const forwardedAt = 1_000_000;
     const current = {
-      fingerprint: snapshot.fingerprint,
+      fingerprint: observation.fingerprint,
       last_forwarded_at: forwardedAt,
     };
-    expect(shouldSkipObservation(snapshot, current, forwardedAt + 15_000)).toBe(true);
+    expect(shouldSkipObservation(observation, current, forwardedAt + 15_000)).toBe(true);
     expect(shouldSkipObservation(
-      snapshot,
+      observation,
       current,
       forwardedAt + OBSERVATION_HEARTBEAT_MS,
     )).toBe(false);
   });
 
   it("separates parallel day tasks for the same venue", async () => {
-    const first = await observationSnapshot(baseObservation);
-    const second = await observationSnapshot({
+    const first = await snapshot(baseObservation);
+    const second = await snapshot({
       ...baseObservation,
       observation_scope: "check_and_notify_day_1",
     });
@@ -101,7 +106,18 @@ describe("observation fingerprint", () => {
 
   it("uses a safe compatibility scope for old publishers", async () => {
     const { observation_scope: _scope, ...legacyObservation } = baseObservation;
-    const snapshot = await observationSnapshot(legacyObservation);
-    expect(snapshot?.key).toBe("v2:szw:default");
+    const observation = await snapshot(legacyObservation);
+    expect(observation?.key).toBe("v2:szw:default");
+  });
+
+  it("forwards invalid or stale timestamps to the canonical validator", async () => {
+    expect(await snapshot({
+      ...baseObservation,
+      checked_at: "not-a-date",
+    })).toBeNull();
+    expect(await snapshot({
+      ...baseObservation,
+      checked_at: "2026-08-25T01:00:00.000Z",
+    })).toBeNull();
   });
 });

--- a/webapp/cloudflare/observation-dedupe.test.ts
+++ b/webapp/cloudflare/observation-dedupe.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  OBSERVATION_HEARTBEAT_MS,
+  observationSnapshot,
+  shouldSkipObservation,
+} from "./observation-dedupe";
+
+const baseObservation = {
+  venue_id: "szw",
+  venue_name: "深圳湾",
+  healthy: true,
+  checked_at: "2026-08-27T01:00:00.000Z",
+  error: null,
+  slots: [
+    {
+      date: "2026-08-28",
+      court_name: "室外1号场",
+      start_time: "18:00",
+      end_time: "19:00",
+    },
+    {
+      date: "2026-08-28",
+      court_name: "室外2号场",
+      start_time: "19:00",
+      end_time: "20:00",
+    },
+  ],
+};
+
+describe("observation fingerprint", () => {
+  it("ignores checked_at and slot ordering", async () => {
+    const first = await observationSnapshot(baseObservation);
+    const second = await observationSnapshot({
+      ...baseObservation,
+      checked_at: "2026-08-27T01:00:15.000Z",
+      slots: [...baseObservation.slots].reverse(),
+    });
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(second?.key).toBe(first?.key);
+    expect(second?.fingerprint).toBe(first?.fingerprint);
+  });
+
+  it("forwards a real availability change immediately", async () => {
+    const first = await observationSnapshot(baseObservation);
+    const second = await observationSnapshot({
+      ...baseObservation,
+      slots: baseObservation.slots.slice(0, 1),
+    });
+    expect(first?.fingerprint).not.toBe(second?.fingerprint);
+  });
+
+  it("keeps an unchanged heartbeat inside the venue freshness window", async () => {
+    const snapshot = await observationSnapshot(baseObservation);
+    if (!snapshot) throw new Error("expected a valid snapshot");
+    const forwardedAt = 1_000_000;
+    const current = {
+      fingerprint: snapshot.fingerprint,
+      last_forwarded_at: forwardedAt,
+    };
+    expect(shouldSkipObservation(snapshot, current, forwardedAt + 15_000)).toBe(true);
+    expect(shouldSkipObservation(
+      snapshot,
+      current,
+      forwardedAt + OBSERVATION_HEARTBEAT_MS,
+    )).toBe(false);
+  });
+
+  it("uses a stable empty scope without merging different venues", async () => {
+    const first = await observationSnapshot({ ...baseObservation, slots: [] });
+    const second = await observationSnapshot({
+      ...baseObservation,
+      venue_id: "gba",
+      venue_name: "大湾区网球场",
+      slots: [],
+    });
+    expect(first?.key).toBe("v1:szw:empty");
+    expect(second?.key).toBe("v1:gba:empty");
+  });
+});

--- a/webapp/cloudflare/observation-dedupe.ts
+++ b/webapp/cloudflare/observation-dedupe.ts
@@ -1,4 +1,4 @@
-const OBSERVATION_KEY_VERSION = "v1";
+const OBSERVATION_KEY_VERSION = "v2";
 
 export const OBSERVATION_HEARTBEAT_MS = 5 * 60_000;
 
@@ -18,6 +18,7 @@ export type ObservationSnapshot = {
   key: string;
   fingerprint: string;
   venueId: string;
+  observationScope: string;
   slotCount: number;
 };
 
@@ -70,7 +71,19 @@ export async function observationSnapshot(
   const candidate = payload as Record<string, unknown>;
   const venueId = stringField(candidate, "venue_id", "venueId");
   const venueName = stringField(candidate, "venue_name", "venueName");
-  if (!venueId || venueId.length > 64 || !venueName || venueName.length > 120) {
+  const explicitScope = stringField(
+    candidate,
+    "observation_scope",
+    "observationScope",
+  );
+  const observationScope = explicitScope || "default";
+  if (
+    !venueId
+    || venueId.length > 64
+    || !venueName
+    || venueName.length > 120
+    || observationScope.length > 120
+  ) {
     return null;
   }
   if (!Array.isArray(candidate.slots) || candidate.slots.length > 200) return null;
@@ -91,21 +104,21 @@ export async function observationSnapshot(
     [left.date, left.courtName, left.startTime, left.endTime].join("|")
       .localeCompare([right.date, right.courtName, right.startTime, right.endTime].join("|"))
   );
-  const dates = Array.from(new Set(uniqueSlots.map((slot) => slot.date))).sort();
-  const scope = dates.length ? dates.join(",") : "empty";
   const error = candidate.error ? String(candidate.error).slice(0, 300) : null;
   const fingerprint = await sha256Hex(JSON.stringify({
     venueId,
     venueName,
+    observationScope,
     healthy: candidate.healthy === true,
     error,
     slots: uniqueSlots,
   }));
 
   return {
-    key: `${OBSERVATION_KEY_VERSION}:${venueId}:${scope}`,
+    key: `${OBSERVATION_KEY_VERSION}:${venueId}:${observationScope}`,
     fingerprint,
     venueId,
+    observationScope,
     slotCount: uniqueSlots.length,
   };
 }

--- a/webapp/cloudflare/observation-dedupe.ts
+++ b/webapp/cloudflare/observation-dedupe.ts
@@ -82,8 +82,8 @@ export async function observationSnapshot(
     slots.push(slot);
   }
 
-  const uniqueSlots = Array.from(new Map(
-    slots.map((slot) => [
+  const uniqueSlots = Array.from(new Map<string, CanonicalObservationSlot>(
+    slots.map((slot): [string, CanonicalObservationSlot] => [
       [slot.date, slot.courtName, slot.startTime, slot.endTime].join("|"),
       slot,
     ]),

--- a/webapp/cloudflare/observation-dedupe.ts
+++ b/webapp/cloudflare/observation-dedupe.ts
@@ -1,0 +1,157 @@
+const OBSERVATION_KEY_VERSION = "v1";
+
+export const OBSERVATION_HEARTBEAT_MS = 5 * 60_000;
+
+type CanonicalObservationSlot = {
+  date: string;
+  courtName: string;
+  startTime: string;
+  endTime: string;
+};
+
+type ObservationStateRow = {
+  fingerprint: string;
+  last_forwarded_at: number;
+};
+
+export type ObservationSnapshot = {
+  key: string;
+  fingerprint: string;
+  venueId: string;
+  slotCount: number;
+};
+
+export type ObservationDedupeDecision = {
+  action: "forward" | "skip";
+  snapshot: ObservationSnapshot | null;
+};
+
+function stringField(
+  candidate: Record<string, unknown>,
+  snakeCase: string,
+  camelCase: string,
+): string {
+  return String(candidate[snakeCase] ?? candidate[camelCase] ?? "").trim();
+}
+
+function canonicalSlot(value: unknown): CanonicalObservationSlot | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const candidate = value as Record<string, unknown>;
+  const date = String(candidate.date ?? "").trim();
+  const courtName = stringField(candidate, "court_name", "courtName");
+  const startTime = stringField(candidate, "start_time", "startTime");
+  const endTime = stringField(candidate, "end_time", "endTime");
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(date)
+    || !courtName
+    || courtName.length > 120
+    || !/^\d{2}:\d{2}$/.test(startTime)
+    || !/^\d{2}:\d{2}$/.test(endTime)
+  ) {
+    return null;
+  }
+  return { date, courtName, startTime, endTime };
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function observationSnapshot(
+  payload: unknown,
+): Promise<ObservationSnapshot | null> {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const candidate = payload as Record<string, unknown>;
+  const venueId = stringField(candidate, "venue_id", "venueId");
+  const venueName = stringField(candidate, "venue_name", "venueName");
+  if (!venueId || venueId.length > 64 || !venueName || venueName.length > 120) {
+    return null;
+  }
+  if (!Array.isArray(candidate.slots) || candidate.slots.length > 200) return null;
+
+  const slots: CanonicalObservationSlot[] = [];
+  for (const value of candidate.slots) {
+    const slot = canonicalSlot(value);
+    if (!slot) return null;
+    slots.push(slot);
+  }
+
+  const uniqueSlots = Array.from(new Map(
+    slots.map((slot) => [
+      [slot.date, slot.courtName, slot.startTime, slot.endTime].join("|"),
+      slot,
+    ]),
+  ).values()).sort((left, right) =>
+    [left.date, left.courtName, left.startTime, left.endTime].join("|")
+      .localeCompare([right.date, right.courtName, right.startTime, right.endTime].join("|"))
+  );
+  const dates = Array.from(new Set(uniqueSlots.map((slot) => slot.date))).sort();
+  const scope = dates.length ? dates.join(",") : "empty";
+  const error = candidate.error ? String(candidate.error).slice(0, 300) : null;
+  const fingerprint = await sha256Hex(JSON.stringify({
+    venueId,
+    venueName,
+    healthy: candidate.healthy === true,
+    error,
+    slots: uniqueSlots,
+  }));
+
+  return {
+    key: `${OBSERVATION_KEY_VERSION}:${venueId}:${scope}`,
+    fingerprint,
+    venueId,
+    slotCount: uniqueSlots.length,
+  };
+}
+
+export function shouldSkipObservation(
+  snapshot: ObservationSnapshot,
+  current: ObservationStateRow | null,
+  now: number,
+  heartbeatMs = OBSERVATION_HEARTBEAT_MS,
+): boolean {
+  return Boolean(
+    current
+    && current.fingerprint === snapshot.fingerprint
+    && now - Number(current.last_forwarded_at) < heartbeatMs,
+  );
+}
+
+export async function decideObservationDedupe(
+  db: D1Database,
+  payload: unknown,
+  now = Date.now(),
+): Promise<ObservationDedupeDecision> {
+  const snapshot = await observationSnapshot(payload);
+  if (!snapshot) return { action: "forward", snapshot: null };
+  const current = await db.prepare(
+    `SELECT fingerprint, last_forwarded_at
+       FROM observation_ingest_state
+      WHERE observation_key = ?`,
+  ).bind(snapshot.key).first<ObservationStateRow>();
+  return {
+    action: shouldSkipObservation(snapshot, current, now) ? "skip" : "forward",
+    snapshot,
+  };
+}
+
+export async function recordForwardedObservation(
+  db: D1Database,
+  snapshot: ObservationSnapshot,
+  now = Date.now(),
+): Promise<void> {
+  await db.prepare(
+    `INSERT INTO observation_ingest_state
+       (observation_key, fingerprint, last_forwarded_at)
+     VALUES (?, ?, ?)
+     ON CONFLICT(observation_key) DO UPDATE SET
+       fingerprint = excluded.fingerprint,
+       last_forwarded_at = excluded.last_forwarded_at`,
+  ).bind(snapshot.key, snapshot.fingerprint, now).run();
+}

--- a/webapp/cloudflare/observation-dedupe.ts
+++ b/webapp/cloudflare/observation-dedupe.ts
@@ -66,6 +66,7 @@ async function sha256Hex(value: string): Promise<string> {
 
 export async function observationSnapshot(
   payload: unknown,
+  now = Date.now(),
 ): Promise<ObservationSnapshot | null> {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
   const candidate = payload as Record<string, unknown>;
@@ -77,12 +78,17 @@ export async function observationSnapshot(
     "observationScope",
   );
   const observationScope = explicitScope || "default";
+  const checkedAt = stringField(candidate, "checked_at", "checkedAt");
+  const checkedAtMs = Date.parse(checkedAt);
   if (
     !venueId
     || venueId.length > 64
     || !venueName
     || venueName.length > 120
     || observationScope.length > 120
+    || !checkedAt
+    || !Number.isFinite(checkedAtMs)
+    || Math.abs(now - checkedAtMs) > 86_400_000
   ) {
     return null;
   }
@@ -141,7 +147,7 @@ export async function decideObservationDedupe(
   payload: unknown,
   now = Date.now(),
 ): Promise<ObservationDedupeDecision> {
-  const snapshot = await observationSnapshot(payload);
+  const snapshot = await observationSnapshot(payload, now);
   if (!snapshot) return { action: "forward", snapshot: null };
   const current = await db.prepare(
     `SELECT fingerprint, last_forwarded_at

--- a/webapp/migrations/0009_reduce_cloudflare_free_tier_usage.sql
+++ b/webapp/migrations/0009_reduce_cloudflare_free_tier_usage.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS observation_ingest_state (
+    observation_key TEXT PRIMARY KEY,
+    fingerprint TEXT NOT NULL,
+    last_forwarded_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS email_delivery_claims_day_status_idx
+    ON email_delivery_claims(delivery_day, status);

--- a/webapp/src/api.test.ts
+++ b/webapp/src/api.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DASHBOARD_CLIENT_CACHE_MS,
+  FALLBACK_DASHBOARD,
+  getDashboard,
+  invalidateDashboardCache,
+  type VerificationReceipt,
+} from "./api";
+
+function dashboardResponse(): Response {
+  return new Response(JSON.stringify(FALLBACK_DASHBOARD), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("dashboard client cache", () => {
+  beforeEach(() => {
+    invalidateDashboardCache();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-27T02:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    invalidateDashboardCache();
+  });
+
+  it("turns the 30-second UI refresh loop into one network request per two minutes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(dashboardResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getDashboard(null);
+    vi.advanceTimersByTime(30_000);
+    await getDashboard(null);
+    vi.advanceTimersByTime(DASHBOARD_CLIENT_CACHE_MS - 30_001);
+    await getDashboard(null);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+    await getDashboard(null);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent refreshes for the same identity", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(dashboardResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await Promise.all([getDashboard(null), getDashboard(null), getDashboard(null)]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("never shares a cached dashboard between identities", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(dashboardResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const receipt: VerificationReceipt = {
+      token: "receipt-token",
+      email: "person@example.com",
+      maskedEmail: "p***@example.com",
+      verifiedAt: "2026-08-27T02:00:00.000Z",
+    };
+
+    await getDashboard(null);
+    await getDashboard(receipt);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: "Bearer receipt-token" }),
+    });
+  });
+
+  it("supports immediate refresh after a state-changing action", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(dashboardResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getDashboard(null);
+    invalidateDashboardCache();
+    await getDashboard(null);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/webapp/src/api.test.ts
+++ b/webapp/src/api.test.ts
@@ -16,7 +16,7 @@ function dashboardResponse(): Response {
 }
 
 function dashboardFetchMock() {
-  return vi.fn(async () => dashboardResponse());
+  return vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => dashboardResponse());
 }
 
 describe("dashboard client cache", () => {

--- a/webapp/src/api.test.ts
+++ b/webapp/src/api.test.ts
@@ -15,6 +15,10 @@ function dashboardResponse(): Response {
   });
 }
 
+function dashboardFetchMock() {
+  return vi.fn(async () => dashboardResponse());
+}
+
 describe("dashboard client cache", () => {
   beforeEach(() => {
     invalidateDashboardCache();
@@ -29,7 +33,7 @@ describe("dashboard client cache", () => {
   });
 
   it("turns the 30-second UI refresh loop into one network request per two minutes", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(dashboardResponse());
+    const fetchMock = dashboardFetchMock();
     vi.stubGlobal("fetch", fetchMock);
 
     await getDashboard(null);
@@ -45,7 +49,7 @@ describe("dashboard client cache", () => {
   });
 
   it("coalesces concurrent refreshes for the same identity", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(dashboardResponse());
+    const fetchMock = dashboardFetchMock();
     vi.stubGlobal("fetch", fetchMock);
 
     await Promise.all([getDashboard(null), getDashboard(null), getDashboard(null)]);
@@ -53,7 +57,7 @@ describe("dashboard client cache", () => {
   });
 
   it("never shares a cached dashboard between identities", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(dashboardResponse());
+    const fetchMock = dashboardFetchMock();
     vi.stubGlobal("fetch", fetchMock);
     const receipt: VerificationReceipt = {
       token: "receipt-token",
@@ -71,7 +75,7 @@ describe("dashboard client cache", () => {
   });
 
   it("supports immediate refresh after a state-changing action", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(dashboardResponse());
+    const fetchMock = dashboardFetchMock();
     vi.stubGlobal("fetch", fetchMock);
 
     await getDashboard(null);

--- a/webapp/src/api.ts
+++ b/webapp/src/api.ts
@@ -125,6 +125,23 @@ export type CoffeeInvite = {
 };
 
 const RECEIPTS_KEY = "zacks-tennis-verified-emails-v1";
+export const DASHBOARD_CLIENT_CACHE_MS = 120_000;
+
+type DashboardClientCache = {
+  identityKey: string;
+  expiresAt: number;
+  value: Dashboard;
+};
+
+type DashboardClientRequest = {
+  identityKey: string;
+  epoch: number;
+  promise: Promise<Dashboard>;
+};
+
+let dashboardCache: DashboardClientCache | null = null;
+let dashboardRequest: DashboardClientRequest | null = null;
+let dashboardCacheEpoch = 0;
 
 const FALLBACK_VENUES: VenueStatus[] = [
   { id: "szw", name: "深圳湾", healthy: true, subscriberCount: 28, lastInspectionAt: "2026-07-29T10:41:40+08:00", lastNotificationAt: null },
@@ -203,6 +220,20 @@ async function jsonRequest<T>(
   return payload;
 }
 
+function dashboardIdentityKey(receipt?: VerificationReceipt | null): string {
+  return receipt?.token || "anonymous";
+}
+
+function pageIsHidden(): boolean {
+  return typeof document !== "undefined" && document.visibilityState === "hidden";
+}
+
+export function invalidateDashboardCache(): void {
+  dashboardCacheEpoch += 1;
+  dashboardCache = null;
+  dashboardRequest = null;
+}
+
 export function loadReceipts(): VerificationReceipt[] {
   try {
     const parsed = JSON.parse(localStorage.getItem(RECEIPTS_KEY) || "[]") as unknown;
@@ -225,17 +256,52 @@ export function saveReceipt(receipt: VerificationReceipt): VerificationReceipt[]
     ...loadReceipts().filter((item) => item.email.toLowerCase() !== receipt.email.toLowerCase()),
   ].slice(0, 3);
   localStorage.setItem(RECEIPTS_KEY, JSON.stringify(next));
+  invalidateDashboardCache();
   return next;
 }
 
 export function removeReceipt(token: string): VerificationReceipt[] {
   const next = loadReceipts().filter((item) => item.token !== token);
   localStorage.setItem(RECEIPTS_KEY, JSON.stringify(next));
+  invalidateDashboardCache();
   return next;
 }
 
 export async function getDashboard(receipt?: VerificationReceipt | null): Promise<Dashboard> {
-  return jsonRequest<Dashboard>("/api/bootstrap", { method: "GET" }, receipt);
+  const identityKey = dashboardIdentityKey(receipt);
+  const now = Date.now();
+  if (
+    dashboardCache
+    && dashboardCache.identityKey === identityKey
+    && (dashboardCache.expiresAt > now || pageIsHidden())
+  ) {
+    return dashboardCache.value;
+  }
+  if (
+    dashboardRequest
+    && dashboardRequest.identityKey === identityKey
+    && dashboardRequest.epoch === dashboardCacheEpoch
+  ) {
+    return dashboardRequest.promise;
+  }
+
+  const epoch = dashboardCacheEpoch;
+  const promise = jsonRequest<Dashboard>("/api/bootstrap", { method: "GET" }, receipt)
+    .then((value) => {
+      if (dashboardCacheEpoch === epoch) {
+        dashboardCache = {
+          identityKey,
+          expiresAt: Date.now() + DASHBOARD_CLIENT_CACHE_MS,
+          value,
+        };
+      }
+      return value;
+    })
+    .finally(() => {
+      if (dashboardRequest?.promise === promise) dashboardRequest = null;
+    });
+  dashboardRequest = { identityKey, epoch, promise };
+  return promise;
 }
 
 export async function requestVerificationCode(email: string): Promise<{
@@ -249,10 +315,12 @@ export async function requestVerificationCode(email: string): Promise<{
 }
 
 export async function verifyEmail(challengeId: string, code: string): Promise<VerificationReceipt> {
-  return jsonRequest("/api/email/verify", {
+  const receipt = await jsonRequest<VerificationReceipt>("/api/email/verify", {
     method: "POST",
     body: JSON.stringify({ challengeId, code }),
   });
+  invalidateDashboardCache();
+  return receipt;
 }
 
 export async function createSubscription(
@@ -264,19 +332,25 @@ export async function createSubscription(
     termCode: SubscriptionTerm;
   },
 ): Promise<{ subscription: Subscription }> {
-  return jsonRequest("/api/subscriptions", {
+  const result = await jsonRequest<{ subscription: Subscription }>("/api/subscriptions", {
     method: "POST",
     body: JSON.stringify(payload),
   }, receipt);
+  invalidateDashboardCache();
+  return result;
 }
 
 export async function cancelSubscription(
   receipt: VerificationReceipt,
   subscriptionId: string,
 ): Promise<{ success: boolean }> {
-  return jsonRequest(`/api/subscriptions/${encodeURIComponent(subscriptionId)}`, {
-    method: "DELETE",
-  }, receipt);
+  const result = await jsonRequest<{ success: boolean }>(
+    `/api/subscriptions/${encodeURIComponent(subscriptionId)}`,
+    { method: "DELETE" },
+    receipt,
+  );
+  invalidateDashboardCache();
+  return result;
 }
 
 export async function startCoffeeInviteSession(
@@ -306,10 +380,19 @@ export async function redeemPriorityInvite(
   remindersToday: number;
   remainingToday: number;
 }> {
-  return jsonRequest("/api/priority/redeem", {
+  const result = await jsonRequest<{
+    success: boolean;
+    alreadyPriority?: boolean;
+    tier: DeliveryTier;
+    dailyLimit: number;
+    remindersToday: number;
+    remainingToday: number;
+  }>("/api/priority/redeem", {
     method: "POST",
     body: JSON.stringify({ code }),
   }, receipt);
+  invalidateDashboardCache();
+  return result;
 }
 
 export async function getCommunityUsers(

--- a/webapp/wrangler.jsonc
+++ b/webapp/wrangler.jsonc
@@ -25,7 +25,7 @@
     }
   ],
   "triggers": {
-    "crons": ["* * * * *"]
+    "crons": ["*/5 * * * *", "17 * * * *"]
   },
   "observability": {
     "enabled": true,


### PR DESCRIPTION
## Summary

Reduce Cloudflare Workers CPU, D1 usage, and front-end request volume without changing any venue watcher polling schedule.

### Preserved contracts

- 深圳湾 remains every 15 seconds with four parallel day tasks.
- 大湾区 remains every 30 seconds with three parallel day tasks.
- Existing single-task 30-second watchers remain every 30 seconds.
- 深圳市体育中心 remains every minute.
- Real slot, health, and error changes are forwarded immediately.
- Availability that disappears and then reappears is forwarded on the first matching poll.
- Subscriber email remains owned by the Web Worker.

### Changes

- Add an indexed observation fingerprint table.
  - The shared Airflow publisher derives a stable scope from the current task ID; watcher DAG schedules and call sites remain unchanged.
  - Ignore `checked_at` when deciding whether availability changed.
  - Forward changed observations immediately.
  - Forward unchanged observations once every five minutes as a health heartbeat.
  - Fail open for older publishers until Worker and Airflow ship from the same exact commit.
- Remove delivery reconciliation from every observation request.
- Split Worker cron load:
  - recent-first reconciliation every five minutes, batch 5;
  - legacy scheduled maintenance at minute 17 each hour, with no cron overlap.
- Cache `/api/bootstrap` through the Cloudflare Cache API for at most 120 seconds.
  - Cache URLs remain inside `zacks.claude89757.cc`.
  - The verification receipt is one-way hashed with the existing pepper and never appears in the cache URL.
  - Browser responses remain `Cache-Control: no-store`.
- Coalesce browser dashboard network requests for the same identity for 120 seconds.
  - The existing UI refresh loop remains responsive but normally reuses memory instead of calling the Worker.
  - Hidden pages reuse their cached dashboard.
  - Subscription create/cancel, receipt changes, verification, and priority redemption invalidate immediately.
- Count today's submitted digests from `email_delivery_claims` with a dedicated day/status index instead of repeatedly scanning `notification_outbox`.
- Add unit tests, migration tests, deployment runbook updates, and an incident/acceptance record.

## Free-tier budget

The unchanged Airflow schedules produce a theoretical maximum of 47,520 observation Worker requests per day. A continuously open browser identity is reduced from up to 2,880 bootstrap network requests per day to at most 720. This leaves request headroom while the indexed fingerprint gate removes the full D1 subscription/slot/outbox work from unchanged polls.

For unchanged observations, the expensive full-ingest path is reduced by about 95% for the 15-second tasks and 90% for 30-second tasks. Every real state change still bypasses the heartbeat throttle immediately.

Production acceptance still requires a 24-hour Cloudflare observation window because every Airflow poll intentionally remains a Worker request.

## Verification

- [x] Added Vitest coverage for observation fingerprinting, state round-trips, heartbeat behavior, private cache keys, client request coalescing, identity separation, cron routing, and cache invalidation.
- [x] Added Python coverage for Airflow task scopes and the D1 migration.
- [x] `CI / verify` passed on exact PR head `109f55101ba146469ede976afaea490ba4bd2730` (run `33004759604`).
- [x] CI passed lint, type checks, Python/Worker tests, Web verification, critical browser interactions, runtime drift checks, Airflow image build, and Airflow 3 DAG imports.
- [ ] Protected full-release preflight passes after the exact commit is on `main`.
- [ ] Production apply is separately authorized.
- [ ] Post-deploy 24-hour D1/Workers observation meets the incident thresholds.

## Production safety

This PR does **not** change an Airflow DAG schedule and does not send a real email or WeChat probe. Because the shared Airflow publisher changes, the eventual release scope must include both Web and Airflow from the same exact commit. The protected release workflow requires the target commit to be on `main`, so preflight intentionally remains pending while this PR is a draft. Do not merge or deploy without explicit approval.