### PR TITLE
docs(ops): 记录 0.3.0 大沙河国际网球中心生产基线

### DIFF
--- a/docs/production-baseline.md
+++ b/docs/production-baseline.md
@@ -1,5 +1,39 @@
 # Production Baseline
 
+## Dashah International Tennis Center On 2026-08-29
+
+Release `0.3.0` is
+`5bc7427b2fbfd2d0d65f9d96dc91929ceb597964` (PR #94). Web and Airflow both
+run that SHA. Sender was out of scope and was not redeployed.
+
+The paid Dashah International Tennis Center venue (`dsh` /
+`大沙河国际网球中心`) is on the public catalog. Unauthenticated
+`/api/bootstrap` returns nine venues and no email address. The production UI
+lists the venue and shows a healthy inspection. Creating a subscription still
+requires email verification; no verification email or live WeChat probe was
+sent.
+
+`PI_DEVICE_SSH` was seeded through the protected `pi_device_ssh_sync`
+operation before Airflow apply. The 3-minute DAG
+`大沙河国际网球中心巡检` produced three consecutive natural successes
+(`12:32`, `12:35`, `12:38` UTC) and published healthy observations. Web
+`lastInspectionAt` for `dsh` continued to refresh during the observation
+window.
+
+CI `verify` on the exact SHA is run `33252143707`. The first ship attempt
+(`33252303428`) applied D1 migration `0010_add_dsh_venue.sql` and uploaded
+the Worker, then failed health because the custom domain still served the
+previous Worker for a few seconds. After propagation, Web health reported
+nine venues and the exact SHA. The successful ship is
+`33252429294`. Post-observe Airflow health passed with no paused DAGs, no
+missing Variables, and no recent-run failures. Historical WeChat fallback
+outbox records remain and were not replayed.
+
+Rollback remains the previous named release `0.2.4`
+(`ef12280fbff7b8e367a5fb81573bb8117232fee0`) without replacing the Airflow 3
+database. Re-apply that commit through the protected Web and Airflow
+workflows.
+
 ## Zacks Phone Reboot Every Two Days On 2026-08-23
 
 The `zacks_phone_daily_reboot` schedule changed from daily to every other day


### PR DESCRIPTION
## Change

记录 `0.3.0` 生产基线：Web 九场含 `dsh`、Airflow 三轮自然巡检成功、回滚到 `0.2.4`。

## Risk

仅文档。不改变运行时。

## Verification

- [x] 生产 Web 健康为 9 个场地且精确 SHA
- [x] `大沙河国际网球中心巡检` 连续 3 次 success
- [x] 未发送真实通知

## Deployment

文档合入即可，无需再发版。


Made with [Cursor](https://cursor.com)