### PR TITLE
fix(venue): 将体育中心周末微信通知窗口改为 17:00-21:00

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,6 +79,7 @@ Greater Bay Area WeChat uses the same Zacks chatrooms as Shenzhen Bay, with a
 different hour window: weekdays 18:00-21:00 and weekends 12:00-21:00. The booking
 query ends at 21:00 so a closed 21:00-22:00 hour cannot appear as a free slot.
 Shenzhen Bay WeChat remains weekdays 18:00-22:00 and weekends 16:00-22:00.
+Shenzhen Sports Center WeChat uses weekdays 18:00-21:00 and weekends 17:00-21:00.
 
 WeChat availability alerts append the venue booking mini-program as the last
 line of the same send, at most once per chat and mini-program every two hours.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and operational changes.
 
 ## Unreleased
 
+### Changed
+
+- Narrow Shenzhen Sports Center WeChat alerts on weekends from 16:00-21:00
+  to 17:00-21:00. Weekdays stay 18:00-21:00. Web email windows are unchanged.
+
 ## [0.4.0] - 2026-08-29
 
 ### Added

--- a/config/active-components.yaml
+++ b/config/active-components.yaml
@@ -408,7 +408,7 @@ active_dags:
     notifications:
       - webapp_observation
       - wechat
-    purpose: Detect and notify Shenzhen Sports Center tennis availability.
+    purpose: Detect and notify Shenzhen Sports Center tennis availability to the dedicated WeChat chatrooms, using weekday 18:00-21:00 and weekend 17:00-21:00 windows.
     verification:
       - dag_imports
       - recent_runs_succeed

--- a/src/wechat_airflow/venues/tyzx_watcher.py
+++ b/src/wechat_airflow/venues/tyzx_watcher.py
@@ -678,6 +678,51 @@ def get_proxy_list():
     return final_proxy_list
 
 
+def wechat_window_label(is_weekend: bool) -> str:
+    return "17:00-21:00" if is_weekend else "18:00-21:00"
+
+
+def filter_court_data_for_notification(
+    input_date: str, court_data: dict[str, list[list[str]]]
+) -> list[dict[str, Any]]:
+    """按工作日 18:00-21:00、周末 17:00-21:00 筛选需要微信通知的空场。"""
+    inform_date = datetime.datetime.strptime(input_date, "%Y-%m-%d").strftime("%m-%d")
+    check_date = datetime.datetime.strptime(input_date, "%Y-%m-%d")
+    is_weekend = check_date.weekday() >= 5
+    if is_weekend:
+        target_start = datetime.datetime.strptime("17:00", "%H:%M")
+        target_end = datetime.datetime.strptime("21:00", "%H:%M")
+    else:
+        target_start = datetime.datetime.strptime("18:00", "%H:%M")
+        target_end = datetime.datetime.strptime("21:00", "%H:%M")
+
+    up_for_send_data_list: list[dict[str, Any]] = []
+    for court_name, free_slots in court_data.items():
+        if not free_slots:
+            continue
+
+        filtered_slots: list[list[str]] = []
+        for slot in free_slots:
+            try:
+                start_time = datetime.datetime.strptime(slot[0], "%H:%M")
+                end_time = datetime.datetime.strptime(slot[1], "%H:%M")
+            except (ValueError, IndexError) as exc:
+                print(f"      ⚠️ 解析时间格式失败: {slot}, 错误: {exc}")
+                continue
+            if max(start_time, target_start) < min(end_time, target_end):
+                filtered_slots.append(slot)
+
+        if filtered_slots:
+            up_for_send_data_list.append(
+                {
+                    "date": inform_date,
+                    "court_name": f"体育中心{court_name}",
+                    "free_slot_list": filtered_slots,
+                }
+            )
+    return up_for_send_data_list
+
+
 def run_check_tennis_courts():
     """主要检查逻辑"""
     if datetime.time(0, 0) <= datetime.datetime.now().time() < datetime.time(8, 0):
@@ -700,7 +745,6 @@ def run_check_tennis_courts():
 
     for index in range(0, 4):  # 查询今天、明天、后天、大后天
         input_date = (datetime.datetime.now() + datetime.timedelta(days=index)).strftime("%Y-%m-%d")
-        inform_date = (datetime.datetime.now() + datetime.timedelta(days=index)).strftime("%m-%d")
         check_date = datetime.datetime.strptime(input_date, "%Y-%m-%d")
         is_weekend = check_date.weekday() >= 5
         weekday_str = ["一", "二", "三", "四", "五", "六", "日"][check_date.weekday()]
@@ -721,61 +765,33 @@ def run_check_tennis_courts():
 
             print(f"🎾 {input_date} 场地筛选结果:")
             total_available_slots = 0
-            total_filtered_slots = 0
-
             for court_name, free_slots in court_data.items():
                 if free_slots:
                     total_available_slots += len(free_slots)
-                    filtered_slots = []
-
                     print(f"  🏟️ {court_name}: 原始可用时段 {len(free_slots)} 个")
                     for slot in free_slots:
                         print(f"    📍 {slot[0]}-{slot[1]}")
 
-                    # 根据工作日/周末筛选时段
-                    for slot in free_slots:
-                        # 安全地解析时间格式
-                        try:
-                            # 检查时间段是否与目标时间范围有重叠
-                            start_time = datetime.datetime.strptime(slot[0], "%H:%M")
-                            end_time = datetime.datetime.strptime(slot[1], "%H:%M")
+            day_notifications = filter_court_data_for_notification(input_date, court_data)
+            up_for_send_data_list.extend(day_notifications)
+            filtered_by_court = {
+                item["court_name"]: item["free_slot_list"] for item in day_notifications
+            }
+            for court_name, free_slots in court_data.items():
+                if not free_slots:
+                    continue
+                filtered_slots = filtered_by_court.get(f"体育中心{court_name}", [])
+                if filtered_slots:
+                    print(f"    ✅ 筛选后符合时段要求: {len(filtered_slots)} 个")
+                    for slot in filtered_slots:
+                        print(f"      ⭐ {slot[0]}-{slot[1]}")
+                else:
+                    print(
+                        f"    ❌ 筛选后无符合时段要求的场地 (需要{day_type}{wechat_window_label(is_weekend)})"
+                    )
 
-                            if is_weekend:
-                                # 周末关注15点到21点的场地
-                                target_start = datetime.datetime.strptime("16:00", "%H:%M")
-                                target_end = datetime.datetime.strptime("21:00", "%H:%M")
-                            else:
-                                # 工作日关注18点到21点的场地
-                                target_start = datetime.datetime.strptime("18:00", "%H:%M")
-                                target_end = datetime.datetime.strptime("21:00", "%H:%M")
-
-                            # 判断时间段是否有重叠：max(start1, start2) < min(end1, end2)
-                            if max(start_time, target_start) < min(end_time, target_end):
-                                filtered_slots.append(slot)
-
-                        except (ValueError, IndexError) as e:
-                            print(f"      ⚠️ 解析时间格式失败: {slot}, 错误: {e}")
-                            continue
-
-                    if filtered_slots:
-                        total_filtered_slots += len(filtered_slots)
-                        print(f"    ✅ 筛选后符合时段要求: {len(filtered_slots)} 个")
-                        for slot in filtered_slots:
-                            print(f"      ⭐ {slot[0]}-{slot[1]}")
-
-                        up_for_send_data_list.append(
-                            {
-                                "date": inform_date,
-                                "court_name": f"体育中心{court_name}",
-                                "free_slot_list": filtered_slots,
-                            }
-                        )
-                    else:
-                        print(
-                            f"    ❌ 筛选后无符合时段要求的场地 (需要{day_type}{'15-21点' if is_weekend else '18-21点'})"
-                        )
-
-            time_filter = "15:00-21:00" if is_weekend else "18:00-21:00"
+            time_filter = wechat_window_label(is_weekend)
+            total_filtered_slots = sum(len(item["free_slot_list"]) for item in day_notifications)
             print(
                 f"📊 {input_date} 统计: 总可用{total_available_slots}个时段, 符合{time_filter}条件{total_filtered_slots}个时段"
             )

--- a/tests/tyzx_watcher_test.py
+++ b/tests/tyzx_watcher_test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import unittest
+
+
+class FakeDAG:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+    def __enter__(self) -> FakeDAG:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        return False
+
+
+class FakePythonOperator:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+    def __rshift__(self, other: object) -> object:
+        return other
+
+
+class FakeVariable:
+    values: dict[str, object] = {}
+
+    @classmethod
+    def get(cls, key: str, default: object = None, deserialize_json: bool = False) -> object:
+        return cls.values.get(key, default)
+
+    @classmethod
+    def set(
+        cls,
+        key: str,
+        value: object,
+        description: str | None = None,
+        serialize_json: bool = False,
+    ) -> None:
+        cls.values[key] = value
+
+
+def install_import_stubs() -> None:
+    airflow_module = types.ModuleType("airflow")
+    airflow_sdk_module = types.ModuleType("airflow.sdk")
+    airflow_sdk_module.DAG = FakeDAG
+    airflow_sdk_module.Variable = FakeVariable
+    python_module = types.ModuleType("airflow.providers.standard.operators.python")
+    python_module.PythonOperator = FakePythonOperator
+    sys.modules.setdefault("airflow", airflow_module)
+    sys.modules.setdefault("airflow.sdk", airflow_sdk_module)
+    sys.modules.setdefault("airflow.providers", types.ModuleType("airflow.providers"))
+    sys.modules.setdefault(
+        "airflow.providers.standard", types.ModuleType("airflow.providers.standard")
+    )
+    sys.modules.setdefault(
+        "airflow.providers.standard.operators",
+        types.ModuleType("airflow.providers.standard.operators"),
+    )
+    sys.modules["airflow.providers.standard.operators.python"] = python_module
+
+
+install_import_stubs()
+tyzx_watcher = importlib.import_module("wechat_airflow.venues.tyzx_watcher")
+tyzx_watcher.Variable = FakeVariable
+
+
+class TyzxWatcherTest(unittest.TestCase):
+    def test_filter_slots_uses_weekday_and_weekend_windows(self) -> None:
+        weekday = tyzx_watcher.filter_court_data_for_notification(
+            "2026-08-31",
+            {
+                "1号场": [
+                    ["17:00", "18:00"],
+                    ["18:00", "19:00"],
+                    ["20:00", "21:00"],
+                    ["21:00", "22:00"],
+                ]
+            },
+        )
+        weekend = tyzx_watcher.filter_court_data_for_notification(
+            "2026-08-30",
+            {
+                "2号场": [
+                    ["16:00", "17:00"],
+                    ["16:00", "18:00"],
+                    ["17:00", "18:00"],
+                    ["20:00", "21:00"],
+                ]
+            },
+        )
+
+        self.assertEqual(
+            weekday,
+            [
+                {
+                    "date": "08-31",
+                    "court_name": "体育中心1号场",
+                    "free_slot_list": [["18:00", "19:00"], ["20:00", "21:00"]],
+                }
+            ],
+        )
+        self.assertEqual(
+            weekend,
+            [
+                {
+                    "date": "08-30",
+                    "court_name": "体育中心2号场",
+                    "free_slot_list": [
+                        ["16:00", "18:00"],
+                        ["17:00", "18:00"],
+                        ["20:00", "21:00"],
+                    ],
+                }
+            ],
+        )
+        self.assertEqual(tyzx_watcher.wechat_window_label(True), "17:00-21:00")
+        self.assertEqual(tyzx_watcher.wechat_window_label(False), "18:00-21:00")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change

把深圳市体育中心微信通知的周末窗口从 16:00-21:00 改为 17:00-21:00。工作日仍是 18:00-21:00。Web 邮件按用户自选时段，不受影响。

## Risk

- 只改 Airflow `tyzx` 微信筛选，不影响巡检、Web 观测发布或发送端。
- 周末 16:00-17:00 整点结束的空场不再发微信；与 17:00-21:00 有重叠的时段仍会发。
- 不发送真实邮件或微信验收。
- 回滚：Airflow 回到当前 `main` `9f43b5c`。

## Verification

- [x] `tests/tyzx_watcher_test.py` 覆盖工作日 18:00-21:00 与周末 17:00-21:00
- [ ] `make verify`（以 GitHub `CI / verify` 为准）
- [ ] `make test-dags`
- [x] 未发送真实通知
- [x] 组件清单 purpose 已更新
- [x] 架构与 CHANGELOG 已更新

## Deployment

合入后需单独部署 Airflow 才会生效；本次只合入，不发布。`scope=auto sender=false` 即可，Web / sender 无代码变更。


Made with [Cursor](https://cursor.com)