### PR TITLE
ci(deps): auto-merge verified development minors and require exact-head CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,22 @@ updates:
           - "*"
         update-types:
           - patch
+      # Only development tools whose behavior is exercised directly by CI are
+      # grouped for minor-version automation. Sender/runtime dependencies such
+      # as FastAPI, Selenium, and Uvicorn remain individual manual-review PRs.
+      python-dev-minor:
+        dependency-type: development
+        patterns:
+          - "httpx"
+          - "mypy"
+          - "pre-commit"
+          - "pytest"
+          - "pytest-cov"
+          - "ruff"
+          - "types-paramiko"
+          - "types-requests"
+        update-types:
+          - minor
 
   - package-ecosystem: github-actions
     directory: /
@@ -28,6 +44,22 @@ updates:
           - "*"
         update-types:
           - patch
+      # Build, type-check, unit-test, and browser-test tooling may move within
+      # the current major after the exact PR head passes the complete Web gate.
+      # Wrangler is intentionally excluded because it controls deployment.
+      webapp-dev-minor:
+        dependency-type: development
+        patterns:
+          - "@cloudflare/workers-types"
+          - "@playwright/test"
+          - "@types/react"
+          - "@types/react-dom"
+          - "@vitejs/plugin-react"
+          - "typescript"
+          - "vite"
+          - "vitest"
+        update-types:
+          - minor
 
   - package-ecosystem: docker
     directory: /docker/airflow

--- a/.github/workflows/dependabot-reconcile.yml
+++ b/.github/workflows/dependabot-reconcile.yml
@@ -23,12 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Update and merge eligible patch updates
+      - name: Update and merge verified low-risk dependency updates
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
-          WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
@@ -44,7 +43,7 @@ jobs:
               --force >/dev/null
           }
 
-          ensure_label "automerge:patch" "0e8a16" "Patch-only Dependabot update eligible for protected automatic merge"
+          ensure_label "automerge:dependency" "0e8a16" "Verified low-risk dependency update eligible for protected automatic merge"
           ensure_label "automerge:blocked" "b60205" "Automatic dependency processing is blocked"
           ensure_label "needs-manual-review" "d93f0b" "Dependency update requires manual compatibility review"
 
@@ -56,7 +55,7 @@ jobs:
           else
             mapfile -t pull_requests < <(
               gh api --method GET --paginate "search/issues" \
-                -f q="repo:$REPO is:pr is:open label:\"automerge:patch\"" \
+                -f q="repo:$REPO is:pr is:open label:\"automerge:dependency\"" \
                 -f per_page=100 \
                 --jq '.items[].number'
             )
@@ -75,15 +74,15 @@ jobs:
 
             pr_json="$(gh api "repos/$REPO/pulls/$number")"
 
-            state="$(jq -r '.state' <<<"$pr_json")"
-            draft="$(jq -r '.draft' <<<"$pr_json")"
-            author="$(jq -r '.user.login' <<<"$pr_json")"
-            base_ref="$(jq -r '.base.ref' <<<"$pr_json")"
-            head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
-            head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
-            body="$(jq -r '.body // ""' <<<"$pr_json")"
+            state="$(jq -r '.state' <<< "$pr_json")"
+            draft="$(jq -r '.draft' <<< "$pr_json")"
+            author="$(jq -r '.user.login' <<< "$pr_json")"
+            base_ref="$(jq -r '.base.ref' <<< "$pr_json")"
+            head_repo="$(jq -r '.head.repo.full_name // ""' <<< "$pr_json")"
+            head_sha="$(jq -r '.head.sha' <<< "$pr_json")"
+            body="$(jq -r '.body // ""' <<< "$pr_json")"
             has_eligible_label="$(
-              jq -r '[.labels[].name] | index("automerge:patch") != null' <<<"$pr_json"
+              jq -r '[.labels[].name] | index("automerge:dependency") != null' <<< "$pr_json"
             )"
 
             if [[ "$state" != "open" ||
@@ -105,7 +104,7 @@ jobs:
             if [[ "$body" == *"Maintainer changes"* ]]; then
               gh issue edit "$number" \
                 --repo "$REPO" \
-                --remove-label "automerge:patch" >/dev/null 2>&1 || true
+                --remove-label "automerge:dependency" >/dev/null 2>&1 || true
               gh issue edit "$number" \
                 --repo "$REPO" \
                 --add-label "needs-manual-review" >/dev/null
@@ -148,7 +147,7 @@ jobs:
                   -z "$manifest_kind" ]]; then
               gh issue edit "$number" \
                 --repo "$REPO" \
-                --remove-label "automerge:patch" >/dev/null 2>&1 || true
+                --remove-label "automerge:dependency" >/dev/null 2>&1 || true
               gh issue edit "$number" \
                 --repo "$REPO" \
                 --add-label "needs-manual-review" >/dev/null
@@ -158,18 +157,18 @@ jobs:
 
             safe_status="$(
               gh api "repos/$REPO/commits/$head_sha/status" \
-                --jq '[.statuses[] | select(.context == "dependabot-safe-patch")][0].state // ""'
+                --jq '[.statuses[] | select(.context == "dependabot-safe-update")][0].state // ""'
             )"
             if [[ "$safe_status" != "success" ]]; then
-              echo "Skipping #$number because its current head has not passed patch classification."
+              echo "Skipping #$number because its current head has not passed dependency classification."
               continue
             fi
 
             mergeable_state="unknown"
             for _ in 1 2 3; do
               pr_json="$(gh api "repos/$REPO/pulls/$number")"
-              mergeable_state="$(jq -r '.mergeable_state // "unknown"' <<<"$pr_json")"
-              head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+              mergeable_state="$(jq -r '.mergeable_state // "unknown"' <<< "$pr_json")"
+              head_sha="$(jq -r '.head.sha' <<< "$pr_json")"
               [[ "$mergeable_state" != "unknown" ]] && break
               sleep 2
             done
@@ -182,7 +181,7 @@ jobs:
 
             safe_status="$(
               gh api "repos/$REPO/commits/$head_sha/status" \
-                --jq '[.statuses[] | select(.context == "dependabot-safe-patch")][0].state // ""'
+                --jq '[.statuses[] | select(.context == "dependabot-safe-update")][0].state // ""'
             )"
             if [[ "$safe_status" != "success" ]]; then
               echo "Skipping #$number because its head changed after classification."
@@ -215,23 +214,35 @@ jobs:
               clean)
                 ;;
               *)
-                if [[ "$EVENT_NAME" == "workflow_run" &&
-                      "$WORKFLOW_CONCLUSION" != "success" ]]; then
-                  gh issue edit "$number" \
-                    --repo "$REPO" \
-                    --add-label "automerge:blocked" >/dev/null
-                fi
                 echo "Leaving #$number open; mergeable state is $mergeable_state."
                 continue
                 ;;
             esac
 
-            if [[ "$EVENT_NAME" == "workflow_run" &&
-                  "$WORKFLOW_CONCLUSION" != "success" ]]; then
+            # This check is mandatory for workflow_run, schedule, and manual
+            # dispatch paths. Branch protection is intentionally not assumed.
+            ci_runs_json="$(
+              gh api "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$head_sha&event=pull_request&per_page=100"
+            )"
+            ci_conclusion="$(
+              jq -r --arg sha "$head_sha" \
+                '[.workflow_runs[] | select(.head_sha == $sha and .status == "completed")] | sort_by(.run_number) | last | .conclusion // ""' \
+                <<< "$ci_runs_json"
+            )"
+
+            if [[ "$ci_conclusion" != "success" ]]; then
               gh issue edit "$number" \
                 --repo "$REPO" \
                 --add-label "automerge:blocked" >/dev/null
-              echo "Leaving #$number open because CI concluded $WORKFLOW_CONCLUSION."
+              echo "Leaving #$number open because exact-head CI is ${ci_conclusion:-missing}."
+              continue
+            fi
+
+            latest_head_sha="$(
+              gh api "repos/$REPO/pulls/$number" --jq '.head.sha'
+            )"
+            if [[ "$latest_head_sha" != "$head_sha" ]]; then
+              echo "Skipping #$number because its head moved after exact-head CI verification."
               continue
             fi
 
@@ -243,18 +254,18 @@ jobs:
             if [[ -z "$merge_response" ]]; then
               merge_response='{}'
             fi
-            merged="$(jq -r '.merged // false' <<<"$merge_response")"
+            merged="$(jq -r '.merged // false' <<< "$merge_response")"
 
             if [[ "$merged" == "true" ]]; then
               gh issue edit "$number" \
                 --repo "$REPO" \
                 --remove-label "automerge:blocked" >/dev/null 2>&1 || true
-              echo "Merged #$number after protected branch checks passed."
+              echo "Merged #$number after exact-head CI and dependency policy checks passed."
             else
               gh issue edit "$number" \
                 --repo "$REPO" \
                 --add-label "automerge:blocked" >/dev/null
-              message="$(jq -r '.message // "GitHub rejected the merge"' <<<"$merge_response")"
+              message="$(jq -r '.message // "GitHub rejected the merge"' <<< "$merge_response")"
               echo "Left #$number open: $message"
             fi
           done

--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
 
-      - name: Classify patch-only manifest changes
+      - name: Classify verified dependency updates
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -38,6 +38,8 @@ jobs:
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
           PACKAGE_ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
           DEPENDENCY_GROUP: ${{ steps.metadata.outputs.dependency-group }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          DIRECTORY: ${{ steps.metadata.outputs.directory }}
           TARGET_BRANCH: ${{ steps.metadata.outputs.target-branch }}
           MAINTAINER_CHANGES: ${{ steps.metadata.outputs.maintainer-changes }}
         run: |
@@ -54,24 +56,88 @@ jobs:
               --force >/dev/null
           }
 
-          ensure_label "automerge:patch" "0e8a16" "Patch-only Dependabot update eligible for protected automatic merge"
+          trim() {
+            local value="$1"
+            value="${value#"${value%%[![:space:]]*}"}"
+            value="${value%"${value##*[![:space:]]}"}"
+            printf '%s' "$value"
+          }
+
+          all_dependencies_allowed() {
+            local allowlist="$1"
+            local raw name
+            local saw_dependency=false
+            local -a dependency_names=()
+
+            IFS=',' read -ra dependency_names <<< "$DEPENDENCY_NAMES"
+            for raw in "${dependency_names[@]}"; do
+              name="$(trim "$raw")"
+              [[ -n "$name" ]] || continue
+              saw_dependency=true
+              if [[ "|$allowlist|" != *"|$name|"* ]]; then
+                reasons+=("dependency is not in the low-risk minor allowlist: $name")
+                return 1
+              fi
+            done
+
+            if [[ "$saw_dependency" != "true" ]]; then
+              reasons+=("verified dependency metadata did not contain a package name")
+              return 1
+            fi
+          }
+
+          ensure_label "automerge:dependency" "0e8a16" "Verified low-risk dependency update eligible for protected automatic merge"
           ensure_label "automerge:blocked" "b60205" "Automatic dependency processing is blocked"
           ensure_label "needs-manual-review" "d93f0b" "Dependency update requires manual compatibility review"
 
-          eligible=true
+          python_minor_allowlist='httpx|mypy|pre-commit|pytest|pytest-cov|ruff|types-paramiko|types-requests'
+          webapp_minor_allowlist='@cloudflare/workers-types|@playwright/test|@types/react|@types/react-dom|@vitejs/plugin-react|typescript|vite|vitest'
+
+          eligible=false
+          profile="manual review"
           reasons=()
 
-          if [[ "$UPDATE_TYPE" != "version-update:semver-patch" ]]; then
-            eligible=false
-            reasons+=("highest update type is ${UPDATE_TYPE:-unknown}")
-          fi
-
-          case "$PACKAGE_ECOSYSTEM:$DEPENDENCY_GROUP" in
-            pip:python-patch|npm_and_yarn:webapp-patch)
+          case "$UPDATE_TYPE" in
+            version-update:semver-patch)
+              case "$PACKAGE_ECOSYSTEM:$DEPENDENCY_GROUP:$DIRECTORY" in
+                pip:python-patch:/)
+                  eligible=true
+                  profile="Python patch group"
+                  ;;
+                npm_and_yarn:webapp-patch:/webapp)
+                  eligible=true
+                  profile="Web patch group"
+                  ;;
+                *)
+                  reasons+=("patch update is outside an approved patch group")
+                  ;;
+              esac
+              ;;
+            version-update:semver-minor)
+              case "$PACKAGE_ECOSYSTEM:$DIRECTORY" in
+                pip:/)
+                  if [[ -n "$DEPENDENCY_GROUP" && "$DEPENDENCY_GROUP" != "python-dev-minor" ]]; then
+                    reasons+=("Python minor update belongs to an unapproved group: $DEPENDENCY_GROUP")
+                  elif all_dependencies_allowed "$python_minor_allowlist"; then
+                    eligible=true
+                    profile="allowlisted Python development minor"
+                  fi
+                  ;;
+                npm_and_yarn:/webapp)
+                  if [[ -n "$DEPENDENCY_GROUP" && "$DEPENDENCY_GROUP" != "webapp-dev-minor" ]]; then
+                    reasons+=("Web minor update belongs to an unapproved group: $DEPENDENCY_GROUP")
+                  elif all_dependencies_allowed "$webapp_minor_allowlist"; then
+                    eligible=true
+                    profile="allowlisted Web development minor"
+                  fi
+                  ;;
+                *)
+                  reasons+=("minor update ecosystem or directory is not approved")
+                  ;;
+              esac
               ;;
             *)
-              eligible=false
-              reasons+=("update is outside an approved patch group")
+              reasons+=("highest update type is ${UPDATE_TYPE:-unknown}")
               ;;
           esac
 
@@ -85,21 +151,49 @@ jobs:
             reasons+=("the Dependabot branch contains maintainer changes")
           fi
 
+          pr_json="$(gh api "repos/$REPO/pulls/$PR_NUMBER")"
+          current_head_sha="$(jq -r '.head.sha // ""' <<< "$pr_json")"
+          reported_changed_files="$(jq -r '.changed_files // -1' <<< "$pr_json")"
+
+          if [[ "$current_head_sha" != "$HEAD_SHA" ]]; then
+            eligible=false
+            reasons+=("pull request head moved while classification was running")
+          fi
+
+          if [[ ! "$reported_changed_files" =~ ^[0-9]+$ ]]; then
+            eligible=false
+            reasons+=("GitHub reported an invalid changed-file count")
+            reported_changed_files=-1
+          fi
+
+          files_json="$(
+            gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files?per_page=100"
+          )"
+          returned_changed_files="$(jq -s '[.[][]] | length' <<< "$files_json")"
           mapfile -t changed_files < <(
-            gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files?per_page=100" \
-              --jq '.[].filename'
+            jq -r -s '[.[][]] | .[].filename' <<< "$files_json"
           )
+
+          if ((reported_changed_files < 0 || returned_changed_files != reported_changed_files)); then
+            eligible=false
+            reasons+=("GitHub returned an incomplete changed-file listing")
+          fi
 
           if ((${#changed_files[@]} == 0)); then
             eligible=false
             reasons+=("no changed files were returned")
           fi
 
+          has_primary_manifest=false
           for path in "${changed_files[@]}"; do
             case "$PACKAGE_ECOSYSTEM:$path" in
               pip:pyproject.toml)
+                has_primary_manifest=true
                 ;;
-              npm_and_yarn:webapp/package.json|npm_and_yarn:webapp/package-lock.json)
+              npm_and_yarn:webapp/package.json)
+                has_primary_manifest=true
+                ;;
+              npm_and_yarn:webapp/package-lock.json)
                 ;;
               *)
                 eligible=false
@@ -107,6 +201,11 @@ jobs:
                 ;;
             esac
           done
+
+          if [[ "$has_primary_manifest" != "true" ]]; then
+            eligible=false
+            reasons+=("primary dependency manifest is missing")
+          fi
 
           if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             eligible=false
@@ -116,7 +215,10 @@ jobs:
           if [[ "$eligible" == "true" ]]; then
             gh issue edit "$PR_NUMBER" \
               --repo "$REPO" \
-              --add-label "automerge:patch" >/dev/null
+              --add-label "automerge:dependency" >/dev/null
+            gh issue edit "$PR_NUMBER" \
+              --repo "$REPO" \
+              --remove-label "automerge:patch" >/dev/null 2>&1 || true
             gh issue edit "$PR_NUMBER" \
               --repo "$REPO" \
               --remove-label "automerge:blocked" >/dev/null 2>&1 || true
@@ -126,19 +228,24 @@ jobs:
 
             gh api --method POST "repos/$REPO/statuses/$HEAD_SHA" \
               -f state="success" \
-              -f context="dependabot-safe-patch" \
-              -f description="Verified patch-only Dependabot manifest update" >/dev/null
+              -f context="dependabot-safe-update" \
+              -f description="Verified low-risk dependency update" >/dev/null
 
             {
               echo "### Dependabot classification"
               echo
               echo "- Eligible: yes"
+              echo "- Profile: $profile"
               echo "- Ecosystem: \`$PACKAGE_ECOSYSTEM\`"
-              echo "- Group: \`$DEPENDENCY_GROUP\`"
+              echo "- Dependencies: \`$DEPENDENCY_NAMES\`"
+              echo "- Group: \`${DEPENDENCY_GROUP:-individual}\`"
               echo "- Update type: \`$UPDATE_TYPE\`"
               echo "- Approved head: \`$HEAD_SHA\`"
             } >> "$GITHUB_STEP_SUMMARY"
           else
+            gh issue edit "$PR_NUMBER" \
+              --repo "$REPO" \
+              --remove-label "automerge:dependency" >/dev/null 2>&1 || true
             gh issue edit "$PR_NUMBER" \
               --repo "$REPO" \
               --remove-label "automerge:patch" >/dev/null 2>&1 || true
@@ -153,6 +260,7 @@ jobs:
               echo "### Dependabot classification"
               echo
               echo "- Eligible: no"
+              echo "- Dependencies: \`${DEPENDENCY_NAMES:-unknown}\`"
               for reason in "${reasons[@]}"; do
                 echo "- $reason"
               done

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -8,23 +8,44 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
 
 
-def test_dependabot_groups_only_aggregate_patch_updates() -> None:
+def test_dependabot_groups_only_aggregate_approved_update_tiers() -> None:
     config = yaml.safe_load((ROOT / ".github" / "dependabot.yml").read_text())
 
     groups_by_ecosystem = {
         update["package-ecosystem"]: update.get("groups", {}) for update in config["updates"]
     }
 
-    assert groups_by_ecosystem["pip"]["python-patch"]["update-types"] == ["patch"]
-    assert groups_by_ecosystem["npm"]["webapp-patch"]["update-types"] == ["patch"]
+    python_groups = groups_by_ecosystem["pip"]
+    webapp_groups = groups_by_ecosystem["npm"]
+
+    assert python_groups["python-patch"]["update-types"] == ["patch"]
+    assert webapp_groups["webapp-patch"]["update-types"] == ["patch"]
+    assert python_groups["python-dev-minor"]["update-types"] == ["minor"]
+    assert webapp_groups["webapp-dev-minor"]["update-types"] == ["minor"]
+
+    python_minor = set(python_groups["python-dev-minor"]["patterns"])
+    webapp_minor = set(webapp_groups["webapp-dev-minor"]["patterns"])
+
+    assert {"pytest", "pre-commit", "types-requests"} <= python_minor
+    assert {"vite", "@vitejs/plugin-react", "@playwright/test"} <= webapp_minor
+
+    # Runtime and deployment-control dependencies must remain individual PRs.
+    assert not {"fastapi", "uvicorn", "selenium", "Appium-Python-Client"} & python_minor
+    assert not {"wrangler", "@fontsource/roboto", "motion"} & webapp_minor
 
 
-def test_dependabot_classifier_uses_fetch_metadata_ecosystem_names() -> None:
+def test_dependabot_classifier_uses_verified_metadata_and_explicit_allowlists() -> None:
     triage = (WORKFLOWS / "dependabot-triage.yml").read_text()
 
-    assert "pip:python-patch|npm_and_yarn:webapp-patch" in triage
+    assert "npm_and_yarn:webapp-patch:/webapp" in triage
     assert "npm_and_yarn:webapp/package.json" in triage
     assert "npm_and_yarn:webapp/package-lock.json" in triage
+    assert "DEPENDENCY_NAMES" in triage
+    assert "python_minor_allowlist" in triage
+    assert "webapp_minor_allowlist" in triage
+    assert "version-update:semver-minor" in triage
+    assert "dependabot-safe-update" in triage
+    assert "automerge:dependency" in triage
 
 
 def test_write_capable_pr_automation_never_executes_pr_code_or_deploys() -> None:
@@ -48,13 +69,23 @@ def test_dependabot_merge_is_bound_to_the_classified_head_sha() -> None:
     triage = (WORKFLOWS / "dependabot-triage.yml").read_text()
     reconcile = (WORKFLOWS / "dependabot-reconcile.yml").read_text()
 
-    assert 'context="dependabot-safe-patch"' in triage
-    assert 'select(.context == "dependabot-safe-patch")' in reconcile
+    assert 'context="dependabot-safe-update"' in triage
+    assert 'select(.context == "dependabot-safe-update")' in reconcile
     assert "WORKFLOW_HEAD_SHA" in reconcile
     assert '"$WORKFLOW_HEAD_SHA" != "$head_sha"' in reconcile
     assert '-f expected_head_sha="$head_sha"' in reconcile
     assert '-f sha="$head_sha"' in reconcile
     assert '-f merge_method="squash"' in reconcile
+
+
+def test_dependabot_merge_always_requires_exact_head_ci_success() -> None:
+    reconcile = (WORKFLOWS / "dependabot-reconcile.yml").read_text()
+
+    assert "actions/workflows/ci.yml/runs?head_sha=$head_sha&event=pull_request" in reconcile
+    assert 'select(.head_sha == $sha and .status == "completed")' in reconcile
+    assert 'if [[ "$ci_conclusion" != "success" ]]' in reconcile
+    assert "Branch protection is intentionally not assumed" in reconcile
+    assert "WORKFLOW_CONCLUSION" not in reconcile
 
 
 def test_pr_reconciler_requires_a_complete_changed_file_listing() -> None:
@@ -71,4 +102,4 @@ def test_dependabot_merge_response_has_valid_json_fallback() -> None:
 
     assert "${merge_response:-{}}" not in reconcile
     assert "merge_response='{}'" in reconcile
-    assert '<<<"$merge_response"' in reconcile
+    assert '<<< "$merge_response"' in reconcile


### PR DESCRIPTION
## Why the PR queue grew

The current automation only accepts grouped pip/npm patch updates. Dependabot therefore opened every minor, major, Docker, and GitHub Actions update as an individual manual-review PR, including several development-only minor updates whose behavior is already exercised by the complete CI suite.

The queue is functioning as configured, but the policy is too coarse: low-risk tooling minors and genuinely risky runtime/control-plane changes receive the same manual label.

## Changes

- Keep the existing Python and Web patch groups.
- Add narrowly allowlisted minor groups for development tools that are directly exercised by CI:
  - Python: httpx, mypy, pre-commit, pytest, pytest-cov, ruff, types-paramiko, types-requests.
  - Web: Cloudflare worker types, Playwright, React types, Vite/plugin-react, TypeScript, Vitest.
- Explicitly leave sender/runtime dependencies, Wrangler, UI runtime/font dependencies, Docker, GitHub Actions, and every major update outside this new automatic tier.
- Allow both the new grouped PRs and the current individual backlog PRs when every verified dependency name is in the same allowlist.
- Rename the eligibility label/status to generic `automerge:dependency` / `dependabot-safe-update`.
- Require a complete paginated changed-file listing and the exact approved manifest/lockfile set during classification.
- Require the latest completed `CI` run for the PR's exact current head SHA to be `success` for **all** reconcile entry points: workflow completion, six-hour schedule, and manual dispatch. The workflow does not assume branch protection is enabled.
- Add regression contracts for the allowlists, excluded runtime/deployment dependencies, exact-head CI query, status binding, and existing no-checkout/no-production boundaries.

## Safety boundaries

- No PR code is checked out or executed by either write-capable workflow.
- No production workflow, environment, deployment dispatcher, or secret is referenced.
- Automatic merging remains limited to same-repository verified Dependabot branches, exact file allowlists, no maintainer changes, exact-head classification, exact-head CI success, and clean mergeability.
- Major updates remain manual.
- FastAPI, Uvicorn, Selenium, Appium, Cryptography, Motion, Wrangler, fonts/runtime UI packages, Docker, and GitHub Actions remain manual or require a dedicated migration path.
- No production deployment is triggered by merging this policy change.

## Expected backlog effect

After this policy merges, the current safe individual minor PRs can be rebased once so the new classifier evaluates them. Passing updates will then merge one at a time, rebasing and rerunning CI as `main` advances. Future safe minor updates will arrive in compact groups instead of a burst of individual PRs.

The authoritative gate is `CI / verify` on this PR's exact head SHA.