### PR TITLE
fix(ops): support production Python in Airflow worktree repair

### DIFF
--- a/scripts/repair_airflow_worktree.py
+++ b/scripts/repair_airflow_worktree.py
@@ -140,11 +140,11 @@ METADATA_FILE="$metadata_file" \
 python3 - <<'PY'
 import json
 import os
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 metadata = {
     "backup_id": os.environ["BACKUP_ID"],
-    "created_at": datetime.now(UTC).isoformat(),
+    "created_at": datetime.now(timezone.utc).isoformat(),
     "current_commit": os.environ["CURRENT_COMMIT"],
     "operation_commit": os.environ["OPERATION_COMMIT"],
     "patch_sha256": os.environ["PATCH_SHA256"],

--- a/tests/airflow_worktree_repair_test.py
+++ b/tests/airflow_worktree_repair_test.py
@@ -42,6 +42,13 @@ class AirflowWorktreeRepairTest(TestCase):
         self.assertNotIn('"patch_file"', script)
         self.assertNotIn('"metadata_file"', script)
 
+    def test_remote_metadata_uses_python_3_8_compatible_utc(self) -> None:
+        script = repair_airflow_worktree.remote_script()
+
+        self.assertIn("from datetime import datetime, timezone", script)
+        self.assertIn("datetime.now(timezone.utc)", script)
+        self.assertNotIn("from datetime import UTC", script)
+
     def test_verification_accepts_repaired_and_already_clean_results(self) -> None:
         common = {
             "ok": True,


### PR DESCRIPTION
## Production failure

The protected Airflow preflight reached the new bounded worktree repair, but the production host's `python3` rejected `from datetime import UTC`. That alias was introduced after the host's Python version, so the repair stopped before reading or mutating the checkout.

## Fix

- Replace `datetime.UTC` with the Python 3.8-compatible `timezone.utc` API in the remote metadata writer.
- Add a regression contract proving the generated remote script does not import `UTC` and uses `datetime.now(timezone.utc)`.

## Safety

The bounded repair contract is unchanged: it still backs up exactly one tracked drift, preserves untracked files, verifies restoration, and does not restart services, mutate databases, or send notifications.