### PR TITLE
fix(venue): gate Dashah fifth booking day until noon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,7 +216,7 @@ and operational changes.
 - Keep venue recipient lists independent and make email and WeChat failure
   outboxes explicit.
 - Add Agent-Native manifests, deterministic verification commands, production
-  health checks, migration runbooks, configuration, and decisions.
+  health checks, migration runbooks, and CI.
 - Run the synchronous WeChat sender as an independent, exact-commit, non-root
   systemd service with automatic startup, restart, and readiness checks; retain
   Compose as an alternate development runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and operational changes.
 
 ## Unreleased
 
+## [0.5.3] - 2026-08-30
+
 ### Added
 
 - Append booking mini-program footers for Dashah International (威逊文体),
@@ -14,6 +16,9 @@ and operational changes.
 
 - Narrow Shenzhen Sports Center WeChat alerts on weekends from 16:00-21:00
   to 17:00-21:00. Weekdays stay 18:00-21:00. Web email windows are unchanged.
+- Before 12:00 Asia/Shanghai, inspect only the four already released Dashah
+  International booking dates. Restore the rolling fifth date at noon so its
+  pre-release disabled cells cannot be published or pushed as false availability.
 
 ## [0.5.2] - 2026-08-29
 
@@ -211,7 +216,7 @@ and operational changes.
 - Keep venue recipient lists independent and make email and WeChat failure
   outboxes explicit.
 - Add Agent-Native manifests, deterministic verification commands, production
-  health checks, migration runbooks, and CI.
+  health checks, migration runbooks, configuration, and decisions.
 - Run the synchronous WeChat sender as an independent, exact-commit, non-root
   systemd service with automatic startup, restart, and readiness checks; retain
   Compose as an alternate development runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wechat-on-airflow"
-version = "0.5.2"
+version = "0.5.3"
 description = "Airflow workflows for Shenzhen tennis availability notifications."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/src/wechat_airflow/__init__.py
+++ b/src/wechat_airflow/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime code for the production Airflow workflows."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/src/wechat_airflow/venues/dsh_ydmap_watcher.py
+++ b/src/wechat_airflow/venues/dsh_ydmap_watcher.py
@@ -191,9 +191,7 @@ def run_check_tennis_courts() -> None:
     inspection_days = inspection_days_for(now)
     if inspection_days < LOOKAHEAD_DAYS:
         farthest_date = (now.date() + datetime.timedelta(days=LOOKAHEAD_DAYS - 1)).isoformat()
-        print_with_timestamp(
-            f"{farthest_date} 为最远可预订日期，12:00前尚未开放，本轮跳过该日期"
-        )
+        print_with_timestamp(f"{farthest_date} 为最远可预订日期，12:00前尚未开放，本轮跳过该日期")
 
     print_with_timestamp(f"start to check {VENUE_NAME}...")
     webapp_slots: list[dict[str, str]] = []
@@ -233,8 +231,7 @@ def run_check_tennis_courts() -> None:
                 key=CACHE_KEY,
                 value=sended_msg_list[-MAX_CACHED_MESSAGES:],
                 description=(
-                    f"{VENUE_NAME}网球场场地通知 - 最后更新: "
-                    f"{now.strftime('%Y-%m-%d %H:%M:%S')}"
+                    f"{VENUE_NAME}网球场场地通知 - 最后更新: {now.strftime('%Y-%m-%d %H:%M:%S')}"
                 ),
                 serialize_json=True,
             )

--- a/src/wechat_airflow/venues/dsh_ydmap_watcher.py
+++ b/src/wechat_airflow/venues/dsh_ydmap_watcher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import time
 from typing import TypedDict
+from zoneinfo import ZoneInfo
 
 from airflow.sdk import Variable
 
@@ -26,6 +27,8 @@ CACHE_KEY = "大沙河国际网球中心"
 DAG_ID = "大沙河国际网球中心巡检"
 LOOKAHEAD_DAYS = DEFAULT_DAYS
 MAX_CACHED_MESSAGES = 100
+LOCAL_TIMEZONE = ZoneInfo("Asia/Shanghai")
+FARTHEST_BOOKING_DATE_OPEN_TIME = datetime.time(12, 0)
 
 
 class NotificationCourt(TypedDict):
@@ -47,6 +50,21 @@ def _as_str_list(value: object) -> list[str]:
 
 def _load_device_config() -> PiDeviceConfig:
     return PiDeviceConfig.from_value(Variable.get(CONFIG_VARIABLE, deserialize_json=True))
+
+
+def _local_now() -> datetime.datetime:
+    return datetime.datetime.now(LOCAL_TIMEZONE)
+
+
+def inspection_days_for(now: datetime.datetime) -> int:
+    """Return the currently released booking horizon.
+
+    The rolling fifth date is visible in the mini program before it becomes
+    bookable, but its disabled cells must not be interpreted as availability.
+    """
+    if LOOKAHEAD_DAYS <= 1 or now.time() >= FARTHEST_BOOKING_DATE_OPEN_TIME:
+        return LOOKAHEAD_DAYS
+    return LOOKAHEAD_DAYS - 1
 
 
 def merge_time_ranges(data: list[list[str]]) -> list[list[str]]:
@@ -163,22 +181,28 @@ def print_court_data(input_date: str, court_data: CourtAvailability) -> None:
 
 
 def run_check_tennis_courts() -> None:
-    if datetime.time(0, 0) <= datetime.datetime.now().time() < datetime.time(8, 0):
+    now = _local_now()
+    if datetime.time(0, 0) <= now.time() < datetime.time(8, 0):
         print("每天0点-8点不巡检")
         publish_venue_observation(VENUE_ID, VENUE_NAME, [], healthy=True)
         return
 
     run_start_time = time.time()
+    inspection_days = inspection_days_for(now)
+    if inspection_days < LOOKAHEAD_DAYS:
+        farthest_date = (now.date() + datetime.timedelta(days=LOOKAHEAD_DAYS - 1)).isoformat()
+        print_with_timestamp(
+            f"{farthest_date} 为最远可预订日期，12:00前尚未开放，本轮跳过该日期"
+        )
+
     print_with_timestamp(f"start to check {VENUE_NAME}...")
     webapp_slots: list[dict[str, str]] = []
     up_for_send_data_list: list[NotificationCourt] = []
     try:
-        payload = fetch_inspect_payload(_load_device_config(), days=LOOKAHEAD_DAYS)
+        payload = fetch_inspect_payload(_load_device_config(), days=inspection_days)
         availability = parse_inspect_payload(payload)
-        for offset in range(LOOKAHEAD_DAYS):
-            input_date = (datetime.datetime.now() + datetime.timedelta(days=offset)).strftime(
-                "%Y-%m-%d"
-            )
+        for offset in range(inspection_days):
+            input_date = (now.date() + datetime.timedelta(days=offset)).isoformat()
             court_data = availability.get(input_date, {})
             webapp_slots.extend(flatten_court_slots(input_date, court_data))
             print_court_data(input_date, court_data)
@@ -198,7 +222,11 @@ def run_check_tennis_courts() -> None:
 
     if up_for_send_data_list:
         sended_msg_list = _as_str_list(Variable.get(CACHE_KEY, deserialize_json=True, default=[]))
-        up_for_send_msg_list = build_new_notifications(up_for_send_data_list, sended_msg_list)
+        up_for_send_msg_list = build_new_notifications(
+            up_for_send_data_list,
+            sended_msg_list,
+            current_year=now.year,
+        )
         if up_for_send_msg_list:
             sended_msg_list.extend(up_for_send_msg_list)
             Variable.set(
@@ -206,7 +234,7 @@ def run_check_tennis_courts() -> None:
                 value=sended_msg_list[-MAX_CACHED_MESSAGES:],
                 description=(
                     f"{VENUE_NAME}网球场场地通知 - 最后更新: "
-                    f"{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+                    f"{now.strftime('%Y-%m-%d %H:%M:%S')}"
                 ),
                 serialize_json=True,
             )

--- a/tests/dsh_ydmap_watcher_test.py
+++ b/tests/dsh_ydmap_watcher_test.py
@@ -153,6 +153,66 @@ class DshYdmapWatcherTest(unittest.TestCase):
             ],
         )
 
+    def test_inspection_horizon_opens_fifth_day_at_noon(self) -> None:
+        before_open = dsh_watcher.datetime.datetime(2026, 8, 30, 11, 59, 59)
+        at_open = dsh_watcher.datetime.datetime(2026, 8, 30, 12, 0, 0)
+
+        self.assertEqual(dsh_watcher.inspection_days_for(before_open), 4)
+        self.assertEqual(dsh_watcher.inspection_days_for(at_open), 5)
+
+    def test_before_noon_ignores_farthest_date_false_positive(self) -> None:
+        original_fetch = dsh_watcher.fetch_inspect_payload
+        original_publish = dsh_watcher.publish_venue_observation
+        original_enqueue = dsh_watcher.enqueue_wechat_message
+        original_datetime = dsh_watcher.datetime
+
+        class FixedDatetime(original_datetime.datetime):
+            @classmethod
+            def now(cls, tz: object = None) -> FixedDatetime:
+                return cls(2026, 8, 30, 8, 23, 0)
+
+        class FixedDatetimeModule:
+            datetime = FixedDatetime
+            time = original_datetime.time
+            timedelta = original_datetime.timedelta
+
+        published: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        def fake_fetch(config: object, *, days: int) -> dict[str, object]:
+            self.assertEqual(days, 4)
+            return {
+                "ok": True,
+                "days": [
+                    {
+                        "date": "2026-09-03",
+                        "courts": {"1号风雨场": [["18:00", "22:00"]]},
+                    }
+                ],
+            }
+
+        def fake_publish(*args: object, **kwargs: object) -> dict[str, bool]:
+            published.append((args, kwargs))
+            return {"success": True}
+
+        def fail_wechat(msg: str) -> object:
+            raise AssertionError(f"unreleased farthest date must not notify: {msg}")
+
+        dsh_watcher.fetch_inspect_payload = fake_fetch
+        dsh_watcher.publish_venue_observation = fake_publish
+        dsh_watcher.enqueue_wechat_message = fail_wechat
+        dsh_watcher.datetime = FixedDatetimeModule
+        try:
+            dsh_watcher.run_check_tennis_courts()
+            self.assertEqual(len(published), 1)
+            self.assertEqual(published[0][0][:3], ("dsh", "大沙河国际网球中心", []))
+            self.assertEqual(published[0][1], {"healthy": True})
+            self.assertNotIn(dsh_watcher.CACHE_KEY, FakeVariable.values)
+        finally:
+            dsh_watcher.fetch_inspect_payload = original_fetch
+            dsh_watcher.publish_venue_observation = original_publish
+            dsh_watcher.enqueue_wechat_message = original_enqueue
+            dsh_watcher.datetime = original_datetime
+
     def test_check_tennis_courts_publishes_webapp_before_wechat(self) -> None:
         expected_msg = "【大沙河国际网球中心1号风雨场】星期日(08-30)空场: 16:00-18:00"
         original_fetch = dsh_watcher.fetch_inspect_payload


### PR DESCRIPTION
## Root cause

大沙河国际网球中心会提前展示滚动的第 5 个日期，但该日期要到北京时间 12:00 才开放预订。开放前页面中的禁用场次可能被浏览器采集器识别为空场，随后进入 Web 订阅与微信通知链路，造成最远日期的错误提醒。

这不是固定“星期四”规则，而是每天滚动的最远可预订日期规则。

## Changes

- 使用 `Asia/Shanghai` 作为开放时间判断基准。
- 00:00–11:59 只请求并处理已经开放的前 4 天；不会点击、解析、发布或通知第 5 天。
- 12:00 起恢复原有 5 天巡检范围。
- 保持大沙河 DAG 原有 3 分钟巡检频率，前 4 天的巡检和通知逻辑不变。
- Web observation 与微信通知共用同一日期边界，避免一侧仍产生错误提醒。
- 发布版本准备为 `0.5.3`。

## Regression coverage

- 覆盖 11:59:59 返回 4 天、12:00:00 返回 5 天的边界。
- 模拟截图中的 08:23 场景，并故意注入第 5 天 `18:00-22:00` 的假空场；断言该日期不会进入 Web、缓存或微信。
- 保留 13:00 后 5 天巡检以及 Web 先于微信发布的既有测试。

## Safety

- 不修改 DAG ID、调度频率、Airflow Variable schema 或发送端。
- 未发送真实邮件或微信消息。
- 变更范围为 Airflow；发布时 `sender=false`。

本地隔离验证：10 个大沙河相关单元测试通过，Python 编译检查通过。权威门禁为本 PR 精确 head SHA 的 `CI / verify`。