### PR TITLE
fix(ci): classify npm patch groups with Dependabot ecosystem name

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -67,7 +67,7 @@ jobs:
           fi
 
           case "$PACKAGE_ECOSYSTEM:$DEPENDENCY_GROUP" in
-            pip:python-patch|npm:webapp-patch)
+            pip:python-patch|npm_and_yarn:webapp-patch)
               ;;
             *)
               eligible=false
@@ -99,7 +99,7 @@ jobs:
             case "$PACKAGE_ECOSYSTEM:$path" in
               pip:pyproject.toml)
                 ;;
-              npm:webapp/package.json|npm:webapp/package-lock.json)
+              npm_and_yarn:webapp/package.json|npm_and_yarn:webapp/package-lock.json)
                 ;;
               *)
                 eligible=false

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -45,3 +45,14 @@ def test_dependabot_merge_is_bound_to_the_classified_head_sha() -> None:
     assert '-f expected_head_sha="$head_sha"' in reconcile
     assert '-f sha="$head_sha"' in reconcile
     assert '-f merge_method="squash"' in reconcile
+
+
+def test_dependabot_triage_uses_fetch_metadata_ecosystem_names() -> None:
+    triage = (WORKFLOWS / "dependabot-triage.yml").read_text()
+
+    assert "pip:python-patch|npm_and_yarn:webapp-patch" in triage
+    assert (
+        "npm_and_yarn:webapp/package.json|npm_and_yarn:webapp/package-lock.json"
+        in triage
+    )
+    assert "npm:webapp-patch" not in triage

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -51,8 +51,5 @@ def test_dependabot_triage_uses_fetch_metadata_ecosystem_names() -> None:
     triage = (WORKFLOWS / "dependabot-triage.yml").read_text()
 
     assert "pip:python-patch|npm_and_yarn:webapp-patch" in triage
-    assert (
-        "npm_and_yarn:webapp/package.json|npm_and_yarn:webapp/package-lock.json"
-        in triage
-    )
+    assert "npm_and_yarn:webapp/package.json|npm_and_yarn:webapp/package-lock.json" in triage
     assert "npm:webapp-patch" not in triage


### PR DESCRIPTION
## Summary

- accept Dependabot's verified `npm_and_yarn` ecosystem identifier for the `webapp-patch` group
- apply the same identifier to the manifest-only file allowlist
- add a regression test so the metadata contract cannot silently drift back to `npm`

## Live failure reproduced

PR #119 is a grouped semver-patch update that changes only `webapp/package.json` and `webapp/package-lock.json`. Dependabot metadata reported:

- `update-type: version-update:semver-patch`
- `package-ecosystem: npm_and_yarn`
- `dependency-group: webapp-patch`
- `maintainer-changes: false`

The old classifier expected `npm`, so it incorrectly added `needs-manual-review` despite successful CI.

## Safety

This change does not check out or execute pull-request code, does not reference production workflows or environments, and does not deploy, restart, or mutate production services. Exact-head classification, protected `verify`, SHA-bound squash merge, and manual handling for minor/major updates remain unchanged.
