### PR TITLE
feat(notify): 为国际中心、福中福和宝安场补充订场小程序

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,7 +84,9 @@ Shenzhen Sports Center WeChat uses weekdays 18:00-21:00 and weekends 17:00-21:00
 WeChat availability alerts append the venue booking mini-program as the last
 line of the same send, at most once per chat and mini-program every two hours.
 Shenzhen Bay and Greater Bay Area share the 未来荟 program, so the second venue
-does not repeat that card. Slot dedupe caches stay link-free.
+does not repeat that card. Dashah International uses 威逊文体, Fuzhongfu uses
+泛思博特, and PICKLE POP Bao'an uses PICKLEPOP宝安摩天轮馆. Slot dedupe
+caches stay link-free.
 
 The Airflow WeChat deduplication cache is written before WeChat delivery.
 Its fallback outbox is a deduplicated incident record, not an automatic retry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and operational changes.
 
 ## Unreleased
 
+### Added
+
+- Append booking mini-program footers for Dashah International (威逊文体),
+  Fuzhongfu (泛思博特), and PICKLE POP Bao'an (PICKLEPOP宝安摩天轮馆).
+
 ### Changed
 
 - Narrow Shenzhen Sports Center WeChat alerts on weekends from 16:00-21:00

--- a/docs/runbooks/troubleshooting.md
+++ b/docs/runbooks/troubleshooting.md
@@ -140,7 +140,9 @@ verify that the Airflow venue cache was written before delivery and compare the
 message identity with its fallback outbox. Check for overlapping DAG runs and
 preserve evidence before changing either cache. A repeated booking mini-program
 card in the same chat within two hours is a cooldown-cache miss, not a new
-slot; Shenzhen Bay and Greater Bay Area share the 未来荟 program.
+slot; Shenzhen Bay and Greater Bay Area share the 未来荟 program. Dashah
+International uses 威逊文体, Fuzhongfu uses 泛思博特, and PICKLE POP Bao'an
+uses PICKLEPOP宝安摩天轮馆.
 
 ## Phone Reboot Failure
 

--- a/src/wechat_airflow/notifications/booking_links.py
+++ b/src/wechat_airflow/notifications/booking_links.py
@@ -40,6 +40,18 @@ TYZX_PROGRAM = BookingMiniProgram(
     program_id="tyzx",
     link="#小程序://i深体/GA0nZbyQSAq9iSa",
 )
+DSH_PROGRAM = BookingMiniProgram(
+    program_id="dsh",
+    link="#小程序://威逊文体/il2QpVgwVeghPtg",
+)
+FSB_PROGRAM = BookingMiniProgram(
+    program_id="fsb",
+    link="#小程序://泛思博特/D0aY3jOJ2oq34fh",
+)
+PPBA_PROGRAM = BookingMiniProgram(
+    program_id="ppba",
+    link="#小程序://PICKLEPOP宝安摩天轮馆/PK3I72u2dNFoA2b",
+)
 
 VENUE_BOOKING_PROGRAMS: Mapping[str, BookingMiniProgram] = {
     "szw": WEILAIHUI,
@@ -48,6 +60,9 @@ VENUE_BOOKING_PROGRAMS: Mapping[str, BookingMiniProgram] = {
     "tops": TOPS_PROGRAM,
     "jdwx": JDWX_PROGRAM,
     "dsh_free": DSH_FREE_PROGRAM,
+    "dsh": DSH_PROGRAM,
+    "fsb": FSB_PROGRAM,
+    "ppba": PPBA_PROGRAM,
     "tyzx": TYZX_PROGRAM,
 }
 

--- a/tests/booking_links_test.py
+++ b/tests/booking_links_test.py
@@ -18,6 +18,23 @@ class BookingLinksTest(unittest.TestCase):
         self.assertIsNone(booking_links.program_for_venue(" "))
         self.assertIsNone(booking_links.program_for_venue("unknown"))
 
+    def test_active_venues_have_registered_booking_links(self):
+        catalog = {
+            "szw": booking_links.WEILAIHUI,
+            "gba": booking_links.WEILAIHUI,
+            "dsh_free": booking_links.DSH_FREE_PROGRAM,
+            "dsh": booking_links.DSH_PROGRAM,
+            "sysh": booking_links.SYSH_PROGRAM,
+            "tops": booking_links.TOPS_PROGRAM,
+            "fsb": booking_links.FSB_PROGRAM,
+            "ppba": booking_links.PPBA_PROGRAM,
+            "tyzx": booking_links.TYZX_PROGRAM,
+            "jdwx": booking_links.JDWX_PROGRAM,
+        }
+        self.assertEqual(set(catalog), set(booking_links.VENUE_BOOKING_PROGRAMS))
+        for venue_id, program in catalog.items():
+            self.assertEqual(booking_links.program_for_venue(venue_id), program)
+
     def test_attach_footer_adds_the_scheme_once_as_the_last_line(self):
         message = "【深圳湾1号场】星期二(08-18)空场: 18:00-19:00"
         attached = booking_links.attach_footer(message, booking_links.WEILAIHUI.link)
@@ -93,7 +110,15 @@ class BookingLinksTest(unittest.TestCase):
         self.assertEqual(
             booking_links.program_for_venue("dsh_free"), booking_links.DSH_FREE_PROGRAM
         )
-        self.assertIsNone(booking_links.program_for_venue("dsh"))
+        self.assertEqual(booking_links.program_for_venue("dsh"), booking_links.DSH_PROGRAM)
+        self.assertEqual(booking_links.DSH_PROGRAM.link, "#小程序://威逊文体/il2QpVgwVeghPtg")
+        self.assertEqual(booking_links.program_for_venue("fsb"), booking_links.FSB_PROGRAM)
+        self.assertEqual(booking_links.FSB_PROGRAM.link, "#小程序://泛思博特/D0aY3jOJ2oq34fh")
+        self.assertEqual(booking_links.program_for_venue("ppba"), booking_links.PPBA_PROGRAM)
+        self.assertEqual(
+            booking_links.PPBA_PROGRAM.link,
+            "#小程序://PICKLEPOP宝安摩天轮馆/PK3I72u2dNFoA2b",
+        )
         self.assertEqual(booking_links.program_for_venue("tyzx"), booking_links.TYZX_PROGRAM)
         self.assertEqual(
             booking_links.SYSH_PROGRAM.link,


### PR DESCRIPTION
## Change

为微信空场提醒补齐三个场地的订场小程序页脚：

- 大沙河国际网球中心（`dsh`）→ 威逊文体
- 泛思博特福中福（`fsb`）→ 泛思博特
- PICKLE POP宝安（`ppba`）→ PICKLEPOP宝安摩天轮馆

十个在巡检场地现在都有登记的订场小程序。同一群、同一小程序仍是两小时冷却，深圳湾与大湾区继续共用未来荟。

## Risk

- 只改微信提醒末行的小程序链接目录，不影响巡检、Web 订阅邮件或去重缓存。
- 槽位去重缓存仍不含链接。
- 回滚：还原本 PR 合入前提交即可。

## Verification

- [x] `ruff` / `mypy` / `tests/booking_links_test.py` 与 `tests/wechat_send_api_test.py` 已通过
- [ ] `make verify`（含镜像与 DAG import，未在本机完整跑）
- [ ] `make test-dags`
- [x] 未发送真实通知
- [x] 组件与配置清单无需变更
- [x] 已更新 `ARCHITECTURE.md`、`CHANGELOG.md` 与排障手册

## Deployment

合入后需按精确 SHA 部署 Airflow，微信页脚才会在生产生效。本次只合入代码，不部署。回滚使用上一发布 SHA，无需动数据库。


Made with [Cursor](https://cursor.com)