### PR TITLE
fix(ci): recognize npm_and_yarn Dependabot metadata

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -67,7 +67,7 @@ jobs:
           fi
 
           case "$PACKAGE_ECOSYSTEM:$DEPENDENCY_GROUP" in
-            pip:python-patch|npm:webapp-patch)
+            pip:python-patch|npm_and_yarn:webapp-patch)
               ;;
             *)
               eligible=false
@@ -99,7 +99,7 @@ jobs:
             case "$PACKAGE_ECOSYSTEM:$path" in
               pip:pyproject.toml)
                 ;;
-              npm:webapp/package.json|npm:webapp/package-lock.json)
+              npm_and_yarn:webapp/package.json|npm_and_yarn:webapp/package-lock.json)
                 ;;
               *)
                 eligible=false

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -19,6 +19,14 @@ def test_dependabot_groups_only_aggregate_patch_updates() -> None:
     assert groups_by_ecosystem["npm"]["webapp-patch"]["update-types"] == ["patch"]
 
 
+def test_dependabot_classifier_uses_fetch_metadata_ecosystem_names() -> None:
+    triage = (WORKFLOWS / "dependabot-triage.yml").read_text()
+
+    assert "pip:python-patch|npm_and_yarn:webapp-patch" in triage
+    assert "npm_and_yarn:webapp/package.json" in triage
+    assert "npm_and_yarn:webapp/package-lock.json" in triage
+
+
 def test_write_capable_pr_automation_never_executes_pr_code_or_deploys() -> None:
     workflow_names = [
         "dependabot-triage.yml",


### PR DESCRIPTION
## Runtime finding

The first live patch group (#119) passed the full `CI / verify` workflow, but the trusted `dependabot/fetch-metadata` action reports npm as `npm_and_yarn`. The classifier expected the Dependabot config spelling `npm`, so it safely classified the PR as manual instead of issuing the head-bound eligibility status.

## Fix

- Accept the verified metadata ecosystem name `npm_and_yarn` for the approved `webapp-patch` group.
- Apply the same normalized ecosystem name to the exact manifest/lockfile allowlist.
- Add a regression contract so this metadata compatibility cannot silently regress.

## Safety

No permissions, merge conditions, production workflow references, deploy triggers, secrets, or runtime files are changed. The classifier still requires a verified Dependabot PR, semver patch updates only, the exact approved group, the exact file allowlist, no maintainer changes, the latest protected CI, and the exact head SHA.