### PR TITLE
fix(ci): parse Dependabot merge responses without false failures

### DIFF
--- a/.github/workflows/dependabot-reconcile.yml
+++ b/.github/workflows/dependabot-reconcile.yml
@@ -227,15 +227,21 @@ jobs:
                 -f sha="$head_sha" \
                 -f merge_method="squash" 2>/dev/null || true
             )"
-            merged="$(jq -r '.merged // false' <<<"${merge_response:-{}}")"
+            if [[ -z "$merge_response" ]]; then
+              merge_response='{}'
+            fi
+            merged="$(jq -r '.merged // false' <<<"$merge_response")"
 
             if [[ "$merged" == "true" ]]; then
+              gh issue edit "$number" \
+                --repo "$REPO" \
+                --remove-label "automerge:blocked" >/dev/null 2>&1 || true
               echo "Merged #$number after protected branch checks passed."
             else
               gh issue edit "$number" \
                 --repo "$REPO" \
                 --add-label "automerge:blocked" >/dev/null
-              message="$(jq -r '.message // "GitHub rejected the merge"' <<<"${merge_response:-{}}")"
+              message="$(jq -r '.message // "GitHub rejected the merge"' <<<"$merge_response")"
               echo "Left #$number open: $message"
             fi
           done

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -58,6 +58,6 @@ def test_dependabot_merge_is_bound_to_the_classified_head_sha() -> None:
 def test_dependabot_merge_response_has_valid_json_fallback() -> None:
     reconcile = (WORKFLOWS / "dependabot-reconcile.yml").read_text()
 
-    assert '${merge_response:-{}}' not in reconcile
+    assert "${merge_response:-{}}" not in reconcile
     assert "merge_response='{}'" in reconcile
     assert '<<<"$merge_response"' in reconcile

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -53,3 +53,11 @@ def test_dependabot_merge_is_bound_to_the_classified_head_sha() -> None:
     assert '-f expected_head_sha="$head_sha"' in reconcile
     assert '-f sha="$head_sha"' in reconcile
     assert '-f merge_method="squash"' in reconcile
+
+
+def test_dependabot_merge_response_has_valid_json_fallback() -> None:
+    reconcile = (WORKFLOWS / "dependabot-reconcile.yml").read_text()
+
+    assert '${merge_response:-{}}' not in reconcile
+    assert "merge_response='{}'" in reconcile
+    assert '<<<"$merge_response"' in reconcile


### PR DESCRIPTION
## Summary

- replace the malformed Bash parameter-expansion fallback used for the merge API response with an explicit valid `{}` JSON fallback
- parse both success and rejection responses from the same validated JSON value
- remove stale `automerge:blocked` after a protected merge succeeds
- add a regression contract that rejects the malformed fallback

## Failure reproduced

The protected reconciler successfully squash-merged #119 after exact-head classification and CI passed, but the workflow then failed with:

```text
jq: parse error: Unmatched '}'
```

The previous `${merge_response:-{}}` expression appends an extra brace when `merge_response` is non-empty. This patch preserves the existing identity, file allowlist, exact-SHA, branch-protection, and CI gates while making post-merge result handling deterministic.

## Production safety

No application, deployment, production workflow, environment, secret, or runtime configuration is changed. The workflow still does not check out or execute pull-request code and does not call any production release or ship workflow.
