### PR TITLE
fix(ops): 新目标 DAG 不被上次回滚的暂停状态卡住

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and operational changes.
 - Narrow Shenzhen Sports Center WeChat alerts on weekends from 16:00-21:00
   to 17:00-21:00. Weekdays stay 18:00-21:00. Web email windows are unchanged.
 
+## [0.5.2] - 2026-08-29
+
+### Changed
+
+- Restore newly introduced target DAGs as unpaused even when a previous
+  failed rollout left them paused in Airflow metadata, so apply no longer
+  preserves that leftover and immediately fails health.
+
 ## [0.5.1] - 2026-08-29
 
 ### Changed

--- a/docs/runbooks/production-deployment.md
+++ b/docs/runbooks/production-deployment.md
@@ -89,9 +89,11 @@ or unclassified runtime paths conservatively expand to all components.
 ## Airflow Transaction
 
 Airflow apply builds a commit-tagged image, drains active task instances,
-preserves each DAG's pause state, replaces only application services, and
-retains PostgreSQL, Redis, log, and other stateful volumes. It batches
-pause-state changes through the supported Airflow CLI.
+preserves each already-declared DAG's pause state, restores newly introduced
+target DAGs as unpaused even if leftover metadata marked them paused, replaces
+only application services, and retains PostgreSQL, Redis, log, and other
+stateful volumes. It batches pause-state changes through the supported
+Airflow CLI.
 
 Deployment and full production health are one transaction. If new containers
 start but any complete health check fails, the workflow restores the prior

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wechat-on-airflow"
-version = "0.5.1"
+version = "0.5.2"
 description = "Airflow workflows for Shenzhen tennis availability notifications."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/scripts/deploy_airflow.py
+++ b/scripts/deploy_airflow.py
@@ -35,6 +35,23 @@ ACTIVE_TASK_STATES = (
 COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 
 
+def planned_target_pause_state(
+    dag_id: str,
+    *,
+    current_dag_ids: set[str],
+    recorded_paused: bool | None,
+) -> bool:
+    """Return True when apply should leave a target DAG paused.
+
+    Newly introduced target DAGs are always restored unpaused. A previous
+    failed rollout can leave them paused in metadata; that leftover must not
+    survive the next apply of the same target set.
+    """
+    if dag_id not in current_dag_ids:
+        return False
+    return bool(recorded_paused)
+
+
 def airflow_image_name(airflow_version: str, commit: str) -> str:
     if not COMMIT_PATTERN.fullmatch(commit):
         raise OpsError("target commit must resolve to a full SHA-1")
@@ -216,9 +233,13 @@ with create_session() as session:
             select(DagModel.dag_id, DagModel.is_paused).where(DagModel.dag_id.in_(all_dag_ids))
         ).all()
     )
+current_set = set(current_dag_ids)
 for dag_id in current_dag_ids:
     print(f"current\\t{{int(bool(states.get(dag_id, True)))}}\\t{{dag_id}}")
 for dag_id in target_dag_ids:
+    if dag_id not in current_set:
+        print(f"target\\t0\\t{{dag_id}}")
+        continue
     print(f"target\\t{{int(bool(states.get(dag_id, False)))}}\\t{{dag_id}}")
 PY
 

--- a/src/wechat_airflow/__init__.py
+++ b/src/wechat_airflow/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime code for the production Airflow workflows."""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/tests/ops_scripts_test.py
+++ b/tests/ops_scripts_test.py
@@ -292,8 +292,41 @@ class AirflowDeploymentTest(unittest.TestCase):
         self.assertIn("target_dag_ids_b64", script)
         self.assertIn("retired_dags_left_paused", script)
         self.assertIn('restore_dags "$restore_regex"', script)
+        self.assertIn("if dag_id not in current_set:", script)
         self.assertIn("states.get(dag_id, False)", script)
         self.assertIn("states.get(dag_id, True)", script)
+
+    def test_newly_introduced_target_dags_are_restored_unpaused(self):
+        current = {"existing"}
+
+        self.assertFalse(
+            deploy_airflow.planned_target_pause_state(
+                "new_venue",
+                current_dag_ids=current,
+                recorded_paused=True,
+            )
+        )
+        self.assertFalse(
+            deploy_airflow.planned_target_pause_state(
+                "new_venue",
+                current_dag_ids=current,
+                recorded_paused=None,
+            )
+        )
+        self.assertTrue(
+            deploy_airflow.planned_target_pause_state(
+                "existing",
+                current_dag_ids=current,
+                recorded_paused=True,
+            )
+        )
+        self.assertFalse(
+            deploy_airflow.planned_target_pause_state(
+                "existing",
+                current_dag_ids=current,
+                recorded_paused=False,
+            )
+        )
 
     def test_recovery_deploy_bounds_current_work_and_preserves_outbox(self):
         script = deploy_airflow.remote_script()


### PR DESCRIPTION
## Change

0.5.1 apply 已把五店代码装上，但健康失败原因变成：五店 DAG 仍暂停。上一次 0.5.0 回滚把它们留在 metadata 里 `is_paused=true`，apply 按“恢复原暂停状态”把这个遗留原样写回去。新引入的目标 DAG 现在一律解暂停。

## Risk

- 通知：不改场馆过滤，不发真实邮件/微信。
- 调度：已在目标清单中的 DAG 暂停状态仍被保留；仅对相对当前镜像新增的 DAG 强制解暂停。
- 配置/数据库：无。
- 回滚：Airflow 仍可回到 `9f43b5c`（0.4.0）。

## Verification

- [x] `make verify`
- [x] `make test-dags`
- [x] No real notification was sent
- [x] Component and configuration manifests are updated
- [x] Documentation or ADR is updated when required

## Deployment

Merge 后对 exact SHA 执行 `/release ship 0.5.2 <full-sha> scope=auto sender=false`。


Made with [Cursor](https://cursor.com)