### PR TITLE
ci(deps): split Dependabot updates and add report-only triage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,26 +4,49 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Production Python dependencies remain individual PRs. Only non-major
+    # development-tool updates are grouped for lower-risk review.
     groups:
-      python-runtime:
+      python-dev-nonmajor:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
         patterns:
           - "*"
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
+
   - package-ecosystem: npm
     directory: /webapp
     schedule:
       interval: weekly
+    # Keep runtime and development updates separate, and leave every major
+    # update as an individual PR for explicit review.
     groups:
-      webapp-runtime:
+      webapp-runtime-nonmajor:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
         patterns:
           - "*"
+      webapp-dev-nonmajor:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+        patterns:
+          - "*"
+
   - package-ecosystem: docker
     directory: /docker/airflow
     schedule:
       interval: monthly
+
   - package-ecosystem: docker
     directory: /docker/sender
     schedule:

--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -1,0 +1,173 @@
+name: Dependabot PR Triage
+
+# pull_request_target uses the trusted workflow from the default branch. This
+# workflow must never check out or execute code from a pull request head.
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Optional open Dependabot PR number; leave empty to inspect all.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: dependabot-triage-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      (github.event.pull_request.user.login == 'dependabot[bot]' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Refresh report-only triage comments
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_PR: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          marker='<!-- dependabot-triage-report -->'
+          repo="$GITHUB_REPOSITORY"
+
+          if [[ -n "${REQUESTED_PR:-}" ]]; then
+            if [[ ! "$REQUESTED_PR" =~ ^[0-9]+$ ]]; then
+              echo "Invalid PR number: $REQUESTED_PR" >&2
+              exit 1
+            fi
+            prs=("$REQUESTED_PR")
+          else
+            mapfile -t prs < <(
+              gh api --paginate "repos/$repo/pulls?state=open&per_page=100" \
+                --jq '.[] | select(.user.login == "dependabot[bot]") | .number'
+            )
+          fi
+
+          if ((${#prs[@]} == 0)); then
+            echo "No open Dependabot pull requests."
+            exit 0
+          fi
+
+          for pr in "${prs[@]}"; do
+            pr_json="$(gh api "repos/$repo/pulls/$pr")"
+            author="$(jq -r '.user.login' <<<"$pr_json")"
+            head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
+            state="$(jq -r '.state' <<<"$pr_json")"
+
+            if [[ "$state" != "open" || "$author" != "dependabot[bot]" || "$head_repo" != "$repo" ]]; then
+              echo "Skipping PR #$pr: not an open same-repository Dependabot PR."
+              continue
+            fi
+
+            title="$(jq -r '.title' <<<"$pr_json")"
+            head_ref="$(jq -r '.head.ref' <<<"$pr_json")"
+            combined="${title,,} ${head_ref,,}"
+
+            mapfile -t files < <(
+              gh api --paginate "repos/$repo/pulls/$pr/files?per_page=100" \
+                --jq '.[].filename'
+            )
+
+            ecosystems=()
+            unexpected_files=()
+            sensitive_files=()
+            for file in "${files[@]}"; do
+              case "$file" in
+                pyproject.toml|uv.lock|Pipfile|Pipfile.lock|poetry.lock|requirements*.txt|requirements/*.txt)
+                  ecosystems+=("python")
+                  ;;
+                webapp/package.json|webapp/package-lock.json|webapp/npm-shrinkwrap.json|webapp/yarn.lock|webapp/pnpm-lock.yaml)
+                  ecosystems+=("webapp")
+                  ;;
+                .github/workflows/*)
+                  ecosystems+=("github-actions")
+                  sensitive_files+=("$file")
+                  ;;
+                Dockerfile|*/Dockerfile|docker/*|docker-compose*.yml)
+                  ecosystems+=("docker")
+                  sensitive_files+=("$file")
+                  ;;
+                *)
+                  unexpected_files+=("$file")
+                  ;;
+              esac
+            done
+
+            if ((${#ecosystems[@]} == 0)); then
+              ecosystem="unknown"
+            else
+              ecosystem="$(printf '%s\n' "${ecosystems[@]}" | sort -u | paste -sd, - | sed 's/,/, /g')"
+            fi
+
+            if ((${#unexpected_files[@]} > 0)); then
+              classification="manual review — non-dependency files changed"
+            elif ((${#sensitive_files[@]} > 0)); then
+              classification="manual review — workflow or container control surface"
+            elif [[ "$combined" == *"python-dev-nonmajor"* || "$combined" == *"webapp-dev-nonmajor"* ]]; then
+              classification="low-risk candidate after CI — report only"
+            elif [[ "$combined" == *"webapp-runtime-nonmajor"* ]]; then
+              classification="manual review — Web runtime dependencies"
+            else
+              classification="manual review — individual, major, or legacy grouped update"
+            fi
+
+            if ((${#files[@]} == 0)); then
+              changed_files="- No changed files reported by GitHub."
+            else
+              changed_files="$(printf -- '- `%s`\n' "${files[@]}")"
+            fi
+
+            printf -v body '%s\n' \
+              "$marker" \
+              "### Dependabot triage report" \
+              "" \
+              "- **Mode:** report only — this workflow cannot merge, rebase, update branches, close PRs, or dispatch deployment workflows." \
+              "- **Classification:** $classification" \
+              "- **Detected surface:** $ecosystem" \
+              "- **Head branch:** \`$head_ref\`" \
+              "- **Required gate:** the latest \`CI / verify\` run on the current PR head." \
+              "" \
+              "<details>" \
+              "<summary>Changed files (${#files[@]})</summary>" \
+              "" \
+              "$changed_files" \
+              "</details>" \
+              "" \
+              "This report is generated from GitHub pull-request metadata only. The workflow never checks out or executes code from the pull request."
+            body="${body%$'\n'}"
+
+            comment_id="$(
+              gh api --paginate "repos/$repo/issues/$pr/comments?per_page=100" \
+                --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- dependabot-triage-report -->"))) | .id' \
+                | head -n 1
+            )"
+
+            if [[ -n "$comment_id" ]]; then
+              current_body="$(gh api "repos/$repo/issues/comments/$comment_id" --jq '.body')"
+              if [[ "$current_body" != "$body" ]]; then
+                gh api --method PATCH "repos/$repo/issues/comments/$comment_id" \
+                  -f body="$body" >/dev/null
+                echo "Updated triage report on PR #$pr."
+              else
+                echo "Triage report on PR #$pr is already current."
+              fi
+            else
+              gh api --method POST "repos/$repo/issues/$pr/comments" \
+                -f body="$body" >/dev/null
+              echo "Created triage report on PR #$pr."
+            fi
+          done


### PR DESCRIPTION
## Summary

- Group only non-major Python development-tool updates; keep Python production dependencies and all major updates as individual PRs.
- Split Web non-major updates into runtime and development groups; keep every Web major update as an individual PR.
- Add a report-only Dependabot triage workflow that classifies dependency PRs and maintains one idempotent audit comment per PR.

## Current backlog

- PR #90 was closed as superseded by the already-merged #89 fix.
- PRs #92 and #93 are intentionally left open and unchanged. After this configuration is merged, they can be closed/recreated so Dependabot emits smaller PRs under the new grouping policy.

## Safety boundaries

- No auto-merge, direct merge, rebase, branch update, or PR-closing operation is implemented.
- The triage workflow never checks out or executes pull-request code. It reads GitHub PR metadata and changed filenames only.
- Permissions are limited to `contents: read`, `pull-requests: read`, and `issues: write` for the audit comment.
- No production environment, production secret, deployment workflow, or release dispatcher is referenced.
- Existing `CI / verify` and all protected production workflows are unchanged.
- Repository auto-merge and update-branch settings are unchanged.

## Local verification

- Parsed both YAML files successfully.
- Extracted the workflow Bash block and passed `bash -n`.
- Executed the triage script against a mocked GitHub API response for a legacy Dependabot PR.
- Scanned the workflow for checkout, merge, auto-merge, workflow dispatch, and production-dispatch commands; none are present.

The authoritative gate remains GitHub `CI / verify` on this PR's exact head SHA.