### PR TITLE
fix(ops): 新 DAG 不足三次成功不触发 apply 回滚

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and operational changes.
 - Narrow Shenzhen Sports Center WeChat alerts on weekends from 16:00-21:00
   to 17:00-21:00. Weekdays stay 18:00-21:00. Web email windows are unchanged.
 
+## [0.5.1] - 2026-08-29
+
+### Changed
+
+- Treat a newly declared DAG whose completed runs are all successful but
+  still fewer than the required observation cycles as apply-time healthy
+  warming-up, so 30-second venue DAGs are not rolled back after their first
+  one or two successes.
+
 ## [0.5.0] - 2026-08-29
 
 ### Added

--- a/docs/runbooks/production-deployment.md
+++ b/docs/runbooks/production-deployment.md
@@ -106,7 +106,8 @@ The health gate checks, among other contracts:
 - private Execution API route behavior;
 - DAG source readability, registration, pause state, and import errors;
 - required Variables without exposing values;
-- declared recent successful schedule cycles;
+- declared recent successful schedule cycles (new DAGs with only successful
+  but incomplete history stay apply-healthy as warming-up warnings);
 - managed Cloudflare Tunnel and sender readiness;
 - outbox evidence without automatic replay.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wechat-on-airflow"
-version = "0.5.0"
+version = "0.5.1"
 description = "Airflow workflows for Shenzhen tennis availability notifications."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/scripts/production_health.py
+++ b/scripts/production_health.py
@@ -94,9 +94,11 @@ def classify_recent_run_history(
 ) -> tuple[dict[str, Any] | None, bool]:
     """Return (failure, is_new_without_history) for one DAG.
 
-    A declared DAG with zero completed runs is treated as newly introduced and
-    does not fail apply-time health. Once any run exists, the newest required
-    runs must all succeed.
+    A declared DAG with zero completed runs, or with fewer than the required
+    successful runs and no failures, is treated as newly introduced / warming
+    up and does not fail apply-time health. Once the newest required runs all
+    exist, they must all succeed. Any failed completed run in that window is
+    an apply failure.
     """
     if required_count <= 0:
         return None, False
@@ -105,7 +107,7 @@ def classify_recent_run_history(
         return None, True
     relevant_runs = valid_runs[:required_count]
     states = [str(run.get("state", "")).lower() for run in relevant_runs]
-    if len(relevant_runs) < required_count or any(state != "success" for state in states):
+    if any(state != "success" for state in states):
         return (
             {
                 "observed_count": len(relevant_runs),
@@ -114,6 +116,8 @@ def classify_recent_run_history(
             },
             False,
         )
+    if len(relevant_runs) < required_count:
+        return None, True
     return None, False
 
 
@@ -883,8 +887,8 @@ PY
     if new_dags_without_history:
         add_warning(
             "recent_dag_runs",
-            "newly declared DAGs have no completed runs yet: "
-            + ", ".join(new_dags_without_history),
+            "newly declared or warming-up DAGs have not yet completed "
+            "the required successful run history: " + ", ".join(new_dags_without_history),
             "observe the configured natural schedule cycles before treating the DAG as proven",
         )
     if malformed_outboxes:

--- a/src/wechat_airflow/__init__.py
+++ b/src/wechat_airflow/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime code for the production Airflow workflows."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/tests/ops_scripts_test.py
+++ b/tests/ops_scripts_test.py
@@ -654,10 +654,14 @@ class ProductionHealthParsingTest(unittest.TestCase):
         partial_success, still_new = production_health.classify_recent_run_history(
             3, [{"state": "success"}]
         )
-        self.assertEqual(
-            partial_success, {"observed_count": 1, "required_count": 3, "states": ["success"]}
+        self.assertIsNone(partial_success)
+        self.assertTrue(still_new)
+
+        two_successes, still_warming = production_health.classify_recent_run_history(
+            3, [{"state": "success"}, {"state": "success"}]
         )
-        self.assertFalse(still_new)
+        self.assertIsNone(two_successes)
+        self.assertTrue(still_warming)
 
         failed, _ = production_health.classify_recent_run_history(
             3, [{"state": "failed"}, {"state": "success"}]


### PR DESCRIPTION
## Change

0.5.0 五店 DAG 上线时，apply 刚结束就跑出 1–2 次成功；健康门禁把“未满 3 次成功”当成失败并自动回滚 Airflow。现在全成功但未满观察次数视为 warming-up，只警告不失败。0.5.1 用于把五店巡检真正落到生产。

## Risk

- 通知：不改场馆过滤、不发真实邮件/微信。
- 调度：不改 DAG ID 或 cron。
- 配置：无 Variable/Connection 变更。
- 数据库：无迁移。
- 回滚：Airflow 仍可回到 `9f43b5c`（0.4.0）；Web 已在 `7367a0c`。

## Verification

- [x] `make verify`
- [x] `make test-dags`
- [x] No real notification was sent
- [x] Component and configuration manifests are updated
- [x] Documentation or ADR is updated when required

## Deployment

Merge 后对 exact SHA 执行 `/release ship 0.5.1 <full-sha> scope=auto sender=false`。Web 会重部署到新 SHA；Airflow 从回滚后的 0.4.0 前进到 0.5.1。Sender 不在范围。


Made with [Cursor](https://cursor.com)