### PR TITLE
fix(airflow): use SDK Variable in fresh-start verifier

### DIFF
--- a/scripts/verify_fresh_start_config.py
+++ b/scripts/verify_fresh_start_config.py
@@ -43,7 +43,7 @@ def main() -> None:
     ):
         raise SystemExit("expected variables must be a JSON object of string values")
 
-    from airflow.models import Variable
+    from airflow.sdk import Variable
 
     def get_variable(name: str) -> str:
         return str(Variable.get(name))

--- a/tests/verify_fresh_start_config_test.py
+++ b/tests/verify_fresh_start_config_test.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import verify_fresh_start_config  # noqa: E402
+
+
+def test_verifier_uses_airflow_3_sdk_variable_api() -> None:
+    source = (SCRIPTS_DIR / "verify_fresh_start_config.py").read_text(encoding="utf-8")
+
+    assert "from airflow.sdk import Variable" in source
+    assert "from airflow.models import Variable" not in source
+
+
+def test_compare_variables_redacts_values_and_reports_names_only() -> None:
+    def getter(name: str) -> str:
+        values = {"matching": "expected", "mismatched": "actual-secret"}
+        if name == "missing":
+            raise KeyError(name)
+        return values[name]
+
+    report = verify_fresh_start_config.compare_variables(
+        {
+            "matching": "expected",
+            "mismatched": "expected-secret",
+            "missing": "missing-secret",
+        },
+        getter,
+    )
+
+    assert report == {
+        "ok": False,
+        "expected_count": 3,
+        "missing_names": ["missing"],
+        "mismatched_names": ["mismatched"],
+    }
+    assert "actual-secret" not in repr(report)
+    assert "expected-secret" not in repr(report)
+    assert "missing-secret" not in repr(report)


### PR DESCRIPTION
## Finding

The newly allowlisted Python development-tool group #137 was correctly blocked by exact-head CI. Ruff 0.16.4 now detects that `airflow.models.Variable` is a deprecated Airflow 3 compatibility import in `scripts/verify_fresh_start_config.py`.

## Change

- Import `Variable` from the Airflow 3 public SDK namespace.
- Add a regression contract that rejects the legacy import.
- Preserve the verifier's value-redaction behavior by testing that only missing/mismatched variable names appear in its report.

## Safety

- The script remains read-only: it calls only `Variable.get` and never prints values.
- No DAG, runtime image version, production configuration, database, notification, or deployment workflow is changed.
- No production action is triggered by this PR.
- After this passes and merges, #137 can be rebased and must pass the full exact-head CI again before dependency automation may merge it.

The authoritative gate is `CI / verify` on this PR's exact head SHA.