### PR TITLE
feat(webapp): give priority email reminders a 10-second lead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ and operational changes.
 
 ## Unreleased
 
+## [0.2.4] - 2026-08-28
+
+### Changed
+
+- Submit priority-user venue reminder digests before standard-user digests and
+  keep a full ten-second lead after the latest priority submission attempt
+  completes, including across concurrent Cloudflare Worker drains.
+- Keep email verification and subscription-expiry messages outside the reminder
+  priority gate, preserve every existing venue polling schedule, and defer a
+  standard reminder instead of submitting it early when priority work remains
+  active beyond one bounded Worker wait.
+
 ## [0.2.3] - 2026-08-23
 
 ### Changed

--- a/docs/adr/0013-priority-email-ten-second-lead.md
+++ b/docs/adr/0013-priority-email-ten-second-lead.md
@@ -1,0 +1,62 @@
+# ADR 0013: Priority Email Ten-Second Lead
+
+- Status: Accepted
+- Date: 2026-08-28
+
+## Context
+
+Subscriber reminder digests already resolve each normalized verified email to a
+standard or priority delivery tier. Priority recipients are ordered first and
+receive a larger daily allowance, but concurrent Cloudflare Worker drains can
+still submit a standard reminder immediately after, or alongside, a priority
+reminder. The product requires a visible delivery advantage: priority reminder
+submissions must complete first, followed by a ten-second lead before standard
+reminder submission begins.
+
+The change must preserve the existing Airflow venue polling schedules, Web-owned
+D1 outbox, provider budget, verification-email availability, and Cloudflare Free
+resource constraints.
+
+## Decision
+
+- Apply the lead only to subscriber venue-reminder digests. Verification codes,
+  subscription-expiry reminders, and other explicitly categorized system mail
+  remain immediate.
+- Before a standard reminder calls Tencent SES, query D1 for active priority
+  reminder work and the latest completed priority delivery claim.
+- Treat priority outbox rows in `processing`, or due rows in `pending`/`retry`,
+  as outstanding. A standard reminder rechecks while any such row exists.
+- After the latest priority SES submission attempt finishes, wait until the full
+  ten-second interval has elapsed. A provider-accepted attempt and a failed
+  attempt both close that attempt's priority window; a later priority retry
+  opens a new window and resets the lead.
+- Reuse `email_delivery_claims.updated_at` and the existing delivery-day indexes
+  as the completion clock. No D1 schema migration, new cron, or Airflow schedule
+  change is required.
+- Bound one Worker invocation's wait to fifteen seconds. If priority work remains
+  active beyond that bound, fail the standard submission before the provider
+  call so the existing outbox retry path defers it rather than sending early.
+- Never log an email address while evaluating or enforcing the gate.
+
+## Concurrency Semantics
+
+The D1 query coordinates independent Worker drains. It covers priority work that
+was already queued, leased, or completed when the standard reminder checks the
+lane. Work created after a standard reminder has passed its final gate cannot be
+predicted; it belongs to the next delivery wave. Within each observable wave,
+priority submissions finish first and standard submissions start no earlier
+than ten seconds after the most recent priority completion.
+
+## Consequences
+
+- Priority subscribers receive a deterministic ten-second submission lead over
+  standard subscribers in the same observable delivery wave.
+- Standard reminders may arrive later than ten seconds when priority traffic is
+  still active or a Worker invocation reaches its bounded wait. They are never
+  intentionally submitted early.
+- The gate adds only bounded, indexed D1 reads to reminder delivery. Waiting is
+  asynchronous and does not change venue-inspection frequency.
+- Verification and lifecycle mail are isolated from reminder-lane contention.
+- Production acceptance uses unit/type/build checks, exact-commit Web health,
+  and natural venue publication cycles. Routine verification must not send a
+  real email or inject a production slot.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wechat-on-airflow"
-version = "0.2.3"
+version = "0.2.4"
 description = "Airflow workflows for Shenzhen tennis availability notifications."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/src/wechat_airflow/__init__.py
+++ b/src/wechat_airflow/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime code for the production Airflow workflows."""
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/webapp/cloudflare/priority-email-delivery.test.ts
+++ b/webapp/cloudflare/priority-email-delivery.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PRIORITY_EMAIL_GATE_POLL_MS,
+  PRIORITY_EMAIL_LEAD_MS,
+  PriorityEmailWindowPendingError,
+  standardReminderWaitMs,
+  waitForSubscriberReminderWindow,
+  type PriorityEmailGateSnapshot,
+} from "./priority-email-delivery";
+
+const STANDARD_IDLE: PriorityEmailGateSnapshot = {
+  recipientTier: "standard",
+  priorityOutstanding: false,
+  lastPriorityCompletedAt: null,
+};
+
+describe("priority subscriber email lead", () => {
+  it("never delays the priority recipient", () => {
+    expect(standardReminderWaitMs({
+      recipientTier: "priority",
+      priorityOutstanding: true,
+      lastPriorityCompletedAt: 9_999,
+    }, 10_000)).toBe(0);
+  });
+
+  it("allows a standard reminder when there is no priority activity", () => {
+    expect(standardReminderWaitMs(STANDARD_IDLE, 10_000)).toBe(0);
+  });
+
+  it("waits the complete remaining lead after the latest priority completion", () => {
+    expect(standardReminderWaitMs({
+      recipientTier: "standard",
+      priorityOutstanding: false,
+      lastPriorityCompletedAt: 5_000,
+    }, 9_000)).toBe(6_000);
+    expect(standardReminderWaitMs({
+      recipientTier: "standard",
+      priorityOutstanding: false,
+      lastPriorityCompletedAt: 5_000,
+    }, 5_000 + PRIORITY_EMAIL_LEAD_MS)).toBe(0);
+  });
+
+  it("rechecks active priority work and restarts the ten-second window", async () => {
+    let current = 1_000;
+    const sleeps: number[] = [];
+    const snapshots: PriorityEmailGateSnapshot[] = [
+      {
+        recipientTier: "standard",
+        priorityOutstanding: true,
+        lastPriorityCompletedAt: null,
+      },
+      {
+        recipientTier: "standard",
+        priorityOutstanding: false,
+        lastPriorityCompletedAt: 2_000,
+      },
+      {
+        recipientTier: "standard",
+        priorityOutstanding: false,
+        lastPriorityCompletedAt: 2_000,
+      },
+    ];
+
+    await waitForSubscriberReminderWindow({}, "standard@example.com", {
+      now: () => current,
+      sleep: async (delayMs) => {
+        sleeps.push(delayMs);
+        current += delayMs;
+      },
+      readSnapshot: async () => snapshots.shift() ?? STANDARD_IDLE,
+    });
+
+    expect(sleeps).toEqual([PRIORITY_EMAIL_GATE_POLL_MS, PRIORITY_EMAIL_LEAD_MS]);
+    expect(current).toBe(12_000);
+  });
+
+  it("defers rather than sending a standard reminder early after the bounded wait", async () => {
+    let current = 0;
+    const maxWaitMs = 2_500;
+
+    await expect(waitForSubscriberReminderWindow({}, "standard@example.com", {
+      now: () => current,
+      sleep: async (delayMs) => {
+        current += delayMs;
+      },
+      readSnapshot: async () => ({
+        recipientTier: "standard",
+        priorityOutstanding: true,
+        lastPriorityCompletedAt: null,
+      }),
+      maxWaitMs,
+    })).rejects.toBeInstanceOf(PriorityEmailWindowPendingError);
+
+    expect(current).toBe(maxWaitMs);
+  });
+});

--- a/webapp/cloudflare/priority-email-delivery.ts
+++ b/webapp/cloudflare/priority-email-delivery.ts
@@ -1,0 +1,165 @@
+import {
+  normalizeDeliveryTier,
+  type DeliveryTier,
+} from "./delivery-tiers";
+
+export const SUBSCRIBER_REMINDER_CATEGORY = "场地提醒";
+export const PRIORITY_EMAIL_LEAD_MS = 10_000;
+export const PRIORITY_EMAIL_GATE_POLL_MS = 1_000;
+export const PRIORITY_EMAIL_GATE_MAX_WAIT_MS = 15_000;
+
+export type PriorityEmailGateEnv = {
+  DB?: D1Database;
+};
+
+export type PriorityEmailGateSnapshot = {
+  recipientTier: DeliveryTier;
+  priorityOutstanding: boolean;
+  lastPriorityCompletedAt: number | null;
+};
+
+type PriorityEmailGateRow = {
+  recipient_tier?: string;
+  priority_outstanding?: number;
+  last_priority_completed_at?: number | null;
+};
+
+type PriorityEmailWaitOptions = {
+  now?: () => number;
+  sleep?: (delayMs: number) => Promise<void>;
+  readSnapshot?: (now: number) => Promise<PriorityEmailGateSnapshot>;
+  maxWaitMs?: number;
+};
+
+export class PriorityEmailWindowPendingError extends Error {
+  readonly code = "priority_email_window_pending";
+  readonly retryAfterMs: number;
+
+  constructor(retryAfterMs = PRIORITY_EMAIL_GATE_POLL_MS) {
+    super("priority subscriber email window is still active");
+    this.name = "PriorityEmailWindowPendingError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+function shanghaiDeliveryDay(now: number): string {
+  return new Date(now + 8 * 3_600_000).toISOString().slice(0, 10);
+}
+
+export function standardReminderWaitMs(
+  snapshot: PriorityEmailGateSnapshot,
+  now: number,
+): number {
+  if (snapshot.recipientTier === "priority") return 0;
+  if (snapshot.priorityOutstanding) return PRIORITY_EMAIL_GATE_POLL_MS;
+  if (
+    snapshot.lastPriorityCompletedAt === null
+    || !Number.isFinite(snapshot.lastPriorityCompletedAt)
+  ) {
+    return 0;
+  }
+  return Math.max(
+    0,
+    Math.ceil(snapshot.lastPriorityCompletedAt + PRIORITY_EMAIL_LEAD_MS - now),
+  );
+}
+
+export async function readPriorityEmailGateSnapshot(
+  env: PriorityEmailGateEnv,
+  recipient: string,
+  now = Date.now(),
+): Promise<PriorityEmailGateSnapshot> {
+  if (!env.DB) {
+    return {
+      recipientTier: "standard",
+      priorityOutstanding: false,
+      lastPriorityCompletedAt: null,
+    };
+  }
+
+  const row = await env.DB.prepare(
+    `SELECT
+       CASE WHEN EXISTS (
+         SELECT 1
+           FROM user_delivery_tiers recipient_tier
+          WHERE recipient_tier.email = ?
+            AND recipient_tier.tier = 'priority'
+            AND recipient_tier.revoked_at IS NULL
+       ) THEN 'priority' ELSE 'standard' END AS recipient_tier,
+       EXISTS (
+         SELECT 1
+           FROM notification_outbox outbox
+           JOIN user_delivery_tiers tiers ON tiers.email = outbox.email
+          WHERE tiers.tier = 'priority'
+            AND tiers.revoked_at IS NULL
+            AND (
+              outbox.status = 'processing'
+              OR (
+                outbox.status IN ('pending', 'retry')
+                AND outbox.next_attempt_at <= ?
+              )
+            )
+          LIMIT 1
+       ) AS priority_outstanding,
+       (
+         SELECT MAX(claims.updated_at)
+           FROM email_delivery_claims claims
+           JOIN user_delivery_tiers tiers ON tiers.email = claims.email
+          WHERE claims.delivery_day = ?
+            AND claims.status IN ('sent', 'released')
+            AND claims.updated_at >= ?
+            AND tiers.tier = 'priority'
+            AND tiers.revoked_at IS NULL
+       ) AS last_priority_completed_at`,
+  ).bind(
+    recipient,
+    now,
+    shanghaiDeliveryDay(now),
+    now - PRIORITY_EMAIL_LEAD_MS,
+  ).first<PriorityEmailGateRow>();
+
+  const completedAt = Number(row?.last_priority_completed_at);
+  return {
+    recipientTier: normalizeDeliveryTier(row?.recipient_tier),
+    priorityOutstanding: Boolean(row?.priority_outstanding),
+    lastPriorityCompletedAt: row?.last_priority_completed_at === null
+      || row?.last_priority_completed_at === undefined
+      || !Number.isFinite(completedAt)
+      ? null
+      : completedAt,
+  };
+}
+
+export async function waitForSubscriberReminderWindow(
+  env: PriorityEmailGateEnv,
+  recipient: string,
+  options: PriorityEmailWaitOptions = {},
+): Promise<void> {
+  if (!env.DB && !options.readSnapshot) return;
+
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? ((delayMs: number) =>
+    new Promise<void>((resolve) => setTimeout(resolve, delayMs))
+  );
+  const readSnapshot = options.readSnapshot
+    ?? ((current: number) => readPriorityEmailGateSnapshot(env, recipient, current));
+  const configuredMaxWait = options.maxWaitMs ?? PRIORITY_EMAIL_GATE_MAX_WAIT_MS;
+  const maxWaitMs = Number.isFinite(configuredMaxWait)
+    ? Math.max(0, Math.trunc(configuredMaxWait))
+    : PRIORITY_EMAIL_GATE_MAX_WAIT_MS;
+  const startedAt = now();
+
+  while (true) {
+    const current = now();
+    const snapshot = await readSnapshot(current);
+    const waitMs = standardReminderWaitMs(snapshot, current);
+    if (waitMs <= 0) return;
+
+    const elapsed = Math.max(0, current - startedAt);
+    const remaining = maxWaitMs - elapsed;
+    if (remaining <= 0) {
+      throw new PriorityEmailWindowPendingError(waitMs);
+    }
+    await sleep(Math.min(waitMs, remaining));
+  }
+}

--- a/webapp/cloudflare/tencent-ses.test.ts
+++ b/webapp/cloudflare/tencent-ses.test.ts
@@ -15,6 +15,15 @@ const SECRETS = {
   EMAIL_TEMPLATE_ID: "33340",
 };
 
+function successfulSendResponse(messageId = "message-id"): Response {
+  return new Response(
+    JSON.stringify({
+      Response: { MessageId: messageId, RequestId: "request-id" },
+    }),
+    { status: 200 },
+  );
+}
+
 describe("Tencent SES TC3 request", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -23,14 +32,7 @@ describe("Tencent SES TC3 request", () => {
 
   it("matches the Tencent SDK canonical signed headers", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_785_249_600_000);
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          Response: { MessageId: "message-id", RequestId: "request-id" },
-        }),
-        { status: 200 },
-      ),
-    );
+    const fetchMock = vi.fn().mockResolvedValue(successfulSendResponse());
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await sendTencentTemplateEmail(
@@ -53,6 +55,57 @@ describe("Tencent SES TC3 request", () => {
     expect(headers["Content-Type"]).toBe("application/json");
     expect(headers.Authorization).toContain("SignedHeaders=content-type;host");
     expect(headers.Authorization).not.toContain("x-tc-action");
+  });
+
+  it("checks the D1 priority lane before a subscriber reminder", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_785_249_600_000);
+    const fetchMock = vi.fn().mockResolvedValue(successfulSendResponse("priority-aware"));
+    vi.stubGlobal("fetch", fetchMock);
+    const first = vi.fn().mockResolvedValue({
+      recipient_tier: "standard",
+      priority_outstanding: 0,
+      last_priority_completed_at: null,
+    });
+    const bind = vi.fn(() => ({ first }));
+    const prepare = vi.fn(() => ({ bind }));
+
+    const result = await sendTencentTemplateEmail(
+      { ...SECRETS, DB: { prepare } as unknown as D1Database },
+      "recipient@example.com",
+      "subject",
+      "body",
+    );
+
+    expect(result.messageId).toBe("priority-aware");
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(bind).toHaveBeenCalledWith(
+      "recipient@example.com",
+      1_785_249_600_000,
+      "2026-07-28",
+      1_785_249_590_000,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not gate verification and other explicit system categories", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_785_249_600_000);
+    const fetchMock = vi.fn().mockResolvedValue(successfulSendResponse("verification"));
+    vi.stubGlobal("fetch", fetchMock);
+    const prepare = vi.fn(() => {
+      throw new Error("priority gate must not run");
+    });
+
+    const result = await sendTencentTemplateEmail(
+      { ...SECRETS, DB: { prepare } as unknown as D1Database },
+      "recipient@example.com",
+      "subject",
+      "body",
+      "邮箱验证",
+    );
+
+    expect(result.messageId).toBe("verification");
+    expect(prepare).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("prefers the send date embedded in the provider MessageId", () => {

--- a/webapp/cloudflare/tencent-ses.ts
+++ b/webapp/cloudflare/tencent-ses.ts
@@ -1,3 +1,9 @@
+import {
+  SUBSCRIBER_REMINDER_CATEGORY,
+  waitForSubscriberReminderWindow,
+  type PriorityEmailGateEnv,
+} from "./priority-email-delivery";
+
 export type TencentSecrets = {
   TENCENT_SECRET_ID: string;
   TENCENT_SECRET_KEY: string;
@@ -6,6 +12,8 @@ export type TencentSecrets = {
   EMAIL_REPLY_TO: string;
   EMAIL_TEMPLATE_ID: string;
 };
+
+type TencentEmailEnv = TencentSecrets & PriorityEmailGateEnv;
 
 export type TencentEmailStatus = {
   MessageId?: string;
@@ -101,12 +109,19 @@ async function callTencentSes<T>(
 }
 
 export async function sendTencentTemplateEmail(
-  env: TencentSecrets,
+  env: TencentEmailEnv,
   recipient: string,
   subject: string,
   body: string,
-  category = "场地提醒",
+  category = SUBSCRIBER_REMINDER_CATEGORY,
 ): Promise<{ messageId: string | null; requestId: string | null }> {
+  // Only subscriber venue reminders participate in the priority lane. Email
+  // verification and expiry/system mail pass an explicit category and remain
+  // immediate so a reminder backlog cannot delay account access or lifecycle mail.
+  if (category === SUBSCRIBER_REMINDER_CATEGORY) {
+    await waitForSubscriberReminderWindow(env, recipient);
+  }
+
   const result = await callTencentSes<{ MessageId?: string }>(env, "SendEmail", {
     FromEmailAddress: env.EMAIL_FROM_ADDRESS,
     Destination: [recipient],


### PR DESCRIPTION
## Summary

- gate subscriber venue-reminder SES submissions on the current D1 priority lane
- send priority recipients immediately, then wait a full 10 seconds after the latest priority submission attempt completes before standard reminders proceed
- coordinate concurrent Worker drains through existing outbox and delivery-claim state without a new migration or cron
- keep verification and subscription-expiry mail outside the gate
- release as `0.2.4`

## Safety invariants

- no Airflow DAG or venue polling schedule changes
- no WeChat sender changes
- no D1 schema migration or destructive data operation
- no real email, fake subscription, or injected production slot in tests/acceptance
- standard reminders defer rather than call Tencent SES early when the bounded Worker wait is exhausted

## Verification

- new timing and contention unit tests
- SES integration tests for D1 gating and system-category bypass
- existing Web Worker type checks, Vitest suite, build, release-contract, workflow-contract, and scope-planning checks via `CI / verify`

## Production plan

After exact-commit CI succeeds and this PR is merged, use Issue #39:

`/release ship 0.2.4 <merge-sha> scope=auto sender=false`

Expected resolved runtime scope: `webapp` only.