### PR TITLE
ci(deps): keep Ruff minor updates under manual review

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       # Only development tools whose behavior is exercised directly by CI are
       # grouped for minor-version automation. Sender/runtime dependencies such
       # as FastAPI, Selenium, and Uvicorn remain individual manual-review PRs.
+      # Ruff is also kept individual because minor releases can change lint and
+      # formatting rules across unrelated repository files.
       python-dev-minor:
         dependency-type: development
         patterns:
@@ -22,7 +24,6 @@ updates:
           - "pre-commit"
           - "pytest"
           - "pytest-cov"
-          - "ruff"
           - "types-paramiko"
           - "types-requests"
         update-types:

--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -90,7 +90,9 @@ jobs:
           ensure_label "automerge:blocked" "b60205" "Automatic dependency processing is blocked"
           ensure_label "needs-manual-review" "d93f0b" "Dependency update requires manual compatibility review"
 
-          python_minor_allowlist='httpx|mypy|pre-commit|pytest|pytest-cov|ruff|types-paramiko|types-requests'
+          # Ruff is deliberately absent: its minor releases can alter lint and
+          # formatting behavior across files outside the dependency manifest.
+          python_minor_allowlist='httpx|mypy|pre-commit|pytest|pytest-cov|types-paramiko|types-requests'
           webapp_minor_allowlist='@cloudflare/workers-types|@playwright/test|@types/react|@types/react-dom|@vitejs/plugin-react|typescript|vite|vitest'
 
           eligible=false

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -29,8 +29,15 @@ def test_dependabot_groups_only_aggregate_approved_update_tiers() -> None:
     assert {"pytest", "pre-commit", "types-requests"} <= python_minor
     assert {"vite", "@vitejs/plugin-react", "@playwright/test"} <= webapp_minor
 
-    # Runtime and deployment-control dependencies must remain individual PRs.
-    assert not {"fastapi", "uvicorn", "selenium", "Appium-Python-Client"} & python_minor
+    # Runtime, deployment-control, and repository-wide rule-engine updates
+    # must remain individual PRs under explicit review.
+    assert not {
+        "fastapi",
+        "uvicorn",
+        "selenium",
+        "Appium-Python-Client",
+        "ruff",
+    } & python_minor
     assert not {"wrangler", "@fontsource/roboto", "motion"} & webapp_minor
 
 
@@ -46,6 +53,7 @@ def test_dependabot_classifier_uses_verified_metadata_and_explicit_allowlists() 
     assert "version-update:semver-minor" in triage
     assert "dependabot-safe-update" in triage
     assert "automerge:dependency" in triage
+    assert "python_minor_allowlist='httpx|mypy|pre-commit|pytest|pytest-cov|types-paramiko|types-requests'" in triage
 
 
 def test_write_capable_pr_automation_never_executes_pr_code_or_deploys() -> None:

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -31,13 +31,16 @@ def test_dependabot_groups_only_aggregate_approved_update_tiers() -> None:
 
     # Runtime, deployment-control, and repository-wide rule-engine updates
     # must remain individual PRs under explicit review.
-    assert not {
-        "fastapi",
-        "uvicorn",
-        "selenium",
-        "Appium-Python-Client",
-        "ruff",
-    } & python_minor
+    assert (
+        not {
+            "fastapi",
+            "uvicorn",
+            "selenium",
+            "Appium-Python-Client",
+            "ruff",
+        }
+        & python_minor
+    )
     assert not {"wrangler", "@fontsource/roboto", "motion"} & webapp_minor
 
 
@@ -53,7 +56,10 @@ def test_dependabot_classifier_uses_verified_metadata_and_explicit_allowlists() 
     assert "version-update:semver-minor" in triage
     assert "dependabot-safe-update" in triage
     assert "automerge:dependency" in triage
-    assert "python_minor_allowlist='httpx|mypy|pre-commit|pytest|pytest-cov|types-paramiko|types-requests'" in triage
+    assert (
+        "python_minor_allowlist='httpx|mypy|pre-commit|pytest|pytest-cov|types-paramiko|types-requests'"
+        in triage
+    )
 
 
 def test_write_capable_pr_automation_never_executes_pr_code_or_deploys() -> None:


### PR DESCRIPTION
## Runtime finding

The new risk-tiered dependency automation correctly stopped Python development-tool group #137 twice. After the Airflow 3 import issue was fixed in #139, Ruff 0.16.4 still changed repository-wide formatting expectations in files unrelated to the dependency manifest (`docs/integrations/tennis168.md` and `tests/wechat_sender_test.py`).

That makes Ruff materially different from pytest, pre-commit, and type stubs: a minor Ruff update can redefine lint/format policy across the whole repository, so it should not be merged unattended merely because the resulting code can be mechanically reformatted.

## Changes

- Remove Ruff from the grouped Python development-minor update set.
- Remove Ruff from the trusted minor allowlist used by the classifier.
- Add a regression contract that keeps Ruff outside the unattended tier.
- Keep all other approved development-minor automation unchanged.

## Expected behavior

After this merges, Dependabot will recreate the Python development-minor group without Ruff. The remaining pre-commit, pytest, and types-requests updates must still pass classification, exact-head CI, clean mergeability, and the manifest-only file gate before automatic merge. Ruff will remain an individual manual-review PR where any required repository-wide formatting can be reviewed as an explicit migration.

## Safety

- This narrows automatic eligibility; it does not broaden it.
- No runtime dependency, application code, deployment workflow, production environment, secret, database, notification, or service is changed.
- No production deployment is triggered.

The authoritative gate is `CI / verify` on this PR's exact head SHA.