### PR TITLE
ci(deps): add authorized nightly Dependabot maintainer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,9 @@ updates:
           - "*"
         update-types:
           - patch
-      # Only development tools whose behavior is exercised directly by CI are
-      # grouped for minor-version automation. Sender/runtime dependencies such
-      # as FastAPI, Selenium, and Uvicorn remain individual manual-review PRs.
-      # Ruff is also kept individual because minor releases can change lint and
-      # formatting rules across unrelated repository files.
+      # Development tools exercised directly by CI stay grouped for immediate
+      # low-risk automation. Runtime libraries and rule engines stay individual
+      # so the authorized nightly maintainer validates each exact PR head.
       python-dev-minor:
         dependency-type: development
         patterns:
@@ -47,7 +45,7 @@ updates:
           - patch
       # Build, type-check, unit-test, and browser-test tooling may move within
       # the current major after the exact PR head passes the complete Web gate.
-      # Wrangler is intentionally excluded because it controls deployment.
+      # Wrangler remains individual for nightly control-plane validation.
       webapp-dev-minor:
         dependency-type: development
         patterns:

--- a/.github/workflows/nightly-dependabot-maintenance.yml
+++ b/.github/workflows/nightly-dependabot-maintenance.yml
@@ -642,7 +642,7 @@ jobs:
                 continue
               fi
 
-              failure_recreate_marker="<!-- nightly-dependabot-failure-recreate:$head_sha:$LOCAL_DATE -->"
+              failure_recreate_marker="<!-- nightly-dependabot-failure-recreate:$number:$LOCAL_DATE -->"
               if ! has_comment_marker "$number" "$failure_recreate_marker"; then
                 failure_recreate_body="$(
                   printf '%s\n\n%s\n\n%s\n' \

--- a/.github/workflows/nightly-dependabot-maintenance.yml
+++ b/.github/workflows/nightly-dependabot-maintenance.yml
@@ -1,0 +1,775 @@
+name: Nightly Dependabot Maintenance
+run-name: nightly/dependabot/${{ github.run_id }}
+
+on:
+  schedule:
+    # GitHub cron is UTC. Running at both UTC candidates plus the timezone
+    # guard below keeps the task at 01:00 in America/Los_Angeles across DST.
+    - cron: "0 8,9 * * *"
+  workflow_dispatch:
+    inputs:
+      max_pull_requests:
+        description: Maximum Dependabot pull requests to process in this run
+        required: false
+        default: "25"
+        type: string
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/nightly-dependabot-maintenance.yml"
+
+permissions:
+  actions: write
+  checks: read
+  contents: write
+  issues: write
+  pull-requests: write
+  statuses: read
+
+concurrency:
+  group: nightly-dependabot-maintenance
+  cancel-in-progress: false
+
+jobs:
+  maintain:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - name: Reconcile every same-repository Dependabot pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          MAX_PULL_REQUESTS_INPUT: ${{ inputs.max_pull_requests }}
+          WORKFLOW_FILE: nightly-dependabot-maintenance.yml
+        run: |
+          set -euo pipefail
+
+          readonly LOCAL_TZ="America/Los_Angeles"
+          readonly LOCAL_DATE="$(TZ="$LOCAL_TZ" date +%F)"
+          readonly LOCAL_HOUR="$(TZ="$LOCAL_TZ" date +%H)"
+          readonly START_EPOCH="$(date +%s)"
+          readonly DEADLINE_EPOCH="$((START_EPOCH + 9600))"
+          readonly CI_WAIT_SECONDS=1200
+          readonly HEAD_WAIT_SECONDS=360
+          readonly DEPENDABOT_EMAIL="49699333+dependabot[bot]@users.noreply.github.com"
+
+          MAX_PULL_REQUESTS="${MAX_PULL_REQUESTS_INPUT:-25}"
+          if [[ ! "$MAX_PULL_REQUESTS" =~ ^[0-9]+$ ]] ||
+             ((MAX_PULL_REQUESTS < 1 || MAX_PULL_REQUESTS > 100)); then
+            echo "max_pull_requests must be an integer between 1 and 100" >&2
+            exit 2
+          fi
+
+          if [[ "$EVENT_NAME" == "schedule" && "$LOCAL_HOUR" != "01" ]]; then
+            echo "Skipping UTC companion schedule; local time is $LOCAL_HOUR:00 $LOCAL_TZ."
+            exit 0
+          fi
+
+          if [[ "$EVENT_NAME" == "schedule" ]]; then
+            duplicate_run=false
+            while IFS=$'\t' read -r run_id status conclusion created_at; do
+              [[ -n "$run_id" && "$run_id" != "$GITHUB_RUN_ID" ]] || continue
+              run_local_date="$(TZ="$LOCAL_TZ" date -d "$created_at" +%F)"
+              if [[ "$run_local_date" == "$LOCAL_DATE" &&
+                    ("$status" == "in_progress" ||
+                     "$status" == "queued" ||
+                     "$conclusion" == "success") ]]; then
+                duplicate_run=true
+                break
+              fi
+            done < <(
+              gh api \
+                "repos/$REPO/actions/workflows/$WORKFLOW_FILE/runs?event=schedule&per_page=20" \
+                --jq '.workflow_runs[] | [
+                  (.id | tostring),
+                  .status,
+                  (.conclusion // ""),
+                  .created_at
+                ] | @tsv'
+            )
+            if [[ "$duplicate_run" == "true" ]]; then
+              echo "A nightly maintenance run already owns $LOCAL_DATE in $LOCAL_TZ."
+              exit 0
+            fi
+          fi
+
+          ensure_label() {
+            local name="$1"
+            local color="$2"
+            local description="$3"
+            gh label create "$name" \
+              --repo "$REPO" \
+              --color "$color" \
+              --description "$description" \
+              --force >/dev/null
+          }
+
+          add_label() {
+            gh issue edit "$1" --repo "$REPO" --add-label "$2" >/dev/null
+          }
+
+          remove_label() {
+            gh issue edit "$1" \
+              --repo "$REPO" \
+              --remove-label "$2" >/dev/null 2>&1 || true
+          }
+
+          has_comment_marker() {
+            local number="$1"
+            local marker="$2"
+            local comments_json=""
+            comments_json="$(
+              gh api --paginate \
+                "repos/$REPO/issues/$number/comments?per_page=100"
+            )"
+            jq -e -s --arg marker "$marker" '
+              [.[][] | (.body // "") | contains($marker)] | any
+            ' <<< "$comments_json" >/dev/null
+          }
+
+          comment_once() {
+            local number="$1"
+            local marker="$2"
+            local body="$3"
+            if ! has_comment_marker "$number" "$marker"; then
+              gh pr comment "$number" \
+                --repo "$REPO" \
+                --body "$body" >/dev/null
+            fi
+          }
+
+          latest_ci() {
+            local sha="$1"
+            gh api \
+              "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$sha&event=pull_request&per_page=100" \
+              --jq '
+                if (.workflow_runs | length) == 0 then
+                  ""
+                else
+                  .workflow_runs
+                  | sort_by(.run_number)
+                  | last
+                  | [
+                      (.id | tostring),
+                      .status,
+                      (.conclusion // ""),
+                      (.run_number | tostring)
+                    ]
+                  | @tsv
+                end
+              '
+          }
+
+          wait_for_ci() {
+            local sha="$1"
+            local timeout_seconds="$2"
+            local wait_deadline="$(( $(date +%s) + timeout_seconds ))"
+            local row=""
+            while (($(date +%s) < wait_deadline)); do
+              row="$(latest_ci "$sha")"
+              if [[ -n "$row" ]]; then
+                IFS=$'\t' read -r run_id status conclusion run_number <<< "$row"
+                if [[ "$status" == "completed" ]]; then
+                  printf '%s\t%s\t%s\t%s\n' \
+                    "$run_id" "$status" "$conclusion" "$run_number"
+                  return 0
+                fi
+              fi
+              sleep 15
+            done
+            if [[ -n "$row" ]]; then
+              printf '%s\n' "$row"
+            else
+              printf '0\tmissing\t\t0\n'
+            fi
+          }
+
+          wait_for_head_change() {
+            local number="$1"
+            local old_sha="$2"
+            local timeout_seconds="$3"
+            local wait_deadline="$(( $(date +%s) + timeout_seconds ))"
+            while (($(date +%s) < wait_deadline)); do
+              current_head="$(
+                gh api "repos/$REPO/pulls/$number" --jq '.head.sha // ""'
+              )"
+              if [[ -n "$current_head" && "$current_head" != "$old_sha" ]]; then
+                printf '%s\n' "$current_head"
+                return 0
+              fi
+              sleep 15
+            done
+            return 1
+          }
+
+          dependency_paths_are_bounded() {
+            local files_json="$1"
+            local path=""
+            while IFS= read -r path; do
+              case "$path" in
+                pyproject.toml|uv.lock|poetry.lock|Pipfile|Pipfile.lock)
+                  ;;
+                requirements.txt|requirements-*.txt|requirements/*.txt)
+                  ;;
+                webapp/package.json|webapp/package-lock.json|webapp/npm-shrinkwrap.json)
+                  ;;
+                docker/*/Dockerfile|docker/*/Dockerfile.*|Dockerfile|Dockerfile.*)
+                  ;;
+                .github/workflows/*.yml|.github/workflows/*.yaml)
+                  ;;
+                .github/actions/*/action.yml|.github/actions/*/action.yaml)
+                  ;;
+                *)
+                  echo "unexpected dependency-update path: $path" >&2
+                  return 1
+                  ;;
+              esac
+            done < <(jq -r -s '[.[][]] | .[].filename' <<< "$files_json")
+          }
+
+          control_plane_patches_are_bounded() {
+            local files_json="$1"
+            local item=""
+            local filename=""
+            local patch=""
+            local line=""
+            local changed_line=""
+
+            while IFS= read -r item; do
+              filename="$(
+                base64 --decode <<< "$item" |
+                  jq -r '.filename'
+              )"
+              patch="$(
+                base64 --decode <<< "$item" |
+                  jq -r '.patch // ""'
+              )"
+              [[ -n "$patch" ]] || return 1
+
+              while IFS= read -r line; do
+                case "$line" in
+                  "+++"*|"---"*|"@@"*)
+                    continue
+                    ;;
+                  "+"*|"-"*)
+                    changed_line="${line:1}"
+                    case "$filename" in
+                      .github/workflows/*.yml|.github/workflows/*.yaml)
+                        [[ "$changed_line" =~ ^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]+[^[:space:]]+@[^[:space:]#]+([[:space:]]+\#.*)?$ ]] ||
+                          return 1
+                        ;;
+                      .github/actions/*/action.yml|.github/actions/*/action.yaml)
+                        [[ "$changed_line" =~ ^[[:space:]]*(uses:|-[[:space:]]+uses:)[[:space:]]+[^[:space:]]+@[^[:space:]#]+([[:space:]]+\#.*)?$ ]] ||
+                          return 1
+                        ;;
+                      docker/*/Dockerfile|docker/*/Dockerfile.*|Dockerfile|Dockerfile.*)
+                        [[ "$changed_line" =~ ^[[:space:]]*FROM[[:space:]]+(--platform=[^[:space:]]+[[:space:]]+)?[^[:space:]]+([[:space:]]+[Aa][Ss][[:space:]]+[^[:space:]]+)?[[:space:]]*$ ]] ||
+                          return 1
+                        ;;
+                    esac
+                    ;;
+                esac
+              done <<< "$patch"
+            done < <(
+              jq -r -s '
+                [.[][]]
+                | .[]
+                | select(
+                    (.filename | startswith(".github/workflows/"))
+                    or (.filename | startswith(".github/actions/"))
+                    or (.filename | test("(^|/)Dockerfile([.].*)?$"))
+                  )
+                | @base64
+              ' <<< "$files_json"
+            )
+          }
+
+          commits_are_dependabot_only() {
+            local number="$1"
+            local expected_count="$2"
+            local commits_json=""
+            local returned_count=""
+            local non_bot_count=""
+            commits_json="$(
+              gh api --paginate \
+                "repos/$REPO/pulls/$number/commits?per_page=100"
+            )"
+            returned_count="$(jq -r -s '[.[][]] | length' <<< "$commits_json")"
+            [[ "$returned_count" == "$expected_count" ]] || return 1
+            non_bot_count="$(
+              jq -r -s --arg email "$DEPENDABOT_EMAIL" '
+                [.[][]]
+                | map(
+                    select(
+                      (.author.login // "") != "dependabot[bot]"
+                      and (.commit.author.email // "") != $email
+                    )
+                  )
+                | length
+              ' <<< "$commits_json"
+            )"
+            [[ "$non_bot_count" == "0" ]]
+          }
+
+          diagnose_ci() {
+            local run_id="$1"
+            gh api "repos/$REPO/actions/runs/$run_id/jobs?filter=latest&per_page=100" \
+              --jq '
+                [
+                  .jobs[]
+                  | select(.conclusion == "failure")
+                  | "- `" + .name + "`: " +
+                    (
+                      [
+                        .steps[]
+                        | select(.conclusion == "failure")
+                        | .name
+                      ]
+                      | if length == 0 then "job failed" else join(", ") end
+                    )
+                ]
+                | if length == 0 then "- Failure details were not returned by GitHub." else .[] end
+              '
+          }
+
+          ensure_label \
+            "maintenance:nightly" \
+            "1d76db" \
+            "Managed by the authorized nightly Dependabot maintainer"
+          ensure_label \
+            "maintenance:retrying" \
+            "fbca04" \
+            "Nightly maintainer is retrying or rebuilding this dependency update"
+          ensure_label \
+            "maintenance:needs-repair" \
+            "b60205" \
+            "Dependency update still fails after bounded automatic recovery"
+          ensure_label \
+            "maintenance:awaiting-ci" \
+            "c5def5" \
+            "Dependency update is waiting for exact-head CI"
+
+          summary_file="/tmp/nightly-dependabot-summary.md"
+          blocked_file="/tmp/nightly-dependabot-blocked.md"
+          : > "$blocked_file"
+          {
+            echo "## Nightly Dependabot maintenance"
+            echo
+            echo "- Local maintenance date: \`$LOCAL_DATE\`"
+            echo "- Timezone: \`$LOCAL_TZ\`"
+            echo "- Maximum PRs: \`$MAX_PULL_REQUESTS\`"
+            echo
+          } > "$summary_file"
+
+          processed=0
+          merged=0
+          updated=0
+          recreated=0
+          rerun=0
+          awaiting=0
+          blocked=0
+          skipped=0
+
+          mapfile -t pull_requests < <(
+            gh api --paginate \
+              "repos/$REPO/pulls?state=open&base=main&per_page=100" |
+              jq -r -s '
+                [.[][]]
+                | map(
+                    select(
+                      .user.login == "dependabot[bot]"
+                      and .base.ref == "main"
+                    )
+                  )
+                | sort_by(.created_at)
+                | .[].number
+              '
+          )
+
+          if ((${#pull_requests[@]} == 0)); then
+            echo "No open Dependabot pull requests target main." |
+              tee -a "$summary_file"
+          fi
+
+          for number in "${pull_requests[@]}"; do
+            ((processed >= MAX_PULL_REQUESTS)) && break
+            (($(date +%s) < DEADLINE_EPOCH)) || {
+              echo "- Runtime budget reached before PR #$number." >> "$summary_file"
+              break
+            }
+            [[ "$number" =~ ^[0-9]+$ ]] || continue
+            ((processed += 1))
+
+            resolved=false
+            for attempt in 1 2 3; do
+              pr_json=""
+              for _ in 1 2 3 4 5; do
+                pr_json="$(gh api "repos/$REPO/pulls/$number")"
+                mergeable_state="$(
+                  jq -r '.mergeable_state // "unknown"' <<< "$pr_json"
+                )"
+                mergeable="$(
+                  jq -r '
+                    if .mergeable == null then
+                      "unknown"
+                    else
+                      (.mergeable | tostring)
+                    end
+                  ' <<< "$pr_json"
+                )"
+                if [[ "$mergeable_state" != "unknown" &&
+                      "$mergeable" != "unknown" ]]; then
+                  break
+                fi
+                sleep 2
+              done
+              state="$(jq -r '.state' <<< "$pr_json")"
+              draft="$(jq -r '.draft' <<< "$pr_json")"
+              author="$(jq -r '.user.login' <<< "$pr_json")"
+              base_ref="$(jq -r '.base.ref' <<< "$pr_json")"
+              head_repo="$(jq -r '.head.repo.full_name // ""' <<< "$pr_json")"
+              head_sha="$(jq -r '.head.sha' <<< "$pr_json")"
+              reported_changed_files="$(jq -r '.changed_files // -1' <<< "$pr_json")"
+              reported_commits="$(jq -r '.commits // -1' <<< "$pr_json")"
+              body="$(jq -r '.body // ""' <<< "$pr_json")"
+
+              if [[ "$state" != "open" ||
+                    "$draft" != "false" ||
+                    "$author" != "dependabot[bot]" ||
+                    "$base_ref" != "main" ||
+                    "$head_repo" != "$REPO" ]]; then
+                ((skipped += 1))
+                echo "- Skipped #$number because its identity or state changed." \
+                  >> "$summary_file"
+                resolved=true
+                break
+              fi
+
+              if [[ ! "$reported_changed_files" =~ ^[0-9]+$ ||
+                    ! "$reported_commits" =~ ^[0-9]+$ ||
+                    "$body" == *"Maintainer changes"* ]]; then
+                add_label "$number" "maintenance:needs-repair"
+                untrusted_marker="<!-- nightly-dependabot-untrusted:$head_sha -->"
+                untrusted_body="$(
+                  printf '%s\n\n%s\n' \
+                    "Nightly maintenance stopped because GitHub metadata was incomplete or the branch reports maintainer changes." \
+                    "$untrusted_marker"
+                )"
+                comment_once \
+                  "$number" \
+                  "$untrusted_marker" \
+                  "$untrusted_body"
+                ((blocked += 1))
+                echo "- #$number: incomplete or maintainer-modified metadata." \
+                  | tee -a "$blocked_file" >> "$summary_file"
+                resolved=true
+                break
+              fi
+
+              files_json="$(
+                gh api --paginate \
+                  "repos/$REPO/pulls/$number/files?per_page=100"
+              )"
+              returned_changed_files="$(
+                jq -r -s '[.[][]] | length' <<< "$files_json"
+              )"
+
+              if [[ "$returned_changed_files" != "$reported_changed_files" ]] ||
+                 ! dependency_paths_are_bounded "$files_json" ||
+                 ! control_plane_patches_are_bounded "$files_json" ||
+                 ! commits_are_dependabot_only "$number" "$reported_commits"; then
+                add_label "$number" "maintenance:needs-repair"
+                boundary_marker="<!-- nightly-dependabot-boundary:$head_sha -->"
+                boundary_body="$(
+                  printf '%s\n\n%s\n' \
+                    "Nightly maintenance refused to mutate or merge this branch because its commits or changed-file listing were outside the dependency-only safety boundary." \
+                    "$boundary_marker"
+                )"
+                comment_once \
+                  "$number" \
+                  "$boundary_marker" \
+                  "$boundary_body"
+                ((blocked += 1))
+                echo "- #$number: dependency-only boundary validation failed." \
+                  | tee -a "$blocked_file" >> "$summary_file"
+                resolved=true
+                break
+              fi
+
+              add_label "$number" "maintenance:nightly"
+
+              if [[ "$mergeable_state" == "behind" ]]; then
+                if gh api --method PUT \
+                  "repos/$REPO/pulls/$number/update-branch" \
+                  -f expected_head_sha="$head_sha" >/dev/null; then
+                  add_label "$number" "maintenance:retrying"
+                  remove_label "$number" "maintenance:needs-repair"
+                  ((updated += 1))
+                  echo "- #$number: synchronized with the latest main." \
+                    >> "$summary_file"
+                  if new_head="$(
+                    wait_for_head_change \
+                      "$number" "$head_sha" "$HEAD_WAIT_SECONDS"
+                  )"; then
+                    head_sha="$new_head"
+                    continue
+                  fi
+                fi
+                ((awaiting += 1))
+                add_label "$number" "maintenance:awaiting-ci"
+                echo "- #$number: branch synchronization is still settling." \
+                  >> "$summary_file"
+                resolved=true
+                break
+              fi
+
+              if [[ "$mergeable_state" == "unknown" ||
+                    "$mergeable" == "unknown" ]]; then
+                ((awaiting += 1))
+                add_label "$number" "maintenance:awaiting-ci"
+                echo "- #$number: GitHub mergeability is still being computed." \
+                  >> "$summary_file"
+                resolved=true
+                break
+              fi
+
+              if [[ "$mergeable_state" == "dirty" || "$mergeable" != "true" ]]; then
+                recreate_marker="<!-- nightly-dependabot-recreate:$head_sha:$LOCAL_DATE -->"
+                if ! has_comment_marker "$number" "$recreate_marker"; then
+                  recreate_body="$(
+                    printf '%s\n\n%s\n\n%s\n' \
+                      "@dependabot recreate" \
+                      "The authorized nightly maintainer requested a clean rebuild against the current \`main\`." \
+                      "$recreate_marker"
+                  )"
+                  gh pr comment "$number" \
+                    --repo "$REPO" \
+                    --body "$recreate_body" >/dev/null
+                  add_label "$number" "maintenance:retrying"
+                  ((recreated += 1))
+                  echo "- #$number: requested a clean Dependabot rebuild." \
+                    >> "$summary_file"
+                  if new_head="$(
+                    wait_for_head_change \
+                      "$number" "$head_sha" "$HEAD_WAIT_SECONDS"
+                  )"; then
+                    head_sha="$new_head"
+                    continue
+                  fi
+                fi
+                ((awaiting += 1))
+                add_label "$number" "maintenance:awaiting-ci"
+                echo "- #$number: waiting for Dependabot to rebuild the branch." \
+                  >> "$summary_file"
+                resolved=true
+                break
+              fi
+
+              IFS=$'\t' read -r \
+                ci_run_id ci_status ci_conclusion ci_run_number < <(
+                  wait_for_ci "$head_sha" "$CI_WAIT_SECONDS"
+                )
+
+              if [[ "$ci_status" != "completed" ]]; then
+                add_label "$number" "maintenance:awaiting-ci"
+                ((awaiting += 1))
+                echo "- #$number: exact-head CI is still ${ci_status:-missing}." \
+                  >> "$summary_file"
+                resolved=true
+                break
+              fi
+
+              if [[ "$ci_conclusion" != "success" ]]; then
+                rerun_marker="<!-- nightly-dependabot-rerun:$head_sha:$LOCAL_DATE -->"
+                if ! has_comment_marker "$number" "$rerun_marker"; then
+                  if gh run rerun "$ci_run_id" --failed --repo "$REPO"; then
+                    rerun_body="$(
+                      printf '%s\n\n%s\n' \
+                        "Nightly maintenance is retrying failed CI jobs once before rebuilding the dependency branch." \
+                        "$rerun_marker"
+                    )"
+                    gh pr comment "$number" \
+                      --repo "$REPO" \
+                      --body "$rerun_body" >/dev/null
+                    add_label "$number" "maintenance:retrying"
+                    ((rerun += 1))
+                    sleep 15
+                    IFS=$'\t' read -r \
+                      ci_run_id ci_status ci_conclusion ci_run_number < <(
+                        wait_for_ci "$head_sha" "$CI_WAIT_SECONDS"
+                      )
+                  fi
+                fi
+              fi
+
+              if [[ "$ci_status" == "completed" &&
+                    "$ci_conclusion" == "success" ]]; then
+                latest_pr_json="$(gh api "repos/$REPO/pulls/$number")"
+                latest_head_sha="$(jq -r '.head.sha' <<< "$latest_pr_json")"
+                latest_mergeable="$(jq -r '.mergeable // false' <<< "$latest_pr_json")"
+                latest_state="$(jq -r '.state' <<< "$latest_pr_json")"
+                if [[ "$latest_state" != "open" ||
+                      "$latest_head_sha" != "$head_sha" ||
+                      "$latest_mergeable" != "true" ]]; then
+                  continue
+                fi
+
+                merge_response="$(
+                  gh api --method PUT \
+                    "repos/$REPO/pulls/$number/merge" \
+                    -f sha="$head_sha" \
+                    -f merge_method="squash" 2>/dev/null || true
+                )"
+                [[ -n "$merge_response" ]] || merge_response='{}'
+                if [[ "$(jq -r '.merged // false' <<< "$merge_response")" == "true" ]]; then
+                  ((merged += 1))
+                  remove_label "$number" "maintenance:retrying"
+                  remove_label "$number" "maintenance:awaiting-ci"
+                  remove_label "$number" "maintenance:needs-repair"
+                  echo "- #$number: merged exact head \`$head_sha\` after CI success." \
+                    >> "$summary_file"
+                  resolved=true
+                  break
+                fi
+
+                merge_message="$(
+                  jq -r '.message // "GitHub rejected the merge"' \
+                    <<< "$merge_response"
+                )"
+                echo "- #$number: merge rejected: $merge_message." \
+                  >> "$summary_file"
+                continue
+              fi
+
+              failure_recreate_marker="<!-- nightly-dependabot-failure-recreate:$head_sha:$LOCAL_DATE -->"
+              if ! has_comment_marker "$number" "$failure_recreate_marker"; then
+                failure_recreate_body="$(
+                  printf '%s\n\n%s\n\n%s\n' \
+                    "@dependabot recreate" \
+                    "Exact-head CI still failed after one retry. The authorized nightly maintainer is rebuilding the branch once before declaring a compatibility repair." \
+                    "$failure_recreate_marker"
+                )"
+                gh pr comment "$number" \
+                  --repo "$REPO" \
+                  --body "$failure_recreate_body" >/dev/null
+                add_label "$number" "maintenance:retrying"
+                ((recreated += 1))
+                if new_head="$(
+                  wait_for_head_change \
+                    "$number" "$head_sha" "$HEAD_WAIT_SECONDS"
+                )"; then
+                  head_sha="$new_head"
+                  continue
+                fi
+              fi
+
+              add_label "$number" "maintenance:needs-repair"
+              remove_label "$number" "maintenance:retrying"
+              remove_label "$number" "maintenance:awaiting-ci"
+              failure_marker="<!-- nightly-dependabot-failure:$head_sha -->"
+              failure_details="$(diagnose_ci "$ci_run_id")"
+              failure_body="$(
+                printf '%s\n\n%s\n%s\n%s\n%s\n\n%s\n\n%s\n\n%s\n' \
+                  "Nightly maintenance exhausted the bounded recovery sequence for this exact head:" \
+                  "1. synchronize or recreate against current \`main\`;" \
+                  "2. run the full exact-head CI;" \
+                  "3. retry failed jobs once;" \
+                  "4. recreate the Dependabot branch once." \
+                  "Persistent failing checks:" \
+                  "$failure_details" \
+                  "The PR remains open and is marked \`maintenance:needs-repair\`; it will never be merged while CI is failing." \
+                  "$failure_marker"
+              )"
+              comment_once \
+                "$number" \
+                "$failure_marker" \
+                "$failure_body"
+              ((blocked += 1))
+              {
+                echo "- #$number at \`$head_sha\`:"
+                echo "$failure_details"
+              } | tee -a "$blocked_file" >> "$summary_file"
+              resolved=true
+              break
+            done
+
+            if [[ "$resolved" != "true" ]]; then
+              ((awaiting += 1))
+              add_label "$number" "maintenance:awaiting-ci"
+              echo "- #$number: deferred after bounded attempts." \
+                >> "$summary_file"
+            fi
+          done
+
+          {
+            echo
+            echo "### Result"
+            echo
+            echo "- Processed: \`$processed\`"
+            echo "- Merged: \`$merged\`"
+            echo "- Synchronized: \`$updated\`"
+            echo "- Recreated: \`$recreated\`"
+            echo "- CI reruns: \`$rerun\`"
+            echo "- Awaiting external completion: \`$awaiting\`"
+            echo "- Persistent repair cases: \`$blocked\`"
+            echo "- Skipped after state changes: \`$skipped\`"
+          } | tee -a "$summary_file" >> "$GITHUB_STEP_SUMMARY"
+
+          backlog_title="[automation] Dependabot maintenance backlog"
+          backlog_number="$(
+            gh issue list \
+              --repo "$REPO" \
+              --state all \
+              --search "$backlog_title in:title" \
+              --json number,title \
+              --jq '
+                map(
+                  select(
+                    .title == "[automation] Dependabot maintenance backlog"
+                  )
+                )
+                | first
+                | .number // ""
+              '
+          )"
+
+          if ((blocked > 0)); then
+            {
+              echo "# Dependabot maintenance backlog"
+              echo
+              echo "Last nightly run: **$LOCAL_DATE** (\`$LOCAL_TZ\`)"
+              echo
+              echo "These PRs passed identity and dependency-only boundary checks,"
+              echo "but still need a compatibility repair because exact-head CI"
+              echo "failed after the bounded retry and branch-rebuild sequence."
+              echo
+              cat "$blocked_file"
+              echo
+              echo "Authoritative run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            } > /tmp/nightly-dependabot-backlog.md
+
+            if [[ -z "$backlog_number" ]]; then
+              backlog_url="$(
+                gh issue create \
+                  --repo "$REPO" \
+                  --title "$backlog_title" \
+                  --body-file /tmp/nightly-dependabot-backlog.md \
+                  --label "maintenance:needs-repair"
+              )"
+              backlog_number="${backlog_url##*/}"
+            else
+              gh issue reopen "$backlog_number" \
+                --repo "$REPO" >/dev/null 2>&1 || true
+              gh issue edit "$backlog_number" \
+                --repo "$REPO" \
+                --body-file /tmp/nightly-dependabot-backlog.md \
+                --add-label "maintenance:needs-repair" >/dev/null
+            fi
+            echo "- Backlog issue: #$backlog_number" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ -n "$backlog_number" ]]; then
+            gh issue close "$backlog_number" \
+              --repo "$REPO" \
+              --comment "Nightly maintenance found no persistent Dependabot repair cases on $LOCAL_DATE." \
+              >/dev/null 2>&1 || true
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and operational changes.
 
 ## Unreleased
 
+## [0.5.3] - 2026-08-30
+
 ### Added
 
 - Append booking mini-program footers for Dashah International (威逊文体),
@@ -14,6 +16,9 @@ and operational changes.
 
 - Narrow Shenzhen Sports Center WeChat alerts on weekends from 16:00-21:00
   to 17:00-21:00. Weekdays stay 18:00-21:00. Web email windows are unchanged.
+- Before 12:00 Asia/Shanghai, inspect only the four already released Dashah
+  International booking dates. Restore the rolling fifth date at noon so its
+  pre-release disabled cells cannot be published or pushed as false availability.
 
 ## [0.5.2] - 2026-08-29
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wechat-on-airflow"
-version = "0.5.2"
+version = "0.5.3"
 description = "Airflow workflows for Shenzhen tennis availability notifications."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/src/wechat_airflow/__init__.py
+++ b/src/wechat_airflow/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime code for the production Airflow workflows."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/src/wechat_airflow/venues/dsh_ydmap_watcher.py
+++ b/src/wechat_airflow/venues/dsh_ydmap_watcher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import time
 from typing import TypedDict
+from zoneinfo import ZoneInfo
 
 from airflow.sdk import Variable
 
@@ -26,6 +27,8 @@ CACHE_KEY = "大沙河国际网球中心"
 DAG_ID = "大沙河国际网球中心巡检"
 LOOKAHEAD_DAYS = DEFAULT_DAYS
 MAX_CACHED_MESSAGES = 100
+LOCAL_TIMEZONE = ZoneInfo("Asia/Shanghai")
+FARTHEST_BOOKING_DATE_OPEN_TIME = datetime.time(12, 0)
 
 
 class NotificationCourt(TypedDict):
@@ -47,6 +50,21 @@ def _as_str_list(value: object) -> list[str]:
 
 def _load_device_config() -> PiDeviceConfig:
     return PiDeviceConfig.from_value(Variable.get(CONFIG_VARIABLE, deserialize_json=True))
+
+
+def _local_now() -> datetime.datetime:
+    return datetime.datetime.now(LOCAL_TIMEZONE)
+
+
+def inspection_days_for(now: datetime.datetime) -> int:
+    """Return the currently released booking horizon.
+
+    The rolling fifth date is visible in the mini program before it becomes
+    bookable, but its disabled cells must not be interpreted as availability.
+    """
+    if LOOKAHEAD_DAYS <= 1 or now.time() >= FARTHEST_BOOKING_DATE_OPEN_TIME:
+        return LOOKAHEAD_DAYS
+    return LOOKAHEAD_DAYS - 1
 
 
 def merge_time_ranges(data: list[list[str]]) -> list[list[str]]:
@@ -163,22 +181,26 @@ def print_court_data(input_date: str, court_data: CourtAvailability) -> None:
 
 
 def run_check_tennis_courts() -> None:
-    if datetime.time(0, 0) <= datetime.datetime.now().time() < datetime.time(8, 0):
+    now = _local_now()
+    if datetime.time(0, 0) <= now.time() < datetime.time(8, 0):
         print("每天0点-8点不巡检")
         publish_venue_observation(VENUE_ID, VENUE_NAME, [], healthy=True)
         return
 
     run_start_time = time.time()
+    inspection_days = inspection_days_for(now)
+    if inspection_days < LOOKAHEAD_DAYS:
+        farthest_date = (now.date() + datetime.timedelta(days=LOOKAHEAD_DAYS - 1)).isoformat()
+        print_with_timestamp(f"{farthest_date} 为最远可预订日期，12:00前尚未开放，本轮跳过该日期")
+
     print_with_timestamp(f"start to check {VENUE_NAME}...")
     webapp_slots: list[dict[str, str]] = []
     up_for_send_data_list: list[NotificationCourt] = []
     try:
-        payload = fetch_inspect_payload(_load_device_config(), days=LOOKAHEAD_DAYS)
+        payload = fetch_inspect_payload(_load_device_config(), days=inspection_days)
         availability = parse_inspect_payload(payload)
-        for offset in range(LOOKAHEAD_DAYS):
-            input_date = (datetime.datetime.now() + datetime.timedelta(days=offset)).strftime(
-                "%Y-%m-%d"
-            )
+        for offset in range(inspection_days):
+            input_date = (now.date() + datetime.timedelta(days=offset)).isoformat()
             court_data = availability.get(input_date, {})
             webapp_slots.extend(flatten_court_slots(input_date, court_data))
             print_court_data(input_date, court_data)
@@ -198,15 +220,18 @@ def run_check_tennis_courts() -> None:
 
     if up_for_send_data_list:
         sended_msg_list = _as_str_list(Variable.get(CACHE_KEY, deserialize_json=True, default=[]))
-        up_for_send_msg_list = build_new_notifications(up_for_send_data_list, sended_msg_list)
+        up_for_send_msg_list = build_new_notifications(
+            up_for_send_data_list,
+            sended_msg_list,
+            current_year=now.year,
+        )
         if up_for_send_msg_list:
             sended_msg_list.extend(up_for_send_msg_list)
             Variable.set(
                 key=CACHE_KEY,
                 value=sended_msg_list[-MAX_CACHED_MESSAGES:],
                 description=(
-                    f"{VENUE_NAME}网球场场地通知 - 最后更新: "
-                    f"{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+                    f"{VENUE_NAME}网球场场地通知 - 最后更新: {now.strftime('%Y-%m-%d %H:%M:%S')}"
                 ),
                 serialize_json=True,
             )

--- a/tests/dsh_ydmap_watcher_test.py
+++ b/tests/dsh_ydmap_watcher_test.py
@@ -153,6 +153,66 @@ class DshYdmapWatcherTest(unittest.TestCase):
             ],
         )
 
+    def test_inspection_horizon_opens_fifth_day_at_noon(self) -> None:
+        before_open = dsh_watcher.datetime.datetime(2026, 8, 30, 11, 59, 59)
+        at_open = dsh_watcher.datetime.datetime(2026, 8, 30, 12, 0, 0)
+
+        self.assertEqual(dsh_watcher.inspection_days_for(before_open), 4)
+        self.assertEqual(dsh_watcher.inspection_days_for(at_open), 5)
+
+    def test_before_noon_ignores_farthest_date_false_positive(self) -> None:
+        original_fetch = dsh_watcher.fetch_inspect_payload
+        original_publish = dsh_watcher.publish_venue_observation
+        original_enqueue = dsh_watcher.enqueue_wechat_message
+        original_datetime = dsh_watcher.datetime
+
+        class FixedDatetime(original_datetime.datetime):
+            @classmethod
+            def now(cls, tz: object = None) -> FixedDatetime:
+                return cls(2026, 8, 30, 8, 23, 0)
+
+        class FixedDatetimeModule:
+            datetime = FixedDatetime
+            time = original_datetime.time
+            timedelta = original_datetime.timedelta
+
+        published: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        def fake_fetch(config: object, *, days: int) -> dict[str, object]:
+            self.assertEqual(days, 4)
+            return {
+                "ok": True,
+                "days": [
+                    {
+                        "date": "2026-09-03",
+                        "courts": {"1号风雨场": [["18:00", "22:00"]]},
+                    }
+                ],
+            }
+
+        def fake_publish(*args: object, **kwargs: object) -> dict[str, bool]:
+            published.append((args, kwargs))
+            return {"success": True}
+
+        def fail_wechat(msg: str) -> object:
+            raise AssertionError(f"unreleased farthest date must not notify: {msg}")
+
+        dsh_watcher.fetch_inspect_payload = fake_fetch
+        dsh_watcher.publish_venue_observation = fake_publish
+        dsh_watcher.enqueue_wechat_message = fail_wechat
+        dsh_watcher.datetime = FixedDatetimeModule
+        try:
+            dsh_watcher.run_check_tennis_courts()
+            self.assertEqual(len(published), 1)
+            self.assertEqual(published[0][0][:3], ("dsh", "大沙河国际网球中心", []))
+            self.assertEqual(published[0][1], {"healthy": True})
+            self.assertNotIn(dsh_watcher.CACHE_KEY, FakeVariable.values)
+        finally:
+            dsh_watcher.fetch_inspect_payload = original_fetch
+            dsh_watcher.publish_venue_observation = original_publish
+            dsh_watcher.enqueue_wechat_message = original_enqueue
+            dsh_watcher.datetime = original_datetime
+
     def test_check_tennis_courts_publishes_webapp_before_wechat(self) -> None:
         expected_msg = "【大沙河国际网球中心1号风雨场】星期日(08-30)空场: 16:00-18:00"
         original_fetch = dsh_watcher.fetch_inspect_payload

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -30,7 +30,7 @@ def test_dependabot_groups_only_aggregate_approved_update_tiers() -> None:
     assert {"vite", "@vitejs/plugin-react", "@playwright/test"} <= webapp_minor
 
     # Runtime, deployment-control, and repository-wide rule-engine updates
-    # must remain individual PRs under explicit review.
+    # remain individual PRs so the nightly maintainer validates each exact head.
     assert (
         not {
             "fastapi",
@@ -66,6 +66,7 @@ def test_write_capable_pr_automation_never_executes_pr_code_or_deploys() -> None
     workflow_names = [
         "dependabot-triage.yml",
         "dependabot-reconcile.yml",
+        "nightly-dependabot-maintenance.yml",
         "pr-reconciler.yml",
     ]
 
@@ -77,6 +78,7 @@ def test_write_capable_pr_automation_never_executes_pr_code_or_deploys() -> None
         assert "production-ship" not in text
         assert "environment: production" not in text
         assert "workflow_call" not in text
+        assert "secrets." not in text
 
 
 def test_dependabot_merge_is_bound_to_the_classified_head_sha() -> None:
@@ -100,6 +102,36 @@ def test_dependabot_merge_always_requires_exact_head_ci_success() -> None:
     assert 'if [[ "$ci_conclusion" != "success" ]]' in reconcile
     assert "Branch protection is intentionally not assumed" in reconcile
     assert "WORKFLOW_CONCLUSION" not in reconcile
+
+
+def test_nightly_maintenance_runs_at_local_one_and_covers_every_dependabot_pr() -> None:
+    nightly = (WORKFLOWS / "nightly-dependabot-maintenance.yml").read_text()
+
+    assert 'cron: "0 8,9 * * *"' in nightly
+    assert 'LOCAL_TZ="America/Los_Angeles"' in nightly
+    assert '"$EVENT_NAME" == "schedule" && "$LOCAL_HOUR" != "01"' in nightly
+    assert "actions/workflows/$WORKFLOW_FILE/runs?event=schedule" in nightly
+    assert "pulls?state=open&base=main&per_page=100" in nightly
+    assert '.user.login == "dependabot[bot]"' in nightly
+    assert 'head_repo" != "$REPO"' in nightly
+
+
+def test_nightly_maintenance_has_bounded_recovery_and_exact_head_merge() -> None:
+    nightly = (WORKFLOWS / "nightly-dependabot-maintenance.yml").read_text()
+
+    assert "reported_changed_files" in nightly
+    assert "returned_changed_files" in nightly
+    assert "dependency_paths_are_bounded" in nightly
+    assert "control_plane_patches_are_bounded" in nightly
+    assert "commits_are_dependabot_only" in nightly
+    assert "pulls/$number/update-branch" in nightly
+    assert "@dependabot recreate" in nightly
+    assert 'gh run rerun "$ci_run_id" --failed' in nightly
+    assert "actions/workflows/ci.yml/runs?head_sha=$sha&event=pull_request" in nightly
+    assert '-f sha="$head_sha"' in nightly
+    assert '-f merge_method="squash"' in nightly
+    assert "maintenance:needs-repair" in nightly
+    assert 'if [[ "$ci_conclusion" != "success" ]]' in nightly
 
 
 def test_pr_reconciler_requires_a_complete_changed_file_listing() -> None:


### PR DESCRIPTION
## Goal

Run a repository-owned maintenance window every day at **01:00 America/Los_Angeles** and take responsibility for every same-repository Dependabot PR, including major, runtime, Docker, deployment-tool, and GitHub Actions updates.

## Nightly maintenance loop

The new `Nightly Dependabot Maintenance` workflow:

- schedules both UTC candidates and gates on `America/Los_Angeles` local hour, so DST does not move the requested 01:00 start;
- deduplicates the repeated 01:00 hour during the autumn DST transition;
- processes up to 25 open Dependabot PRs sequentially, oldest first, within a bounded 160-minute work budget;
- validates that the PR is non-draft, targets `main`, comes from the same repository, contains only Dependabot-authored commits, and has a complete dependency-only file listing;
- restricts GitHub Actions changes to `uses:` version lines and Docker changes to `FROM` image lines before any write action;
- synchronizes branches that are behind, requests a clean Dependabot rebuild for conflicts, waits for exact-head CI, retries failed jobs once, and rebuilds a failed branch once;
- squash-merges only when the current exact head SHA has a successful complete `CI` run and is still mergeable;
- never merges a failing or moving head;
- leaves persistent incompatibilities open under `maintenance:needs-repair`, comments the failing job/step diagnosis, and maintains one repository backlog issue instead of silently abandoning the PR.

## Security boundary

The write-capable workflow does **not** check out or execute PR code. It has no production workflow reference, production environment, repository secret, or deployment call. Untrusted dependency code is executed only by the existing read-only PR CI. The maintainer consumes GitHub metadata and exact-head CI results through the API.

## Operational behavior

- Existing immediate low-risk Dependabot automation remains active.
- The nightly task covers every remaining Dependabot PR regardless of semver tier once the stronger exact-head and dependency-only gates pass.
- A `push` trigger limited to the new workflow path performs an initial maintenance run immediately after this PR lands on `main`; subsequent scheduled runs occur at local 01:00.
- `workflow_dispatch` remains available for an authorized manual sweep with a configurable PR limit.

## Tests

The PR automation contract now verifies:

- local 01:00/DST scheduling and duplicate-run protection;
- all-open-Dependabot discovery rather than allowlist-only discovery;
- complete changed-file and commit-author checks;
- bounded workflow/Docker patch validation;
- update/recreate/rerun recovery stages;
- exact-head SHA binding and squash merge;
- no checkout, PR-code execution, secrets, or production dispatch in any write-capable PR automation.

No application runtime, deployment target, database, notification path, or production service is changed by this PR.