### PR TITLE
feat(venue): 接入PICKLE POP宝安网球场订阅与巡检

### DIFF
--- a/.agents/skills/operate-tennis-alerts/references/release-paths.md
+++ b/.agents/skills/operate-tennis-alerts/references/release-paths.md
@@ -61,7 +61,7 @@ component identities are recorded independently.
 Verify:
 
 - `/api/healthz` reports healthy and the expected Web deployment commit;
-- unauthenticated `/api/bootstrap` exposes nine venues and no email address;
+- unauthenticated `/api/bootstrap` exposes ten venues and no email address;
 - unauthenticated observation writes return HTTP 401;
 - mobile subscription and critical interaction tests pass.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,6 +60,12 @@ both on sale and backed by a non-empty free-court list. The Web application
 therefore never infers a free release from an ordinary empty calendar date.
 Best-effort WeChat for this venue goes only to `Zacks_大沙河限定免费`.
 
+TOPS, 泛思博特福中福, and PICKLE POP宝安 share the public PosPal appointment
+API. Each adapter carries its own store ID and project UID. PICKLE POP宝安
+publishes tennis courts only and never treats pickleball rooms as tennis
+availability. WeChat for these paid venues uses the shared
+`SZ_TENNIS_CHATROOMS` list.
+
 Dashah International Tennis Center is a paid YDMap H5 venue. Airflow does not
 open the booking page itself. A Raspberry Pi scrape host runs Chromium on a
 private loopback HTTP service; the venue watcher SSHes to that host, curls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ and operational changes.
 
 ## Unreleased
 
+## [0.4.0] - 2026-08-29
+
+### Added
+
+- Add PICKLE POP Bao'an (`ppba`) to the Web subscription catalog and a
+  30-second Airflow inspection DAG on the same public PosPal booking API as
+  TOPS and Fansibote Fuzhongfu.
+- Publish tennis-only availability to the Web app and send best-effort WeChat
+  alerts to the shared Zacks chatrooms. Pickleball courts stay out of tennis
+  observations.
+
 ## [0.3.0] - 2026-08-29
 
 ### Added

--- a/README.en.md
+++ b/README.en.md
@@ -12,7 +12,7 @@
 
 ## ✨ Features
 
-- **Multi-venue polling**: 9 Shenzhen venue DAGs (Shenzhen Bay at 15s intervals, Greater Bay Area, Dashah River free courts, Dashah International Tennis Center, Jindi, Shangyue Shahe, TOPS, Fansibote Fuzhongfu, Sports Center) + HTTPS proxy watchers + daily device maintenance
+- **Multi-venue polling**: 10 Shenzhen venue DAGs (Shenzhen Bay at 15s intervals, Greater Bay Area, Dashah River free courts, Dashah International Tennis Center, Jindi, Shangyue Shahe, TOPS, Fansibote Fuzhongfu, PICKLE POP Bao'an, Sports Center) + HTTPS proxy watchers + daily device maintenance
 - **Email subscriptions**: a Cloudflare Worker web app owns email verification, subscription matching, event deduplication, and retries (delivered via Tencent SES)
 - **WeChat alerts**: an independent sender on the Android device host (systemd + Appium) delivers best-effort messages; failures are isolated per chat and never block the email path
 - **Configuration as contract**: machine-readable component/config/runtime contracts under `config/`; DAGs only wire schedules while business logic lives in `src/`
@@ -33,7 +33,7 @@ flowchart TB
         SZ["Shenzhen Bay / GBA booking API"]
         NSWTT["NSWTT Dashah River free courts"]
         YDMAP["YDMap Dashah International Tennis Center (Raspberry Pi browser)"]
-        VENUES["Jindi / Shangyue Shahe / TOPS / Fansibote Fuzhongfu / Sports Center"]
+        VENUES["Jindi / Shangyue Shahe / TOPS / Fansibote Fuzhongfu / PICKLE POP Bao'an / Sports Center"]
         PROXY["Public proxy sources + GitHub proxy repo"]
     end
 
@@ -110,7 +110,7 @@ Public endpoints: Airflow console `https://airflow.claude89757.cc` · subscripti
 ```
 ├── dags/                       # Production DAGs (wiring only, <120 lines each)
 │   └── tennis_dags/
-│       ├── sz_tennis/          # Shenzhen venue watchers (Shenzhen Bay / GBA / Dashah River free courts / Dashah International Tennis Center / Jindi / Shangyue Shahe / TOPS / Fansibote Fuzhongfu / Sports Center)
+│       ├── sz_tennis/          # Shenzhen venue watchers (Shenzhen Bay / GBA / Dashah River free courts / Dashah International Tennis Center / Jindi / Shangyue Shahe / TOPS / Fansibote Fuzhongfu / PICKLE POP Bao'an / Sports Center)
 │       ├── proxy_tools/        # HTTPS proxy watchers (every 5 minutes)
 │       └── zacks_phone_reboot_dag.py  # Device maintenance every two days
 ├── pi_host/                    # Raspberry Pi scrape host (YDMap browser inspection)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## ✨ 功能特性
 
-- **多场馆自动巡检**：9 个深圳场馆巡检 DAG（深圳湾 15s 高频、大湾区、大沙河免费场、大沙河国际网球中心、金地、上越沙河、TOPS、泛思博特福中福、体育中心）+ HTTPS 代理巡检 + 每日设备维护
+- **多场馆自动巡检**：10 个深圳场馆巡检 DAG（深圳湾 15s 高频、大湾区、大沙河免费场、大沙河国际网球中心、金地、上越沙河、TOPS、泛思博特福中福、PICKLE POP宝安、体育中心）+ HTTPS 代理巡检 + 每日设备维护
 - **邮箱订阅推送**：Cloudflare Worker Web 应用全权负责邮箱验证、订阅匹配、事件去重与失败重试（Tencent SES 投递）
 - **微信群提醒**：Android 设备宿主上的独立 WeChat Sender（systemd + Appium），best-effort 投递，失败按群隔离记录，不影响邮件链路
 - **代码即契约**：`config/` 下的机器可读组件/配置/运行时契约；DAG 仅做调度编排，业务实现全部位于 `src/` 包
@@ -33,7 +33,7 @@ flowchart TB
         SZ["深圳湾 / 大湾区订场 API"]
         NSWTT["NSWTT 大沙河免费场"]
         YDMAP["YDMap 大沙河国际网球中心（树莓派浏览器）"]
-        VENUES["金地 / 上越沙河 / TOPS / 泛思博特福中福 / 体育中心"]
+        VENUES["金地 / 上越沙河 / TOPS / 泛思博特福中福 / PICKLE POP宝安 / 体育中心"]
         PROXY["公共代理源 + GitHub 代理仓库"]
     end
 
@@ -110,7 +110,7 @@ flowchart TB
 ```
 ├── dags/                       # 生产 DAG（仅调度编排，单文件 <120 行）
 │   └── tennis_dags/
-│       ├── sz_tennis/          # 深圳场馆巡检：深圳湾 / 大湾区 / 大沙河免费场 / 大沙河国际网球中心 / 金地 / 上越沙河 / TOPS / 泛思博特福中福 / 体育中心
+│       ├── sz_tennis/          # 深圳场馆巡检：深圳湾 / 大湾区 / 大沙河免费场 / 大沙河国际网球中心 / 金地 / 上越沙河 / TOPS / 泛思博特福中福 / PICKLE POP宝安 / 体育中心
 │       ├── proxy_tools/        # HTTPS 代理巡检（每 5 分钟）
 │       └── zacks_phone_reboot_dag.py  # 每两天设备维护
 ├── pi_host/                    # 树莓派采集服务（YDMap 浏览器巡检）

--- a/config/active-components.yaml
+++ b/config/active-components.yaml
@@ -351,6 +351,38 @@ active_dags:
       - wechat_dedupe_cache_written_before_wechat_delivery
       - webapp_observation_precedes_wechat
 
+  - dag_id: PICKLEPOP宝安网球场巡检
+    file: dags/tennis_dags/sz_tennis/ppba_watcher.py
+    schedule: every_30_seconds
+    tasks:
+      - check_tennis_courts
+    variables:
+      - PPBA_PROXY_CACHE
+      - SZ_TENNIS_CHATROOMS
+      - WEBAPP_OBSERVATION_API_TOKEN
+      - WEBAPP_OBSERVATION_API_URL
+      - WEBAPP_OBSERVATION_TIMEOUT_SECONDS
+      - PICKLEPOP宝安网球场
+    connections: []
+    direct_modules:
+      - wechat_airflow.venues.ppba_watcher
+      - wechat_airflow.notifications.webapp
+      - wechat_airflow.notifications.wechat
+    external_services:
+      - ppba_booking_api
+      - public_proxy_list
+      - zacks_tennis_webapp
+      - wechat_sender_api
+    notifications:
+      - webapp_observation
+      - wechat
+    purpose: Detect and notify PICKLE POP Bao'an tennis availability, excluding pickleball courts.
+    verification:
+      - dag_imports
+      - recent_runs_succeed
+      - wechat_dedupe_cache_written_before_wechat_delivery
+      - webapp_observation_precedes_wechat
+
   - dag_id: 深圳市体育中心网球场巡检
     file: dags/tennis_dags/sz_tennis/tyzx_watcher.py
     schedule: "*/1 * * * *"

--- a/config/config-contracts.yaml
+++ b/config/config-contracts.yaml
@@ -61,6 +61,12 @@ variables:
     sensitive: false
     managed_by_application: true
     fresh_start_policy: preserve
+  PPBA_PROXY_CACHE:
+    type: json_list
+    required_by: [PICKLEPOP宝安网球场巡检]
+    sensitive: false
+    managed_by_application: true
+    fresh_start_policy: preserve
   TYZX_SUCCESSFUL_PROXIES_CACHE:
     type: json_list
     required_by: [深圳市体育中心网球场巡检]
@@ -76,6 +82,7 @@ variables:
       - 上越沙河网球场巡检
       - TOPS科技园网球场巡检
       - 泛思博特福中福网球场巡检
+      - PICKLEPOP宝安网球场巡检
       - 大沙河国际网球中心巡检
     sensitive: true
   SZ_TYZX_TENNIS_CHATROOMS:
@@ -145,6 +152,13 @@ variables:
   泛思博特福中福网球场:
     type: json_list
     required_by: [泛思博特福中福网球场巡检]
+    sensitive: false
+    managed_by_application: true
+    fresh_start_policy: preserve
+    default: []
+  PICKLEPOP宝安网球场:
+    type: json_list
+    required_by: [PICKLEPOP宝安网球场巡检]
     sensitive: false
     managed_by_application: true
     fresh_start_policy: preserve

--- a/config/runtime-target.yaml
+++ b/config/runtime-target.yaml
@@ -56,7 +56,7 @@ managed_services:
     public_hostname: zacks.claude89757.cc
     public_base_url: https://zacks.claude89757.cc
     health_path: /api/healthz
-    expected_venue_count: 9
+    expected_venue_count: 10
     deployment_owner: github_actions
   cloudflare_tunnel:
     runtime: systemd

--- a/dags/tennis_dags/sz_tennis/ppba_watcher.py
+++ b/dags/tennis_dags/sz_tennis/ppba_watcher.py
@@ -1,0 +1,33 @@
+import datetime
+from datetime import timedelta
+from zoneinfo import ZoneInfo
+
+from airflow.providers.standard.operators.python import PythonOperator
+from airflow.sdk import DAG
+
+from wechat_airflow.venues.ppba_watcher import run_check_tennis_courts
+
+DEFAULT_ARGS = {
+    "owner": "claude89757",
+    "depends_on_past": False,
+    "start_date": datetime.datetime(2024, 1, 1, tzinfo=ZoneInfo("Asia/Shanghai")),
+    "email_on_failure": False,
+    "email_on_retry": False,
+}
+
+dag = DAG(
+    "PICKLEPOP宝安网球场巡检",
+    default_args=DEFAULT_ARGS,
+    description="PICKLEPOP宝安网球场巡检 - Pospal平台",
+    schedule=timedelta(seconds=30),
+    max_active_runs=1,
+    dagrun_timeout=timedelta(minutes=10),
+    catchup=False,
+    tags=["深圳"],
+)
+
+check_tennis_courts = PythonOperator(
+    task_id="check_tennis_courts",
+    python_callable=run_check_tennis_courts,
+    dag=dag,
+)

--- a/docs/runbooks/configuration.md
+++ b/docs/runbooks/configuration.md
@@ -58,12 +58,14 @@ not an email event. Only zero-price slices with `status=200` are published.
 
 ## PosPal Venue Booking
 
-TOPS and 泛思博特福中福 query the same public PosPal appointment endpoint with a
-store ID and project UID that live in the adapter. They do not use a login
-token or visitor header, so no additional Airflow secret is required when the
-venue is added. WeChat alerts use the shared `SZ_TENNIS_CHATROOMS` list.
-Application-managed `TOPS_PROXY_CACHE`, `FSB_PROXY_CACHE`, and the venue
-dedupe caches are created on the first successful run.
+TOPS, 泛思博特福中福, and PICKLE POP宝安 query the same public PosPal
+appointment endpoint with a store ID and project UID that live in the adapter.
+They do not use a login token or visitor header, so no additional Airflow
+secret is required when the venue is added. WeChat alerts use the shared
+`SZ_TENNIS_CHATROOMS` list. PICKLE POP宝安 publishes tennis courts only and
+drops pickleball rooms. Application-managed `TOPS_PROXY_CACHE`,
+`FSB_PROXY_CACHE`, `PPBA_PROXY_CACHE`, and the venue dedupe caches are created
+on the first successful run.
 
 ## Raspberry Pi YDMap Scraper
 

--- a/docs/runbooks/webapp-deployment.md
+++ b/docs/runbooks/webapp-deployment.md
@@ -98,7 +98,7 @@ D1 migration commands are intentionally unsupported.
 ## Verify
 
 - `/api/healthz` returns `ok: true` and the exact release commit.
-- `/api/bootstrap` returns nine venues and no email addresses.
+- `/api/bootstrap` returns ten venues and no email addresses.
 - An unauthenticated observation write returns HTTP 401.
 - Natural venue DAG runs keep their existing 15-second, 30-second, and one-minute
   schedules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wechat-on-airflow"
-version = "0.3.0"
+version = "0.4.0"
 description = "Airflow workflows for Shenzhen tennis availability notifications."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/scripts/quiesce_wechat_delivery.py
+++ b/scripts/quiesce_wechat_delivery.py
@@ -17,6 +17,7 @@ WECHAT_DAG_IDS = (
     "上越沙河网球场巡检",
     "TOPS科技园网球场巡检",
     "泛思博特福中福网球场巡检",
+    "PICKLEPOP宝安网球场巡检",
     "深圳市体育中心网球场巡检",
     "大沙河国际网球中心巡检",
 )
@@ -242,7 +243,7 @@ import sys
 
 state = json.loads(os.environ.pop("STATE_RESULT"))
 verification = json.loads(os.environ.pop("VERIFICATION"))
-expected_paused = 8
+expected_paused = 9
 ok = (
     verification.get("paused_wechat_dags") == expected_paused
     and verification.get("active_wechat_task_instances") == 0

--- a/src/wechat_airflow/__init__.py
+++ b/src/wechat_airflow/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime code for the production Airflow workflows."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/wechat_airflow/venues/ppba_watcher.py
+++ b/src/wechat_airflow/venues/ppba_watcher.py
@@ -1,0 +1,409 @@
+"""PICKLEPOP宝安网球场巡检 — 银豹/PosPal 场地预约。"""
+
+from __future__ import annotations
+
+import datetime
+import random
+import time
+from typing import TypedDict, cast
+
+import requests
+import urllib3
+from airflow.sdk import Variable
+
+from wechat_airflow.notifications.webapp import (
+    flatten_court_slots,
+    publish_venue_observation,
+)
+from wechat_airflow.notifications.wechat import send_wechat_text_to_chatrooms_best_effort
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+STORE_ID = "5972810"
+PROJECT_UID = "1758968368384975712"
+VENUE_ID = "ppba"
+VENUE_NAME = "PICKLE POP宝安"
+CACHE_KEY = "PICKLEPOP宝安网球场"
+PROXY_CACHE_KEY = "PPBA_PROXY_CACHE"
+DAG_ID = "PICKLEPOP宝安网球场巡检"
+API_URL = "https://wxservice-stg48.pospal.cn/wxapi/AppointmentVenue/LoadValidClassRoomApptSettingV2"
+PROXY_LIST_URL = (
+    "https://raw.githubusercontent.com/claude89757/free_https_proxies/main/https_proxies.txt"
+)
+LOOKAHEAD_DAYS = 3
+MAX_CACHED_PROXIES = 10
+MAX_CACHED_MESSAGES = 100
+
+
+class NotificationCourt(TypedDict):
+    date: str
+    court_name: str
+    free_slot_list: list[list[str]]
+
+
+CourtAvailability = dict[str, list[list[str]]]
+
+
+def print_with_timestamp(*args: object) -> None:
+    timestamp = time.strftime("[%Y-%m-%d %H:%M:%S]", time.localtime())
+    print(timestamp, *args)
+
+
+def _as_mapping(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return {str(key): item for key, item in value.items()}
+    return {}
+
+
+def _as_str_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def normalize_court_name(value: object) -> str:
+    return " ".join(str(value or "未知场地").split())
+
+
+def is_tennis_court(court_name: str) -> bool:
+    return "网球" in court_name
+
+
+def normalize_time(time_str: str) -> str:
+    if not time_str:
+        return time_str
+    parts = time_str.split(":")
+    if len(parts) == 2:
+        return f"{int(parts[0]):02d}:{int(parts[1]):02d}"
+    return time_str
+
+
+def merge_time_ranges(data: list[list[str]]) -> list[list[str]]:
+    if not data:
+        return data
+
+    def time_to_minutes(time_str: str) -> int:
+        return int(time_str[:2]) * 60 + int(time_str[3:])
+
+    data_in_minutes = sorted((time_to_minutes(start), time_to_minutes(end)) for start, end in data)
+    merged: list[tuple[int, int]] = []
+    start, end = data_in_minutes[0]
+    for next_start, next_end in data_in_minutes[1:]:
+        if next_start <= end:
+            end = max(end, next_end)
+        else:
+            merged.append((start, end))
+            start, end = next_start, next_end
+    merged.append((start, end))
+    return [
+        [f"{item[0] // 60:02d}:{item[0] % 60:02d}", f"{item[1] // 60:02d}:{item[1] % 60:02d}"]
+        for item in merged
+    ]
+
+
+def parse_slot_time(begin_datetime: str, end_datetime: str) -> list[str]:
+    begin_dt = datetime.datetime.strptime(begin_datetime, "%Y-%m-%d %H:%M:%S")
+    end_dt = datetime.datetime.strptime(end_datetime, "%Y-%m-%d %H:%M:%S") + datetime.timedelta(
+        minutes=1
+    )
+    start_time = begin_dt.strftime("%H:%M")
+    end_time = "24:00" if end_dt.date() > begin_dt.date() else end_dt.strftime("%H:%M")
+    return [normalize_time(start_time), normalize_time(end_time)]
+
+
+def parse_availability(json_data: object) -> CourtAvailability:
+    payload = _as_mapping(json_data)
+    result = _as_mapping(payload.get("result"))
+    slots = result.get("slots")
+    court_availability: dict[str, list[list[str]]] = {}
+    if not isinstance(slots, list):
+        return {}
+
+    for raw_slot in slots:
+        slot = _as_mapping(raw_slot)
+        appt_info = _as_mapping(slot.get("apptInfo"))
+        if appt_info.get("canApptOrNot") is not True:
+            continue
+        court_name = normalize_court_name(slot.get("classRoomName"))
+        if not is_tennis_court(court_name):
+            continue
+        begin_datetime = slot.get("beginDatetime")
+        end_datetime = slot.get("endDatetime")
+        if not isinstance(begin_datetime, str) or not isinstance(end_datetime, str):
+            continue
+        try:
+            slot_time = parse_slot_time(begin_datetime, end_datetime)
+        except Exception as error:
+            print(
+                f"解析 {VENUE_NAME} 时段失败: "
+                f"{court_name} {begin_datetime}-{end_datetime}, 错误: {error}"
+            )
+            continue
+        court_availability.setdefault(court_name, []).append(slot_time)
+
+    return {
+        court_name: merge_time_ranges(ranges) for court_name, ranges in court_availability.items()
+    }
+
+
+def parse_end_time_for_duration(end_time: str) -> datetime.datetime:
+    if end_time == "24:00":
+        return datetime.datetime.strptime("23:59", "%H:%M") + datetime.timedelta(minutes=1)
+    return datetime.datetime.strptime(end_time, "%H:%M")
+
+
+def parse_end_time_for_overlap(end_time: str) -> datetime.datetime:
+    if end_time == "24:00":
+        return datetime.datetime.strptime("22:00", "%H:%M")
+    return datetime.datetime.strptime(end_time, "%H:%M")
+
+
+def filter_court_data_for_notification(
+    input_date: str, court_data: CourtAvailability
+) -> list[NotificationCourt]:
+    up_for_send_data_list: list[NotificationCourt] = []
+    inform_date = datetime.datetime.strptime(input_date, "%Y-%m-%d").strftime("%m-%d")
+    check_date = datetime.datetime.strptime(input_date, "%Y-%m-%d")
+    is_weekend = check_date.weekday() >= 5
+    if is_weekend:
+        target_start = datetime.datetime.strptime("16:00", "%H:%M")
+        target_end = datetime.datetime.strptime("22:00", "%H:%M")
+    else:
+        target_start = datetime.datetime.strptime("18:00", "%H:%M")
+        target_end = datetime.datetime.strptime("22:00", "%H:%M")
+
+    for court_name, free_slots in court_data.items():
+        if not free_slots or not is_tennis_court(court_name):
+            continue
+        filtered_slots: list[list[str]] = []
+        for slot in free_slots:
+            start_time = datetime.datetime.strptime(slot[0], "%H:%M")
+            duration_minutes = (
+                parse_end_time_for_duration(slot[1]) - start_time
+            ).total_seconds() / 60
+            if duration_minutes < 60:
+                print(f"slot: {slot}, duration_minutes: {duration_minutes}, skip")
+                continue
+            end_time_for_overlap = parse_end_time_for_overlap(slot[1])
+            if max(start_time, target_start) < min(end_time_for_overlap, target_end):
+                filtered_slots.append(slot)
+        if filtered_slots:
+            up_for_send_data_list.append(
+                {
+                    "date": inform_date,
+                    "court_name": f"{VENUE_NAME}{court_name}",
+                    "free_slot_list": filtered_slots,
+                }
+            )
+    return up_for_send_data_list
+
+
+def build_new_notifications(
+    up_for_send_data_list: list[NotificationCourt],
+    sended_msg_list: list[str],
+    current_year: int | None = None,
+) -> list[str]:
+    if current_year is None:
+        current_year = datetime.datetime.now().year
+    up_for_send_msg_list: list[str] = []
+    for data in up_for_send_data_list:
+        date_obj = datetime.datetime.strptime(f"{current_year}-{data['date']}", "%Y-%m-%d")
+        weekday_str = ["一", "二", "三", "四", "五", "六", "日"][date_obj.weekday()]
+        for free_slot in data["free_slot_list"]:
+            notification = (
+                f"【{data['court_name']}】星期{weekday_str}({data['date']})空场: "
+                f"{free_slot[0]}-{free_slot[1]}"
+            )
+            if notification not in sended_msg_list:
+                up_for_send_msg_list.append(notification)
+    return up_for_send_msg_list
+
+
+def update_proxy_cache(proxy: str, success: bool) -> list[str]:
+    try:
+        cached_proxies = _as_str_list(
+            Variable.get(PROXY_CACHE_KEY, deserialize_json=True, default=[])
+        )
+    except Exception:
+        cached_proxies = []
+
+    if success:
+        if proxy not in cached_proxies:
+            cached_proxies.insert(0, proxy)
+            cached_proxies = cached_proxies[:MAX_CACHED_PROXIES]
+            print(f"添加成功代理到缓存: {proxy}")
+    elif proxy in cached_proxies:
+        cached_proxies.remove(proxy)
+        print(f"从缓存中移除失败代理: {proxy}")
+
+    Variable.set(PROXY_CACHE_KEY, cached_proxies, serialize_json=True)
+    return cached_proxies
+
+
+def get_tennis_court_availability(date: str, proxy_list: list[str]) -> CourtAvailability:
+    got_response = False
+    response: requests.Response | None = None
+    successful_proxy: str | None = None
+    try:
+        cached_proxies = _as_str_list(
+            Variable.get(PROXY_CACHE_KEY, deserialize_json=True, default=[])
+        )
+    except Exception:
+        cached_proxies = []
+
+    remaining_proxies = [proxy for proxy in proxy_list if proxy not in cached_proxies]
+    random.shuffle(remaining_proxies)
+    all_proxies_to_try = cached_proxies + remaining_proxies
+    print(
+        f"总共尝试代理数量: {len(all_proxies_to_try)} "
+        f"(缓存: {len(cached_proxies)}, 其他: {len(remaining_proxies)})"
+    )
+
+    headers = {
+        "STOREID": STORE_ID,
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "dateTime": date,
+        "projectUid": PROJECT_UID,
+    }
+
+    for index, proxy in enumerate(all_proxies_to_try):
+        print(f"尝试第 {index + 1} 个代理: {proxy}")
+        try:
+            candidate = requests.post(
+                API_URL,
+                headers=headers,
+                json=payload,
+                proxies={"https": proxy},
+                verify=False,
+                timeout=8,
+            )
+            if candidate.status_code != 200:
+                print(f"代理失败: {proxy}, HTTP状态码: {candidate.status_code}")
+                update_proxy_cache(proxy, False)
+                continue
+            json_data = cast(object, candidate.json())
+            payload_data = _as_mapping(json_data)
+            if payload_data.get("successed") is True and payload_data.get("status") == "success":
+                result_data = _as_mapping(payload_data.get("result"))
+                slots = result_data.get("slots")
+                rooms = result_data.get("validClassRooms")
+                print(
+                    f"{VENUE_NAME} API返回成功: "
+                    f"slots={len(slots) if isinstance(slots, list) else 0}, "
+                    f"rooms={len(rooms) if isinstance(rooms, list) else 0}"
+                )
+                got_response = True
+                successful_proxy = proxy
+                response = candidate
+                time.sleep(1)
+                break
+            print(f"代理失败: {proxy}, API返回错误: {payload_data.get('status')}")
+            update_proxy_cache(proxy, False)
+        except Exception as error:
+            print(f"代理异常: {proxy}, 错误: {error}")
+            update_proxy_cache(proxy, False)
+
+    if successful_proxy:
+        update_proxy_cache(successful_proxy, True)
+    if got_response and response is not None:
+        return parse_availability(cast(object, response.json()))
+    raise Exception("all proxies failed")
+
+
+def load_proxy_list() -> list[str]:
+    try:
+        response = requests.get(PROXY_LIST_URL, timeout=10, verify=False)
+        proxy_list = [line.strip() for line in response.text.strip().split("\n") if line.strip()]
+        random.shuffle(proxy_list)
+        print(f"Loaded {len(proxy_list)} proxies from {PROXY_LIST_URL}")
+        return proxy_list
+    except Exception as error:
+        print(f"获取代理列表失败: {error}")
+        return []
+
+
+def print_court_data(input_date: str, court_data: CourtAvailability) -> None:
+    print_with_timestamp(f"=== {input_date} 可预订场地详细信息 ===")
+    if court_data:
+        for court_name, free_slots in court_data.items():
+            print_with_timestamp(f"【{court_name}】:")
+            if free_slots:
+                for slot in free_slots:
+                    duration_minutes = (
+                        parse_end_time_for_duration(slot[1])
+                        - datetime.datetime.strptime(slot[0], "%H:%M")
+                    ).total_seconds() / 60
+                    print_with_timestamp(
+                        f"  - {slot[0]}-{slot[1]} (时长: {int(duration_minutes)}分钟)"
+                    )
+            else:
+                print_with_timestamp("  - 无可预订时间段")
+    else:
+        print_with_timestamp("无可预订场地数据")
+    print_with_timestamp("=" * 50)
+
+
+def enqueue_wechat_message(all_in_one_msg: str) -> object:
+    chat_names = Variable.get("SZ_TENNIS_CHATROOMS", default="")
+    chat_names_list = str(chat_names).splitlines()
+    print(f"chat_names_list: {chat_names_list}")
+    return send_wechat_text_to_chatrooms_best_effort(
+        chat_names_list,
+        all_in_one_msg,
+        source=DAG_ID,
+        booking_venue_id=VENUE_ID,
+    )
+
+
+def run_check_tennis_courts() -> None:
+    if datetime.time(0, 0) <= datetime.datetime.now().time() < datetime.time(8, 0):
+        print("每天0点-8点不巡检")
+        publish_venue_observation(VENUE_ID, VENUE_NAME, [], healthy=True)
+        return
+
+    run_start_time = time.time()
+    print_with_timestamp(f"start to check {VENUE_NAME}网球场...")
+    proxy_list = load_proxy_list()
+    up_for_send_data_list: list[NotificationCourt] = []
+    webapp_slots: list[dict[str, str]] = []
+    webapp_errors: list[str] = []
+    for index in range(LOOKAHEAD_DAYS):
+        input_date = (datetime.datetime.now() + datetime.timedelta(days=index)).strftime("%Y-%m-%d")
+        print(f"checking {input_date}...")
+        try:
+            court_data = get_tennis_court_availability(input_date, proxy_list)
+            webapp_slots.extend(flatten_court_slots(input_date, court_data))
+            print_court_data(input_date, court_data)
+            time.sleep(1)
+            up_for_send_data_list.extend(filter_court_data_for_notification(input_date, court_data))
+        except Exception as error:
+            print(f"Error checking date {input_date}: {error}")
+            webapp_errors.append(str(error))
+
+    publish_venue_observation(
+        VENUE_ID,
+        VENUE_NAME,
+        webapp_slots,
+        healthy=not webapp_errors,
+        error="; ".join(webapp_errors) or None,
+    )
+
+    if up_for_send_data_list:
+        sended_msg_list = _as_str_list(Variable.get(CACHE_KEY, deserialize_json=True, default=[]))
+        up_for_send_msg_list = build_new_notifications(up_for_send_data_list, sended_msg_list)
+        if up_for_send_msg_list:
+            sended_msg_list.extend(up_for_send_msg_list)
+            Variable.set(
+                key=CACHE_KEY,
+                value=sended_msg_list[-MAX_CACHED_MESSAGES:],
+                description=(
+                    f"{VENUE_NAME}网球场场地通知 - 最后更新: "
+                    f"{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+                ),
+                serialize_json=True,
+            )
+            enqueue_wechat_message("\n".join(up_for_send_msg_list))
+
+    print_with_timestamp(f"Total cost time: {time.time() - run_start_time:.2f}s")

--- a/tests/ops_scripts_test.py
+++ b/tests/ops_scripts_test.py
@@ -423,9 +423,10 @@ class WeChatDeliveryQuiesceTest(unittest.TestCase):
     def test_quiesce_is_scoped_and_preserves_incident_outbox(self):
         script = quiesce_wechat_delivery.remote_script()
 
-        self.assertEqual(len(quiesce_wechat_delivery.WECHAT_DAG_IDS), 8)
+        self.assertEqual(len(quiesce_wechat_delivery.WECHAT_DAG_IDS), 9)
         self.assertIn("大沙河国际网球中心巡检", quiesce_wechat_delivery.WECHAT_DAG_IDS)
-        self.assertIn("expected_paused = 8", script)
+        self.assertIn("PICKLEPOP宝安网球场巡检", quiesce_wechat_delivery.WECHAT_DAG_IDS)
+        self.assertIn("expected_paused = 9", script)
         self.assertIn(
             "compose stop -t 15 airflow-scheduler airflow-worker airflow-triggerer",
             script,
@@ -455,7 +456,7 @@ class WeChatDeliveryQuiesceTest(unittest.TestCase):
 
     def test_quiesce_requires_paused_dags_and_no_active_work(self):
         quiet = {
-            "paused_wechat_dags": 8,
+            "paused_wechat_dags": 9,
             "active_wechat_task_instances": 0,
             "active_wechat_dag_runs": 0,
         }

--- a/tests/ppba_watcher_test.py
+++ b/tests/ppba_watcher_test.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import unittest
+
+
+class FakeDAG:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+    def __enter__(self) -> FakeDAG:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        return False
+
+
+class FakePythonOperator:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+    def __rshift__(self, other: object) -> object:
+        return other
+
+
+class FakeVariable:
+    values: dict[str, object] = {}
+
+    @classmethod
+    def get(cls, key: str, default: object = None, deserialize_json: bool = False) -> object:
+        return cls.values.get(key, default)
+
+    @classmethod
+    def set(
+        cls,
+        key: str,
+        value: object,
+        description: str | None = None,
+        serialize_json: bool = False,
+    ) -> None:
+        cls.values[key] = value
+
+
+def install_import_stubs() -> None:
+    airflow_module = types.ModuleType("airflow")
+    airflow_sdk_module = types.ModuleType("airflow.sdk")
+    airflow_sdk_module.DAG = FakeDAG
+    airflow_sdk_module.Variable = FakeVariable
+    python_module = types.ModuleType("airflow.providers.standard.operators.python")
+    python_module.PythonOperator = FakePythonOperator
+    sys.modules.setdefault("airflow", airflow_module)
+    sys.modules.setdefault("airflow.sdk", airflow_sdk_module)
+    sys.modules.setdefault("airflow.providers", types.ModuleType("airflow.providers"))
+    sys.modules.setdefault(
+        "airflow.providers.standard", types.ModuleType("airflow.providers.standard")
+    )
+    sys.modules.setdefault(
+        "airflow.providers.standard.operators",
+        types.ModuleType("airflow.providers.standard.operators"),
+    )
+    sys.modules["airflow.providers.standard.operators.python"] = python_module
+
+
+install_import_stubs()
+ppba_watcher = importlib.import_module("wechat_airflow.venues.ppba_watcher")
+ppba_watcher.Variable = FakeVariable
+
+
+class PpbaWatcherTest(unittest.TestCase):
+    def setUp(self) -> None:
+        FakeVariable.values = {}
+
+    def test_parse_availability_keeps_tennis_and_drops_pickleball(self) -> None:
+        result = ppba_watcher.parse_availability(
+            {
+                "successed": True,
+                "status": "success",
+                "result": {
+                    "slots": [
+                        {
+                            "classRoomName": "网球1号澳网风 （VIP风雨馆）",
+                            "beginDatetime": "2026-08-31 18:00:00",
+                            "endDatetime": "2026-08-31 18:59:00",
+                            "apptInfo": {"canApptOrNot": True},
+                        },
+                        {
+                            "classRoomName": "网球1号澳网风 （VIP风雨馆）",
+                            "beginDatetime": "2026-08-31 19:00:00",
+                            "endDatetime": "2026-08-31 19:59:00",
+                            "apptInfo": {"canApptOrNot": True},
+                        },
+                        {
+                            "classRoomName": "网球3号法网风   （VIP风雨馆）",
+                            "beginDatetime": "2026-08-31 23:00:00",
+                            "endDatetime": "2026-08-31 23:59:00",
+                            "apptInfo": {"canApptOrNot": True},
+                        },
+                        {
+                            "classRoomName": "匹克球1号 （VIP风雨馆）",
+                            "beginDatetime": "2026-08-31 18:00:00",
+                            "endDatetime": "2026-08-31 18:59:00",
+                            "apptInfo": {"canApptOrNot": True},
+                        },
+                        {
+                            "classRoomName": "网球2号法网风（VIP风雨馆）",
+                            "beginDatetime": "2026-08-31 18:00:00",
+                            "endDatetime": "2026-08-31 18:59:00",
+                            "apptInfo": {"canApptOrNot": False},
+                        },
+                    ]
+                },
+            }
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "网球1号澳网风 （VIP风雨馆）": [["18:00", "20:00"]],
+                "网球3号法网风 （VIP风雨馆）": [["23:00", "24:00"]],
+            },
+        )
+
+    def test_filter_slots_uses_weekday_and_weekend_windows(self) -> None:
+        weekday_result = ppba_watcher.filter_court_data_for_notification(
+            "2026-08-24",
+            {
+                "网球1号澳网风 （VIP风雨馆）": [
+                    ["00:00", "01:00"],
+                    ["06:00", "07:00"],
+                    ["17:00", "18:00"],
+                    ["18:00", "19:00"],
+                    ["21:30", "22:30"],
+                ]
+            },
+        )
+        weekend_result = ppba_watcher.filter_court_data_for_notification(
+            "2026-08-23",
+            {"网球2号法网风（VIP风雨馆）": [["15:00", "16:00"], ["16:00", "17:00"]]},
+        )
+
+        self.assertEqual(
+            weekday_result,
+            [
+                {
+                    "date": "08-24",
+                    "court_name": "PICKLE POP宝安网球1号澳网风 （VIP风雨馆）",
+                    "free_slot_list": [["18:00", "19:00"], ["21:30", "22:30"]],
+                }
+            ],
+        )
+        self.assertEqual(
+            weekend_result,
+            [
+                {
+                    "date": "08-23",
+                    "court_name": "PICKLE POP宝安网球2号法网风（VIP风雨馆）",
+                    "free_slot_list": [["16:00", "17:00"]],
+                }
+            ],
+        )
+
+    def test_build_new_notifications_skips_already_sent_messages(self) -> None:
+        messages = ppba_watcher.build_new_notifications(
+            [
+                {
+                    "date": "08-24",
+                    "court_name": "PICKLE POP宝安网球1号澳网风 （VIP风雨馆）",
+                    "free_slot_list": [["18:00", "19:00"], ["19:00", "20:00"]],
+                }
+            ],
+            ["【PICKLE POP宝安网球1号澳网风 （VIP风雨馆）】星期一(08-24)空场: 18:00-19:00"],
+            current_year=2026,
+        )
+
+        self.assertEqual(
+            messages,
+            ["【PICKLE POP宝安网球1号澳网风 （VIP风雨馆）】星期一(08-24)空场: 19:00-20:00"],
+        )
+
+    def test_empty_proxy_list_does_not_call_api_directly(self) -> None:
+        original_post = ppba_watcher.requests.post
+
+        def fail_if_called(*args: object, **kwargs: object) -> None:
+            raise AssertionError("PPBA API should not be called directly without a proxy")
+
+        ppba_watcher.requests.post = fail_if_called
+        try:
+            with self.assertRaisesRegex(Exception, "all proxies failed"):
+                ppba_watcher.get_tennis_court_availability("2026-08-24", [])
+        finally:
+            ppba_watcher.requests.post = original_post
+
+    def test_check_tennis_courts_publishes_webapp_before_wechat(self) -> None:
+        expected_msg = "【PICKLE POP宝安网球3号法网风 （VIP风雨馆）】星期日(08-23)空场: 16:00-18:00"
+        original_load_proxy = ppba_watcher.load_proxy_list
+        original_get_availability = ppba_watcher.get_tennis_court_availability
+        original_publish = ppba_watcher.publish_venue_observation
+        original_enqueue = ppba_watcher.enqueue_wechat_message
+        original_datetime = ppba_watcher.datetime
+
+        class FixedDatetime(original_datetime.datetime):
+            @classmethod
+            def now(cls, tz: object = None) -> FixedDatetime:
+                return cls(2026, 8, 23, 13, 0, 0)
+
+        class FixedDatetimeModule:
+            datetime = FixedDatetime
+            time = original_datetime.time
+            timedelta = original_datetime.timedelta
+
+        def fake_get_availability(date: str, proxy_list: list[str]) -> dict[str, list[list[str]]]:
+            if date == "2026-08-23":
+                return {"网球3号法网风 （VIP风雨馆）": [["16:00", "18:00"]]}
+            return {}
+
+        events: list[str] = []
+        observations: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        def fake_publish(*args: object, **kwargs: object) -> dict[str, bool]:
+            events.append("webapp")
+            observations.append((args, kwargs))
+            return {"success": True}
+
+        def fallback_wechat(msg: str) -> list[dict[str, object]]:
+            events.append("wechat")
+            return [{"success": False, "error": "device_busy"}]
+
+        ppba_watcher.load_proxy_list = lambda: []
+        ppba_watcher.get_tennis_court_availability = fake_get_availability
+        ppba_watcher.publish_venue_observation = fake_publish
+        ppba_watcher.enqueue_wechat_message = fallback_wechat
+        ppba_watcher.datetime = FixedDatetimeModule
+        try:
+            ppba_watcher.run_check_tennis_courts()
+            self.assertIn(expected_msg, FakeVariable.values.get(ppba_watcher.CACHE_KEY, []))
+            self.assertEqual(events, ["webapp", "wechat"])
+            self.assertEqual(observations[0][0][0:2], ("ppba", "PICKLE POP宝安"))
+        finally:
+            ppba_watcher.load_proxy_list = original_load_proxy
+            ppba_watcher.get_tennis_court_availability = original_get_availability
+            ppba_watcher.publish_venue_observation = original_publish
+            ppba_watcher.enqueue_wechat_message = original_enqueue
+            ppba_watcher.datetime = original_datetime
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/webapp_notification_test.py
+++ b/tests/webapp_notification_test.py
@@ -15,6 +15,7 @@ class WebappNotificationTest(TestCase):
             "sysh_watcher.py": "run_check_tennis_courts",
             "tops_watcher.py": "run_check_tennis_courts",
             "fsb_watcher.py": "run_check_tennis_courts",
+            "ppba_watcher.py": "run_check_tennis_courts",
             "tyzx_watcher.py": "run_check_tennis_courts",
             "dashahe_free_watcher.py": "run_check_dashahe_free_courts",
             "dsh_ydmap_watcher.py": "run_check_tennis_courts",

--- a/webapp/cloudflare/domain.test.ts
+++ b/webapp/cloudflare/domain.test.ts
@@ -59,8 +59,20 @@ describe("subscription domain", () => {
     ).toEqual(["fsb"]);
   });
 
-  it("registers nine venues including Dashah International Tennis Center", () => {
-    expect(Object.keys(VENUES)).toHaveLength(9);
+  it("accepts PICKLE POP Bao'an subscriptions", () => {
+    expect(
+      validateSubscriptionInput({
+        venueIds: ["ppba"],
+        startTime: "18:00",
+        endTime: "22:00",
+        durationDays: 7,
+      }).venueIds,
+    ).toEqual(["ppba"]);
+  });
+
+  it("registers ten venues including PICKLE POP Bao'an", () => {
+    expect(Object.keys(VENUES)).toHaveLength(10);
+    expect(VENUES.ppba).toBe("PICKLE POP宝安");
     expect(VENUES.dsh).toBe("大沙河国际网球中心");
   });
 

--- a/webapp/cloudflare/domain.ts
+++ b/webapp/cloudflare/domain.ts
@@ -6,6 +6,7 @@ export const VENUES = {
   sysh: "上越沙河",
   tops: "TOPS 科技园",
   fsb: "泛思博特福中福",
+  ppba: "PICKLE POP宝安",
   tyzx: "深圳市体育中心",
   jdwx: "金地威新",
 } as const;

--- a/webapp/migrations/0011_add_ppba_venue.sql
+++ b/webapp/migrations/0011_add_ppba_venue.sql
@@ -1,0 +1,2 @@
+INSERT OR IGNORE INTO venue_status (venue_id, venue_name, healthy, updated_at)
+VALUES ('ppba', 'PICKLE POP宝安', 0, '1970-01-01T00:00:00.000Z');

--- a/webapp/src/Prototype.tsx
+++ b/webapp/src/Prototype.tsx
@@ -62,6 +62,7 @@ const VENUE_ACCENTS: Record<VenueId, string> = {
   sysh: "blue",
   tops: "royal",
   fsb: "blue",
+  ppba: "royal",
   tyzx: "cyan",
   jdwx: "green",
 };
@@ -74,6 +75,7 @@ const VENUE_ICONS: Record<VenueId, React.ElementType> = {
   sysh: TennisBallIcon,
   tops: BuildingsIcon,
   fsb: MapPinIcon,
+  ppba: TennisBallIcon,
   tyzx: CourtBasketballIcon,
   jdwx: BuildingApartmentIcon,
 };

--- a/webapp/src/api.ts
+++ b/webapp/src/api.ts
@@ -1,4 +1,4 @@
-export const VENUE_IDS = ["szw", "gba", "dsh_free", "dsh", "sysh", "tops", "fsb", "tyzx", "jdwx"] as const;
+export const VENUE_IDS = ["szw", "gba", "dsh_free", "dsh", "sysh", "tops", "fsb", "ppba", "tyzx", "jdwx"] as const;
 
 export type VenueId = (typeof VENUE_IDS)[number];
 export type DeliveryTier = "standard" | "priority";
@@ -151,6 +151,7 @@ const FALLBACK_VENUES: VenueStatus[] = [
   { id: "sysh", name: "上越沙河", healthy: true, subscriberCount: 24, lastInspectionAt: "2026-07-29T10:41:28+08:00", lastNotificationAt: null },
   { id: "tops", name: "TOPS 科技园", healthy: true, subscriberCount: 22, lastInspectionAt: "2026-07-29T10:41:12+08:00", lastNotificationAt: null },
   { id: "fsb", name: "泛思博特福中福", healthy: true, subscriberCount: 0, lastInspectionAt: "2026-07-29T10:41:08+08:00", lastNotificationAt: null },
+  { id: "ppba", name: "PICKLE POP宝安", healthy: true, subscriberCount: 0, lastInspectionAt: "2026-07-29T10:41:08+08:00", lastNotificationAt: null },
   { id: "tyzx", name: "深圳市体育中心", healthy: true, subscriberCount: 30, lastInspectionAt: "2026-07-29T10:40:55+08:00", lastNotificationAt: null },
   { id: "jdwx", name: "金地威新", healthy: true, subscriberCount: 24, lastInspectionAt: "2026-07-29T10:40:42+08:00", lastNotificationAt: null },
 ];
@@ -163,7 +164,7 @@ const DEFAULT_TERMS: Dashboard["subscriptionTerms"] = {
 export const FALLBACK_DASHBOARD: Dashboard = {
   generatedAt: "2026-07-29T10:42:00+08:00",
   weatherEmailGate: { suppressed: false, precipitationMm: null, thresholdMm: 25 },
-  metrics: { activeSubscriptions: 128, remindersToday: 6, healthyVenues: 9, totalVenues: 9 },
+  metrics: { activeSubscriptions: 128, remindersToday: 6, healthyVenues: 10, totalVenues: 10 },
   deliveryTiers: { standard: 10, priority: 100 },
   subscriptionTerms: DEFAULT_TERMS,
   subscriptionLimits: { standard: 5, priority: 20 },
@@ -189,7 +190,7 @@ export const FALLBACK_DASHBOARD: Dashboard = {
 export const EMPTY_DASHBOARD: Dashboard = {
   ...FALLBACK_DASHBOARD,
   generatedAt: new Date().toISOString(),
-  metrics: { activeSubscriptions: 0, remindersToday: 0, healthyVenues: 0, totalVenues: 9 },
+  metrics: { activeSubscriptions: 0, remindersToday: 0, healthyVenues: 0, totalVenues: 10 },
   venues: FALLBACK_VENUES.map((venue) => ({
     ...venue,
     healthy: false,


### PR DESCRIPTION
## Change

把 PICKLE POP宝安（`ppba`）接入 Web 订阅与 Airflow 巡检：复用 TOPS / 泛思博特福中福同一套公开 PosPal 预约接口，30 秒巡检，先发布网球空场到 Web，再 best-effort 微信。匹克球场不进入网球观测。DAG ID 为无空格的 `PICKLEPOP宝安网球场巡检`（Airflow 3 `validate_key` 不允许空格）。版本 `0.4.0`。

## Risk

- 新增 DAG ID 与 Variable，不影响既有 DAG 历史。
- Web D1 增加 `ppba` 行；bootstrap 场地数变为 10。
- 不发送真实邮件或微信验收。
- 发送端无代码变更，`scope=auto` 不应部署 sender。
- 黄金时段网球空场可能很少，微信触发会偏少；Web 订阅仍按用户自选时段匹配原始网球空场。
- 回滚：对 Web / Airflow 分别回退到当前 `main` 的已记录 commit `3d7068c`（release 0.3.0 基线文档）。

## Verification

- [x] `make verify`（含 lint / typecheck / 270 单测 / webapp 88 / DagBag 13 DAG）
- [x] `make test-dags`
- [x] 未发送真实通知
- [x] 组件与配置合约已更新
- [x] 运行手册与架构文档已更新

## Deployment

合入后：

1. 用合入 SHA 记录变更前生产健康。
2. `/release ship 0.4.0 <full-sha> scope=auto sender=false`（Web + Airflow）。
3. 确认未认证 `/api/bootstrap` 返回 10 个场馆且无邮箱；订阅页出现「PICKLE POP宝安」。
4. 观察至少 3 个自然 30 秒周期，确认新 DAG 解暂停且巡检成功。
5. 用同一 SHA 跑生产健康并记录 baseline。


Made with [Cursor](https://cursor.com)