### PR TITLE
fix(ci): harden PR automation against stale and incomplete metadata

### DIFF
--- a/.github/workflows/dependabot-reconcile.yml
+++ b/.github/workflows/dependabot-reconcile.yml
@@ -29,6 +29,7 @@ jobs:
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
 
@@ -92,6 +93,12 @@ jobs:
                   "$head_repo" != "$REPO" ||
                   "$has_eligible_label" != "true" ]]; then
               echo "Skipping #$number because its identity or state is not eligible."
+              continue
+            fi
+
+            if [[ "$EVENT_NAME" == "workflow_run" &&
+                  "$WORKFLOW_HEAD_SHA" != "$head_sha" ]]; then
+              echo "Skipping #$number because CI completed for ${WORKFLOW_HEAD_SHA:-unknown}, not current head $head_sha."
               continue
             fi
 
@@ -166,6 +173,12 @@ jobs:
               [[ "$mergeable_state" != "unknown" ]] && break
               sleep 2
             done
+
+            if [[ "$EVENT_NAME" == "workflow_run" &&
+                  "$WORKFLOW_HEAD_SHA" != "$head_sha" ]]; then
+              echo "Skipping #$number because its head moved after the completed CI run."
+              continue
+            fi
 
             safe_status="$(
               gh api "repos/$REPO/commits/$head_sha/status" \

--- a/.github/workflows/pr-reconciler.yml
+++ b/.github/workflows/pr-reconciler.yml
@@ -67,6 +67,7 @@ jobs:
             base_ref="$(jq -r '.base.ref' <<<"$pr_json")"
             head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
             head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+            reported_changed_files="$(jq -r '.changed_files // -1' <<<"$pr_json")"
             keep_open="$(
               jq -r '[.labels[].name] | index("keep-open") != null' <<<"$pr_json"
             )"
@@ -79,9 +80,24 @@ jobs:
               continue
             fi
 
+            if [[ ! "$reported_changed_files" =~ ^[0-9]+$ ]]; then
+              echo "Skipping #$number because GitHub reported an invalid changed-file count."
+              continue
+            fi
+
+            files_json="$(
+              gh api --paginate "repos/$REPO/pulls/$number/files?per_page=100"
+            )"
+            returned_changed_files="$(jq -s '[.[][]] | length' <<<"$files_json")"
+            if ((returned_changed_files != reported_changed_files)); then
+              echo "Skipping #$number because GitHub returned $returned_changed_files of $reported_changed_files changed files."
+              continue
+            fi
+
             mapfile -t touched_paths < <(
-              gh api --paginate "repos/$REPO/pulls/$number/files?per_page=100" \
-                --jq '.[] | .filename, (.previous_filename // empty)' |
+              jq -r -s \
+                '[.[][]] | .[] | .filename, (.previous_filename // empty)' \
+                <<<"$files_json" |
                 awk 'NF && !seen[$0]++'
             )
 

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -50,9 +50,20 @@ def test_dependabot_merge_is_bound_to_the_classified_head_sha() -> None:
 
     assert 'context="dependabot-safe-patch"' in triage
     assert 'select(.context == "dependabot-safe-patch")' in reconcile
+    assert "WORKFLOW_HEAD_SHA" in reconcile
+    assert '"$WORKFLOW_HEAD_SHA" != "$head_sha"' in reconcile
     assert '-f expected_head_sha="$head_sha"' in reconcile
     assert '-f sha="$head_sha"' in reconcile
     assert '-f merge_method="squash"' in reconcile
+
+
+def test_pr_reconciler_requires_a_complete_changed_file_listing() -> None:
+    reconciler = (WORKFLOWS / "pr-reconciler.yml").read_text()
+
+    assert "reported_changed_files" in reconciler
+    assert "returned_changed_files" in reconciler
+    assert "returned_changed_files != reported_changed_files" in reconciler
+    assert "GitHub returned $returned_changed_files of $reported_changed_files" in reconciler
 
 
 def test_dependabot_merge_response_has_valid_json_fallback() -> None:


### PR DESCRIPTION
## Context

PR #130 corrected the trusted Dependabot metadata ecosystem name (`npm_and_yarn`), and the patch-only Web dependency PR #119 subsequently passed the full `CI / verify` gate and was merged by the dependency reconciliation path.

This follow-up keeps that behavior unchanged and adds two fail-closed guards around metadata races and API completeness.

## Changes

- Require a completed CI workflow run's `head_sha` to equal the Dependabot PR's current head before reconciliation can update or merge it; re-check after refreshing mergeability metadata.
- Compare the pull request's reported `changed_files` count with the complete paginated file response before automatic superseded cleanup. Any invalid or incomplete listing is skipped rather than closed.
- Extend the repository safety-contract tests for both guards.

## Safety boundaries

- No production workflow, production environment, deployment dispatcher, or secret is referenced.
- No pull-request code is checked out or executed by a write-capable workflow.
- No permission, branch-rule, Dependabot grouping, or automatic-merge eligibility policy is broadened.
- Both changes are fail-closed: uncertainty leaves a PR open.
- This PR itself is not configured for automatic merge.

## Verification

- Branch is based on the latest `main` containing #130 and #119.
- Diff is limited to two PR-maintenance workflows and their contract test.
- Workflow YAML and embedded Bash were syntax-checked during preparation.
- The authoritative gate remains `CI / verify` on this PR's exact head SHA.

No production action was taken while preparing this change.