### PR TITLE
fix(ci): trust bounded nightly sync commits and coalesce recovery

### DIFF
--- a/.github/workflows/nightly-dependabot-maintenance.yml
+++ b/.github/workflows/nightly-dependabot-maintenance.yml
@@ -3,16 +3,19 @@ run-name: nightly/dependabot/${{ github.run_id }}
 
 on:
   schedule:
-    # GitHub cron is UTC. Running at both UTC candidates plus the timezone
-    # guard below keeps the task at 01:00 in America/Los_Angeles across DST.
+    # GitHub cron is UTC. Both candidates plus the timezone guard keep the
+    # maintenance window at 01:00 America/Los_Angeles across daylight saving.
     - cron: "0 8,9 * * *"
   workflow_dispatch:
     inputs:
       max_pull_requests:
-        description: Maximum Dependabot pull requests to process in this run
+        description: Maximum Dependabot pull requests to process in this pass
         required: false
         default: "25"
         type: string
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
   push:
     branches: [main]
     paths:
@@ -28,748 +31,542 @@ permissions:
 
 concurrency:
   group: nightly-dependabot-maintenance
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   maintain:
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 20
     steps:
       - name: Reconcile every same-repository Dependabot pull request
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          EVENT_NAME: ${{ github.event_name }}
-          MAX_PULL_REQUESTS_INPUT: ${{ inputs.max_pull_requests }}
-          WORKFLOW_FILE: nightly-dependabot-maintenance.yml
-        run: |
-          set -euo pipefail
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          retries: 3
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const repository = `${owner}/${repo}`;
+            const localTimeZone = "America/Los_Angeles";
+            const workflowFile = "nightly-dependabot-maintenance.yml";
+            const dependabotEmail = "49699333+dependabot[bot]@users.noreply.github.com";
+            const recoveryGraceMs = 30 * 60 * 1000;
+            const backlogTitle = "[automation] Dependabot maintenance backlog";
 
-          readonly LOCAL_TZ="America/Los_Angeles"
-          readonly LOCAL_DATE="$(TZ="$LOCAL_TZ" date +%F)"
-          readonly LOCAL_HOUR="$(TZ="$LOCAL_TZ" date +%H)"
-          readonly START_EPOCH="$(date +%s)"
-          readonly DEADLINE_EPOCH="$((START_EPOCH + 9600))"
-          readonly CI_WAIT_SECONDS=1200
-          readonly HEAD_WAIT_SECONDS=360
-          readonly DEPENDABOT_EMAIL="49699333+dependabot[bot]@users.noreply.github.com"
+            const parts = Object.fromEntries(
+              new Intl.DateTimeFormat("en-US", {
+                timeZone: localTimeZone,
+                year: "numeric",
+                month: "2-digit",
+                day: "2-digit",
+                hour: "2-digit",
+                hourCycle: "h23",
+              })
+                .formatToParts(new Date())
+                .filter((part) => part.type !== "literal")
+                .map((part) => [part.type, part.value]),
+            );
+            const localDate = `${parts.year}-${parts.month}-${parts.day}`;
+            const localHour = parts.hour;
+            const maxPullRequests = Number(context.payload.inputs?.max_pull_requests ?? "25");
 
-          MAX_PULL_REQUESTS="${MAX_PULL_REQUESTS_INPUT:-25}"
-          if [[ ! "$MAX_PULL_REQUESTS" =~ ^[0-9]+$ ]] ||
-             ((MAX_PULL_REQUESTS < 1 || MAX_PULL_REQUESTS > 100)); then
-            echo "max_pull_requests must be an integer between 1 and 100" >&2
-            exit 2
-          fi
-
-          if [[ "$EVENT_NAME" == "schedule" && "$LOCAL_HOUR" != "01" ]]; then
-            echo "Skipping UTC companion schedule; local time is $LOCAL_HOUR:00 $LOCAL_TZ."
-            exit 0
-          fi
-
-          if [[ "$EVENT_NAME" == "schedule" ]]; then
-            duplicate_run=false
-            while IFS=$'\t' read -r run_id status conclusion created_at; do
-              [[ -n "$run_id" && "$run_id" != "$GITHUB_RUN_ID" ]] || continue
-              run_local_date="$(TZ="$LOCAL_TZ" date -d "$created_at" +%F)"
-              if [[ "$run_local_date" == "$LOCAL_DATE" &&
-                    ("$status" == "in_progress" ||
-                     "$status" == "queued" ||
-                     "$conclusion" == "success") ]]; then
-                duplicate_run=true
-                break
-              fi
-            done < <(
-              gh api \
-                "repos/$REPO/actions/workflows/$WORKFLOW_FILE/runs?event=schedule&per_page=20" \
-                --jq '.workflow_runs[] | [
-                  (.id | tostring),
-                  .status,
-                  (.conclusion // ""),
-                  .created_at
-                ] | @tsv'
-            )
-            if [[ "$duplicate_run" == "true" ]]; then
-              echo "A nightly maintenance run already owns $LOCAL_DATE in $LOCAL_TZ."
-              exit 0
-            fi
-          fi
-
-          ensure_label() {
-            local name="$1"
-            local color="$2"
-            local description="$3"
-            gh label create "$name" \
-              --repo "$REPO" \
-              --color "$color" \
-              --description "$description" \
-              --force >/dev/null
-          }
-
-          add_label() {
-            gh issue edit "$1" --repo "$REPO" --add-label "$2" >/dev/null
-          }
-
-          remove_label() {
-            gh issue edit "$1" \
-              --repo "$REPO" \
-              --remove-label "$2" >/dev/null 2>&1 || true
-          }
-
-          has_comment_marker() {
-            local number="$1"
-            local marker="$2"
-            local comments_json=""
-            comments_json="$(
-              gh api --paginate \
-                "repos/$REPO/issues/$number/comments?per_page=100"
-            )"
-            jq -e -s --arg marker "$marker" '
-              [.[][] | (.body // "") | contains($marker)] | any
-            ' <<< "$comments_json" >/dev/null
-          }
-
-          comment_once() {
-            local number="$1"
-            local marker="$2"
-            local body="$3"
-            if ! has_comment_marker "$number" "$marker"; then
-              gh pr comment "$number" \
-                --repo "$REPO" \
-                --body "$body" >/dev/null
-            fi
-          }
-
-          latest_ci() {
-            local sha="$1"
-            gh api \
-              "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$sha&event=pull_request&per_page=100" \
-              --jq '
-                if (.workflow_runs | length) == 0 then
-                  ""
-                else
-                  .workflow_runs
-                  | sort_by(.run_number)
-                  | last
-                  | [
-                      (.id | tostring),
-                      .status,
-                      (.conclusion // ""),
-                      (.run_number | tostring)
-                    ]
-                  | @tsv
-                end
-              '
-          }
-
-          wait_for_ci() {
-            local sha="$1"
-            local timeout_seconds="$2"
-            local wait_deadline="$(( $(date +%s) + timeout_seconds ))"
-            local row=""
-            while (($(date +%s) < wait_deadline)); do
-              row="$(latest_ci "$sha")"
-              if [[ -n "$row" ]]; then
-                IFS=$'\t' read -r run_id status conclusion run_number <<< "$row"
-                if [[ "$status" == "completed" ]]; then
-                  printf '%s\t%s\t%s\t%s\n' \
-                    "$run_id" "$status" "$conclusion" "$run_number"
-                  return 0
-                fi
-              fi
-              sleep 15
-            done
-            if [[ -n "$row" ]]; then
-              printf '%s\n' "$row"
-            else
-              printf '0\tmissing\t\t0\n'
-            fi
-          }
-
-          wait_for_head_change() {
-            local number="$1"
-            local old_sha="$2"
-            local timeout_seconds="$3"
-            local wait_deadline="$(( $(date +%s) + timeout_seconds ))"
-            while (($(date +%s) < wait_deadline)); do
-              current_head="$(
-                gh api "repos/$REPO/pulls/$number" --jq '.head.sha // ""'
-              )"
-              if [[ -n "$current_head" && "$current_head" != "$old_sha" ]]; then
-                printf '%s\n' "$current_head"
-                return 0
-              fi
-              sleep 15
-            done
-            return 1
-          }
-
-          dependency_paths_are_bounded() {
-            local files_json="$1"
-            local path=""
-            while IFS= read -r path; do
-              case "$path" in
-                pyproject.toml|uv.lock|poetry.lock|Pipfile|Pipfile.lock)
-                  ;;
-                requirements.txt|requirements-*.txt|requirements/*.txt)
-                  ;;
-                webapp/package.json|webapp/package-lock.json|webapp/npm-shrinkwrap.json)
-                  ;;
-                docker/*/Dockerfile|docker/*/Dockerfile.*|Dockerfile|Dockerfile.*)
-                  ;;
-                .github/workflows/*.yml|.github/workflows/*.yaml)
-                  ;;
-                .github/actions/*/action.yml|.github/actions/*/action.yaml)
-                  ;;
-                *)
-                  echo "unexpected dependency-update path: $path" >&2
-                  return 1
-                  ;;
-              esac
-            done < <(jq -r -s '[.[][]] | .[].filename' <<< "$files_json")
-          }
-
-          control_plane_patches_are_bounded() {
-            local files_json="$1"
-            local item=""
-            local filename=""
-            local patch=""
-            local line=""
-            local changed_line=""
-
-            while IFS= read -r item; do
-              filename="$(
-                base64 --decode <<< "$item" |
-                  jq -r '.filename'
-              )"
-              patch="$(
-                base64 --decode <<< "$item" |
-                  jq -r '.patch // ""'
-              )"
-              [[ -n "$patch" ]] || return 1
-
-              while IFS= read -r line; do
-                case "$line" in
-                  "+++"*|"---"*|"@@"*)
-                    continue
-                    ;;
-                  "+"*|"-"*)
-                    changed_line="${line:1}"
-                    case "$filename" in
-                      .github/workflows/*.yml|.github/workflows/*.yaml)
-                        [[ "$changed_line" =~ ^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]+[^[:space:]]+@[^[:space:]#]+([[:space:]]+\#.*)?$ ]] ||
-                          return 1
-                        ;;
-                      .github/actions/*/action.yml|.github/actions/*/action.yaml)
-                        [[ "$changed_line" =~ ^[[:space:]]*(uses:|-[[:space:]]+uses:)[[:space:]]+[^[:space:]]+@[^[:space:]#]+([[:space:]]+\#.*)?$ ]] ||
-                          return 1
-                        ;;
-                      docker/*/Dockerfile|docker/*/Dockerfile.*|Dockerfile|Dockerfile.*)
-                        [[ "$changed_line" =~ ^[[:space:]]*FROM[[:space:]]+(--platform=[^[:space:]]+[[:space:]]+)?[^[:space:]]+([[:space:]]+[Aa][Ss][[:space:]]+[^[:space:]]+)?[[:space:]]*$ ]] ||
-                          return 1
-                        ;;
-                    esac
-                    ;;
-                esac
-              done <<< "$patch"
-            done < <(
-              jq -r -s '
-                [.[][]]
-                | .[]
-                | select(
-                    (.filename | startswith(".github/workflows/"))
-                    or (.filename | startswith(".github/actions/"))
-                    or (.filename | test("(^|/)Dockerfile([.].*)?$"))
-                  )
-                | @base64
-              ' <<< "$files_json"
-            )
-          }
-
-          commits_are_dependabot_only() {
-            local number="$1"
-            local expected_count="$2"
-            local commits_json=""
-            local returned_count=""
-            local non_bot_count=""
-            commits_json="$(
-              gh api --paginate \
-                "repos/$REPO/pulls/$number/commits?per_page=100"
-            )"
-            returned_count="$(jq -r -s '[.[][]] | length' <<< "$commits_json")"
-            [[ "$returned_count" == "$expected_count" ]] || return 1
-            non_bot_count="$(
-              jq -r -s --arg email "$DEPENDABOT_EMAIL" '
-                [.[][]]
-                | map(
-                    select(
-                      (.author.login // "") != "dependabot[bot]"
-                      and (.commit.author.email // "") != $email
-                    )
-                  )
-                | length
-              ' <<< "$commits_json"
-            )"
-            [[ "$non_bot_count" == "0" ]]
-          }
-
-          diagnose_ci() {
-            local run_id="$1"
-            gh api "repos/$REPO/actions/runs/$run_id/jobs?filter=latest&per_page=100" \
-              --jq '
-                [
-                  .jobs[]
-                  | select(.conclusion == "failure")
-                  | "- `" + .name + "`: " +
-                    (
-                      [
-                        .steps[]
-                        | select(.conclusion == "failure")
-                        | .name
-                      ]
-                      | if length == 0 then "job failed" else join(", ") end
-                    )
-                ]
-                | if length == 0 then "- Failure details were not returned by GitHub." else .[] end
-              '
-          }
-
-          ensure_label \
-            "maintenance:nightly" \
-            "1d76db" \
-            "Managed by the authorized nightly Dependabot maintainer"
-          ensure_label \
-            "maintenance:retrying" \
-            "fbca04" \
-            "Nightly maintainer is retrying or rebuilding this dependency update"
-          ensure_label \
-            "maintenance:needs-repair" \
-            "b60205" \
-            "Dependency update still fails after bounded automatic recovery"
-          ensure_label \
-            "maintenance:awaiting-ci" \
-            "c5def5" \
-            "Dependency update is waiting for exact-head CI"
-
-          summary_file="/tmp/nightly-dependabot-summary.md"
-          blocked_file="/tmp/nightly-dependabot-blocked.md"
-          : > "$blocked_file"
-          {
-            echo "## Nightly Dependabot maintenance"
-            echo
-            echo "- Local maintenance date: \`$LOCAL_DATE\`"
-            echo "- Timezone: \`$LOCAL_TZ\`"
-            echo "- Maximum PRs: \`$MAX_PULL_REQUESTS\`"
-            echo
-          } > "$summary_file"
-
-          processed=0
-          merged=0
-          updated=0
-          recreated=0
-          rerun=0
-          awaiting=0
-          blocked=0
-          skipped=0
-
-          mapfile -t pull_requests < <(
-            gh api --paginate \
-              "repos/$REPO/pulls?state=open&base=main&per_page=100" |
-              jq -r -s '
-                [.[][]]
-                | map(
-                    select(
-                      .user.login == "dependabot[bot]"
-                      and .base.ref == "main"
-                    )
-                  )
-                | sort_by(.created_at)
-                | .[].number
-              '
-          )
-
-          if ((${#pull_requests[@]} == 0)); then
-            echo "No open Dependabot pull requests target main." |
-              tee -a "$summary_file"
-          fi
-
-          for number in "${pull_requests[@]}"; do
-            ((processed >= MAX_PULL_REQUESTS)) && break
-            (($(date +%s) < DEADLINE_EPOCH)) || {
-              echo "- Runtime budget reached before PR #$number." >> "$summary_file"
-              break
+            if (!Number.isInteger(maxPullRequests) || maxPullRequests < 1 || maxPullRequests > 100) {
+              core.setFailed("max_pull_requests must be an integer between 1 and 100");
+              return;
             }
-            [[ "$number" =~ ^[0-9]+$ ]] || continue
-            ((processed += 1))
 
-            resolved=false
-            for attempt in 1 2 3; do
-              pr_json=""
-              for _ in 1 2 3 4 5; do
-                pr_json="$(gh api "repos/$REPO/pulls/$number")"
-                mergeable_state="$(
-                  jq -r '.mergeable_state // "unknown"' <<< "$pr_json"
-                )"
-                mergeable="$(
-                  jq -r '
-                    if .mergeable == null then
-                      "unknown"
-                    else
-                      (.mergeable | tostring)
-                    end
-                  ' <<< "$pr_json"
-                )"
-                if [[ "$mergeable_state" != "unknown" &&
-                      "$mergeable" != "unknown" ]]; then
-                  break
-                fi
-                sleep 2
-              done
-              state="$(jq -r '.state' <<< "$pr_json")"
-              draft="$(jq -r '.draft' <<< "$pr_json")"
-              author="$(jq -r '.user.login' <<< "$pr_json")"
-              base_ref="$(jq -r '.base.ref' <<< "$pr_json")"
-              head_repo="$(jq -r '.head.repo.full_name // ""' <<< "$pr_json")"
-              head_sha="$(jq -r '.head.sha' <<< "$pr_json")"
-              reported_changed_files="$(jq -r '.changed_files // -1' <<< "$pr_json")"
-              reported_commits="$(jq -r '.commits // -1' <<< "$pr_json")"
-              body="$(jq -r '.body // ""' <<< "$pr_json")"
+            if (context.eventName === "schedule" && localHour !== "01") {
+              core.info(`Skipping UTC companion schedule at local hour ${localHour}.`);
+              return;
+            }
 
-              if [[ "$state" != "open" ||
-                    "$draft" != "false" ||
-                    "$author" != "dependabot[bot]" ||
-                    "$base_ref" != "main" ||
-                    "$head_repo" != "$REPO" ]]; then
-                ((skipped += 1))
-                echo "- Skipped #$number because its identity or state changed." \
-                  >> "$summary_file"
-                resolved=true
-                break
-              fi
+            const localDateFor = (value) => {
+              const dateParts = Object.fromEntries(
+                new Intl.DateTimeFormat("en-US", {
+                  timeZone: localTimeZone,
+                  year: "numeric",
+                  month: "2-digit",
+                  day: "2-digit",
+                })
+                  .formatToParts(new Date(value))
+                  .filter((part) => part.type !== "literal")
+                  .map((part) => [part.type, part.value]),
+              );
+              return `${dateParts.year}-${dateParts.month}-${dateParts.day}`;
+            };
 
-              if [[ ! "$reported_changed_files" =~ ^[0-9]+$ ||
-                    ! "$reported_commits" =~ ^[0-9]+$ ||
-                    "$body" == *"Maintainer changes"* ]]; then
-                add_label "$number" "maintenance:needs-repair"
-                untrusted_marker="<!-- nightly-dependabot-untrusted:$head_sha -->"
-                untrusted_body="$(
-                  printf '%s\n\n%s\n' \
-                    "Nightly maintenance stopped because GitHub metadata was incomplete or the branch reports maintainer changes." \
-                    "$untrusted_marker"
-                )"
-                comment_once \
-                  "$number" \
-                  "$untrusted_marker" \
-                  "$untrusted_body"
-                ((blocked += 1))
-                echo "- #$number: incomplete or maintainer-modified metadata." \
-                  | tee -a "$blocked_file" >> "$summary_file"
-                resolved=true
-                break
-              fi
+            if (context.eventName === "schedule") {
+              const scheduleRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner,
+                repo,
+                workflow_id: workflowFile,
+                event: "schedule",
+                per_page: 100,
+              });
+              const duplicate = scheduleRuns.some((run) => {
+                if (run.id === context.runId || localDateFor(run.created_at) !== localDate) return false;
+                return ["queued", "in_progress"].includes(run.status) || run.conclusion === "success";
+              });
+              if (duplicate) {
+                core.info(`A maintenance run already owns ${localDate} in ${localTimeZone}.`);
+                return;
+              }
+            }
 
-              files_json="$(
-                gh api --paginate \
-                  "repos/$REPO/pulls/$number/files?per_page=100"
-              )"
-              returned_changed_files="$(
-                jq -r -s '[.[][]] | length' <<< "$files_json"
-              )"
+            const labels = [
+              ["maintenance:nightly", "1d76db", "Managed by the authorized nightly Dependabot maintainer"],
+              ["maintenance:retrying", "fbca04", "Nightly maintainer is retrying or rebuilding this dependency update"],
+              ["maintenance:needs-repair", "b60205", "Dependency update still fails after bounded automatic recovery"],
+              ["maintenance:awaiting-ci", "c5def5", "Dependency update is waiting for exact-head CI"],
+            ];
 
-              if [[ "$returned_changed_files" != "$reported_changed_files" ]] ||
-                 ! dependency_paths_are_bounded "$files_json" ||
-                 ! control_plane_patches_are_bounded "$files_json" ||
-                 ! commits_are_dependabot_only "$number" "$reported_commits"; then
-                add_label "$number" "maintenance:needs-repair"
-                boundary_marker="<!-- nightly-dependabot-boundary:$head_sha -->"
-                boundary_body="$(
-                  printf '%s\n\n%s\n' \
-                    "Nightly maintenance refused to mutate or merge this branch because its commits or changed-file listing were outside the dependency-only safety boundary." \
-                    "$boundary_marker"
-                )"
-                comment_once \
-                  "$number" \
-                  "$boundary_marker" \
-                  "$boundary_body"
-                ((blocked += 1))
-                echo "- #$number: dependency-only boundary validation failed." \
-                  | tee -a "$blocked_file" >> "$summary_file"
-                resolved=true
-                break
-              fi
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({ owner, repo, name, color, description });
+              }
+            }
+            for (const [name, color, description] of labels) {
+              await ensureLabel(name, color, description);
+            }
 
-              add_label "$number" "maintenance:nightly"
+            async function addLabel(number, name) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: [name] });
+            }
 
-              if [[ "$mergeable_state" == "behind" ]]; then
-                if gh api --method PUT \
-                  "repos/$REPO/pulls/$number/update-branch" \
-                  -f expected_head_sha="$head_sha" >/dev/null; then
-                  add_label "$number" "maintenance:retrying"
-                  remove_label "$number" "maintenance:needs-repair"
-                  ((updated += 1))
-                  echo "- #$number: synchronized with the latest main." \
-                    >> "$summary_file"
-                  if new_head="$(
-                    wait_for_head_change \
-                      "$number" "$head_sha" "$HEAD_WAIT_SECONDS"
-                  )"; then
-                    head_sha="$new_head"
-                    continue
-                  fi
-                fi
-                ((awaiting += 1))
-                add_label "$number" "maintenance:awaiting-ci"
-                echo "- #$number: branch synchronization is still settling." \
-                  >> "$summary_file"
-                resolved=true
-                break
-              fi
+            async function removeLabel(number, name) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }
 
-              if [[ "$mergeable_state" == "unknown" ||
-                    "$mergeable" == "unknown" ]]; then
-                ((awaiting += 1))
-                add_label "$number" "maintenance:awaiting-ci"
-                echo "- #$number: GitHub mergeability is still being computed." \
-                  >> "$summary_file"
-                resolved=true
-                break
-              fi
+            async function findMarker(number, marker) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: number,
+                per_page: 100,
+              });
+              return comments.find((comment) => (comment.body ?? "").includes(marker));
+            }
 
-              if [[ "$mergeable_state" == "dirty" || "$mergeable" != "true" ]]; then
-                recreate_marker="<!-- nightly-dependabot-recreate:$head_sha:$LOCAL_DATE -->"
-                if ! has_comment_marker "$number" "$recreate_marker"; then
-                  recreate_body="$(
-                    printf '%s\n\n%s\n\n%s\n' \
-                      "@dependabot recreate" \
-                      "The authorized nightly maintainer requested a clean rebuild against the current \`main\`." \
-                      "$recreate_marker"
-                  )"
-                  gh pr comment "$number" \
-                    --repo "$REPO" \
-                    --body "$recreate_body" >/dev/null
-                  add_label "$number" "maintenance:retrying"
-                  ((recreated += 1))
-                  echo "- #$number: requested a clean Dependabot rebuild." \
-                    >> "$summary_file"
-                  if new_head="$(
-                    wait_for_head_change \
-                      "$number" "$head_sha" "$HEAD_WAIT_SECONDS"
-                  )"; then
-                    head_sha="$new_head"
-                    continue
-                  fi
-                fi
-                ((awaiting += 1))
-                add_label "$number" "maintenance:awaiting-ci"
-                echo "- #$number: waiting for Dependabot to rebuild the branch." \
-                  >> "$summary_file"
-                resolved=true
-                break
-              fi
+            async function commentOnce(number, marker, body) {
+              const existing = await findMarker(number, marker);
+              if (existing) return existing;
+              const response = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: number,
+                body: `${body}\n\n${marker}`,
+              });
+              return response.data;
+            }
 
-              IFS=$'\t' read -r \
-                ci_run_id ci_status ci_conclusion ci_run_number < <(
-                  wait_for_ci "$head_sha" "$CI_WAIT_SECONDS"
-                )
+            const dependencyPathPatterns = [
+              /^pyproject[.]toml$/,
+              /^(?:uv|poetry)[.]lock$/,
+              /^Pipfile(?:[.]lock)?$/,
+              /^requirements(?:-[^/]+)?[.]txt$/,
+              /^requirements[/].+[.]txt$/,
+              /^webapp[/](?:package[.]json|package-lock[.]json|npm-shrinkwrap[.]json)$/,
+              /^(?:docker[/][^/]+[/])?Dockerfile(?:[.].+)?$/,
+              /^[.]github[/]workflows[/][^/]+[.]ya?ml$/,
+              /^[.]github[/]actions[/].+[/]action[.]ya?ml$/,
+            ];
 
-              if [[ "$ci_status" != "completed" ]]; then
-                add_label "$number" "maintenance:awaiting-ci"
-                ((awaiting += 1))
-                echo "- #$number: exact-head CI is still ${ci_status:-missing}." \
-                  >> "$summary_file"
-                resolved=true
-                break
-              fi
+            function pathsAreBounded(files) {
+              return files.every((file) => dependencyPathPatterns.some((pattern) => pattern.test(file.filename)));
+            }
 
-              if [[ "$ci_conclusion" != "success" ]]; then
-                rerun_marker="<!-- nightly-dependabot-rerun:$head_sha:$LOCAL_DATE -->"
-                if ! has_comment_marker "$number" "$rerun_marker"; then
-                  if gh run rerun "$ci_run_id" --failed --repo "$REPO"; then
-                    rerun_body="$(
-                      printf '%s\n\n%s\n' \
-                        "Nightly maintenance is retrying failed CI jobs once before rebuilding the dependency branch." \
-                        "$rerun_marker"
-                    )"
-                    gh pr comment "$number" \
-                      --repo "$REPO" \
-                      --body "$rerun_body" >/dev/null
-                    add_label "$number" "maintenance:retrying"
-                    ((rerun += 1))
-                    sleep 15
-                    IFS=$'\t' read -r \
-                      ci_run_id ci_status ci_conclusion ci_run_number < <(
-                        wait_for_ci "$head_sha" "$CI_WAIT_SECONDS"
-                      )
-                  fi
-                fi
-              fi
+            function changedLines(patch) {
+              return (patch ?? "")
+                .split("\n")
+                .filter((line) => line.startsWith("+") || line.startsWith("-"))
+                .filter((line) => !line.startsWith("+++") && !line.startsWith("---"))
+                .map((line) => line.slice(1));
+            }
 
-              if [[ "$ci_status" == "completed" &&
-                    "$ci_conclusion" == "success" ]]; then
-                latest_pr_json="$(gh api "repos/$REPO/pulls/$number")"
-                latest_head_sha="$(jq -r '.head.sha' <<< "$latest_pr_json")"
-                latest_mergeable="$(jq -r '.mergeable // false' <<< "$latest_pr_json")"
-                latest_state="$(jq -r '.state' <<< "$latest_pr_json")"
-                if [[ "$latest_state" != "open" ||
-                      "$latest_head_sha" != "$head_sha" ||
-                      "$latest_mergeable" != "true" ]]; then
-                  continue
-                fi
+            function controlPlanePatchesAreBounded(files) {
+              for (const file of files) {
+                const isWorkflow = /^[.]github[/]workflows[/][^/]+[.]ya?ml$/.test(file.filename);
+                const isAction = /^[.]github[/]actions[/].+[/]action[.]ya?ml$/.test(file.filename);
+                const isDockerfile = /(?:^|[/])Dockerfile(?:[.].+)?$/.test(file.filename);
+                if (!isWorkflow && !isAction && !isDockerfile) continue;
+                if (!file.patch) return false;
+                const lines = changedLines(file.patch);
+                if (lines.length === 0) return false;
+                if (isWorkflow || isAction) {
+                  const usesOnly = lines.every((line) =>
+                    /^\s*(?:-\s*)?uses:\s+\S+@\S+(?:\s+#.*)?$/.test(line),
+                  );
+                  if (!usesOnly) return false;
+                }
+                if (isDockerfile) {
+                  const fromOnly = lines.every((line) =>
+                    /^\s*FROM\s+(?:--platform=\S+\s+)?\S+(?:\s+[Aa][Ss]\s+\S+)?\s*$/.test(line),
+                  );
+                  if (!fromOnly) return false;
+                }
+              }
+              return true;
+            }
 
-                merge_response="$(
-                  gh api --method PUT \
-                    "repos/$REPO/pulls/$number/merge" \
-                    -f sha="$head_sha" \
-                    -f merge_method="squash" 2>/dev/null || true
-                )"
-                [[ -n "$merge_response" ]] || merge_response='{}'
-                if [[ "$(jq -r '.merged // false' <<< "$merge_response")" == "true" ]]; then
-                  ((merged += 1))
-                  remove_label "$number" "maintenance:retrying"
-                  remove_label "$number" "maintenance:awaiting-ci"
-                  remove_label "$number" "maintenance:needs-repair"
-                  echo "- #$number: merged exact head \`$head_sha\` after CI success." \
-                    >> "$summary_file"
-                  resolved=true
-                  break
-                fi
+            function commitIsTrusted(commit) {
+              const dependabotCommit =
+                commit.author?.login === "dependabot[bot]" ||
+                commit.commit?.author?.email === dependabotEmail;
+              const maintainerSyncCommit =
+                commit.author?.login === "github-actions[bot]" &&
+                /^Merge branch 'main' into dependabot[/]/.test(commit.commit?.message ?? "") &&
+                Array.isArray(commit.parents) &&
+                commit.parents.length === 2;
+              return dependabotCommit || maintainerSyncCommit;
+            }
 
-                merge_message="$(
-                  jq -r '.message // "GitHub rejected the merge"' \
-                    <<< "$merge_response"
-                )"
-                echo "- #$number: merge rejected: $merge_message." \
-                  >> "$summary_file"
-                continue
-              fi
+            async function latestExactHeadCi(headSha) {
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner,
+                repo,
+                workflow_id: "ci.yml",
+                head_sha: headSha,
+                event: "pull_request",
+                per_page: 100,
+              });
+              return runs
+                .filter((run) => run.head_sha === headSha)
+                .sort((left, right) => left.run_number - right.run_number)
+                .at(-1);
+            }
 
-              failure_recreate_marker="<!-- nightly-dependabot-failure-recreate:$number:$LOCAL_DATE -->"
-              if ! has_comment_marker "$number" "$failure_recreate_marker"; then
-                failure_recreate_body="$(
-                  printf '%s\n\n%s\n\n%s\n' \
-                    "@dependabot recreate" \
-                    "Exact-head CI still failed after one retry. The authorized nightly maintainer is rebuilding the branch once before declaring a compatibility repair." \
-                    "$failure_recreate_marker"
-                )"
-                gh pr comment "$number" \
-                  --repo "$REPO" \
-                  --body "$failure_recreate_body" >/dev/null
-                add_label "$number" "maintenance:retrying"
-                ((recreated += 1))
-                if new_head="$(
-                  wait_for_head_change \
-                    "$number" "$head_sha" "$HEAD_WAIT_SECONDS"
-                )"; then
-                  head_sha="$new_head"
-                  continue
-                fi
-              fi
+            async function failureDetails(runId) {
+              const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner,
+                repo,
+                run_id: runId,
+                filter: "latest",
+                per_page: 100,
+              });
+              const failures = jobs
+                .filter((job) => job.conclusion === "failure")
+                .map((job) => {
+                  const steps = (job.steps ?? [])
+                    .filter((step) => step.conclusion === "failure")
+                    .map((step) => step.name);
+                  return `- \`${job.name}\`: ${steps.length ? steps.join(", ") : "job failed"}`;
+                });
+              return failures.length ? failures.join("\n") : "- Failure details were not returned by GitHub.";
+            }
 
-              add_label "$number" "maintenance:needs-repair"
-              remove_label "$number" "maintenance:retrying"
-              remove_label "$number" "maintenance:awaiting-ci"
-              failure_marker="<!-- nightly-dependabot-failure:$head_sha -->"
-              failure_details="$(diagnose_ci "$ci_run_id")"
-              failure_body="$(
-                printf '%s\n\n%s\n%s\n%s\n%s\n\n%s\n\n%s\n\n%s\n' \
-                  "Nightly maintenance exhausted the bounded recovery sequence for this exact head:" \
-                  "1. synchronize or recreate against current \`main\`;" \
-                  "2. run the full exact-head CI;" \
-                  "3. retry failed jobs once;" \
-                  "4. recreate the Dependabot branch once." \
-                  "Persistent failing checks:" \
-                  "$failure_details" \
-                  "The PR remains open and is marked \`maintenance:needs-repair\`; it will never be merged while CI is failing." \
-                  "$failure_marker"
-              )"
-              comment_once \
-                "$number" \
-                "$failure_marker" \
-                "$failure_body"
-              ((blocked += 1))
-              {
-                echo "- #$number at \`$head_sha\`:"
-                echo "$failure_details"
-              } | tee -a "$blocked_file" >> "$summary_file"
-              resolved=true
-              break
-            done
+            const counters = {
+              processed: 0,
+              merged: 0,
+              synchronized: 0,
+              recreated: 0,
+              rerun: 0,
+              awaiting: 0,
+              blocked: 0,
+              skipped: 0,
+            };
+            const summary = [];
 
-            if [[ "$resolved" != "true" ]]; then
-              ((awaiting += 1))
-              add_label "$number" "maintenance:awaiting-ci"
-              echo "- #$number: deferred after bounded attempts." \
-                >> "$summary_file"
-            fi
-          done
+            const openPulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              base: "main",
+              sort: "created",
+              direction: "asc",
+              per_page: 100,
+            });
+            const dependabotPulls = openPulls
+              .filter((pull) => pull.user?.login === "dependabot[bot]")
+              .slice(0, maxPullRequests);
 
-          {
-            echo
-            echo "### Result"
-            echo
-            echo "- Processed: \`$processed\`"
-            echo "- Merged: \`$merged\`"
-            echo "- Synchronized: \`$updated\`"
-            echo "- Recreated: \`$recreated\`"
-            echo "- CI reruns: \`$rerun\`"
-            echo "- Awaiting external completion: \`$awaiting\`"
-            echo "- Persistent repair cases: \`$blocked\`"
-            echo "- Skipped after state changes: \`$skipped\`"
-          } | tee -a "$summary_file" >> "$GITHUB_STEP_SUMMARY"
+            for (const pull of dependabotPulls) {
+              const number = pull.number;
+              counters.processed += 1;
+              let current = (await github.rest.pulls.get({ owner, repo, pull_number: number })).data;
 
-          backlog_title="[automation] Dependabot maintenance backlog"
-          backlog_number="$(
-            gh issue list \
-              --repo "$REPO" \
-              --state all \
-              --search "$backlog_title in:title" \
-              --json number,title \
-              --jq '
-                map(
-                  select(
-                    .title == "[automation] Dependabot maintenance backlog"
-                  )
-                )
-                | first
-                | .number // ""
-              '
-          )"
+              if (
+                current.state !== "open" ||
+                current.draft ||
+                current.user?.login !== "dependabot[bot]" ||
+                current.base?.ref !== "main" ||
+                current.head?.repo?.full_name !== repository ||
+                !current.head?.ref?.startsWith("dependabot/")
+              ) {
+                counters.skipped += 1;
+                summary.push(`- #${number}: skipped because identity or state changed.`);
+                continue;
+              }
 
-          if ((blocked > 0)); then
-            {
-              echo "# Dependabot maintenance backlog"
-              echo
-              echo "Last nightly run: **$LOCAL_DATE** (\`$LOCAL_TZ\`)"
-              echo
-              echo "These PRs passed identity and dependency-only boundary checks,"
-              echo "but still need a compatibility repair because exact-head CI"
-              echo "failed after the bounded retry and branch-rebuild sequence."
-              echo
-              cat "$blocked_file"
-              echo
-              echo "Authoritative run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-            } > /tmp/nightly-dependabot-backlog.md
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: number,
+                per_page: 100,
+              });
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner,
+                repo,
+                pull_number: number,
+                per_page: 100,
+              });
+              const metadataComplete =
+                files.length === current.changed_files && commits.length === current.commits;
+              const branchReportsMaintainerChanges = (current.body ?? "").includes("Maintainer changes");
+              const boundaryOk =
+                metadataComplete &&
+                !branchReportsMaintainerChanges &&
+                pathsAreBounded(files) &&
+                controlPlanePatchesAreBounded(files) &&
+                commits.every(commitIsTrusted);
 
-            if [[ -z "$backlog_number" ]]; then
-              backlog_url="$(
-                gh issue create \
-                  --repo "$REPO" \
-                  --title "$backlog_title" \
-                  --body-file /tmp/nightly-dependabot-backlog.md \
-                  --label "maintenance:needs-repair"
-              )"
-              backlog_number="${backlog_url##*/}"
-            else
-              gh issue reopen "$backlog_number" \
-                --repo "$REPO" >/dev/null 2>&1 || true
-              gh issue edit "$backlog_number" \
-                --repo "$REPO" \
-                --body-file /tmp/nightly-dependabot-backlog.md \
-                --add-label "maintenance:needs-repair" >/dev/null
-            fi
-            echo "- Backlog issue: #$backlog_number" >> "$GITHUB_STEP_SUMMARY"
-          elif [[ -n "$backlog_number" ]]; then
-            gh issue close "$backlog_number" \
-              --repo "$REPO" \
-              --comment "Nightly maintenance found no persistent Dependabot repair cases on $LOCAL_DATE." \
-              >/dev/null 2>&1 || true
-          fi
+              if (!boundaryOk) {
+                await addLabel(number, "maintenance:needs-repair");
+                await removeLabel(number, "maintenance:retrying");
+                await removeLabel(number, "maintenance:awaiting-ci");
+                const marker = `<!-- nightly-dependabot-boundary:${current.head.sha} -->`;
+                await commentOnce(
+                  number,
+                  marker,
+                  "Nightly maintenance refused to mutate or merge this branch because its identity, commits, complete changed-file listing, or dependency-only patch boundary could not be proven.",
+                );
+                counters.blocked += 1;
+                summary.push(`- #${number}: dependency-only boundary validation failed.`);
+                continue;
+              }
+
+              await addLabel(number, "maintenance:nightly");
+              await removeLabel(number, "maintenance:needs-repair");
+              await removeLabel(number, "maintenance:retrying");
+              await removeLabel(number, "maintenance:awaiting-ci");
+
+              if (current.mergeable_state === "behind") {
+                await github.request("PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch", {
+                  owner,
+                  repo,
+                  pull_number: number,
+                  expected_head_sha: current.head.sha,
+                });
+                await addLabel(number, "maintenance:retrying");
+                await addLabel(number, "maintenance:awaiting-ci");
+                counters.synchronized += 1;
+                summary.push(`- #${number}: synchronized with current \`main\`; exact-head CI will continue the loop.`);
+                continue;
+              }
+
+              if (current.mergeable_state === "unknown" || current.mergeable === null) {
+                await addLabel(number, "maintenance:awaiting-ci");
+                counters.awaiting += 1;
+                summary.push(`- #${number}: GitHub is still computing mergeability.`);
+                continue;
+              }
+
+              if (current.mergeable_state === "dirty" || current.mergeable === false) {
+                const marker = `<!-- nightly-dependabot-recreate:${number}:${localDate} -->`;
+                const prior = await findMarker(number, marker);
+                if (!prior) {
+                  await commentOnce(
+                    number,
+                    marker,
+                    "@dependabot recreate\n\nThe authorized nightly maintainer requested a clean rebuild against the current `main`.",
+                  );
+                  await addLabel(number, "maintenance:retrying");
+                  await addLabel(number, "maintenance:awaiting-ci");
+                  counters.recreated += 1;
+                  summary.push(`- #${number}: requested one clean branch rebuild.`);
+                } else if (Date.now() - Date.parse(prior.created_at) < recoveryGraceMs) {
+                  await addLabel(number, "maintenance:awaiting-ci");
+                  counters.awaiting += 1;
+                  summary.push(`- #${number}: waiting for the requested branch rebuild.`);
+                } else {
+                  await addLabel(number, "maintenance:needs-repair");
+                  counters.blocked += 1;
+                  summary.push(`- #${number}: conflict persisted after the bounded rebuild request.`);
+                }
+                continue;
+              }
+
+              const ciRun = await latestExactHeadCi(current.head.sha);
+              if (!ciRun || ciRun.status !== "completed") {
+                await addLabel(number, "maintenance:awaiting-ci");
+                counters.awaiting += 1;
+                summary.push(`- #${number}: exact-head CI is ${ciRun?.status ?? "missing"}.`);
+                continue;
+              }
+
+              if (ciRun.conclusion === "success") {
+                current = (await github.rest.pulls.get({ owner, repo, pull_number: number })).data;
+                if (
+                  current.state !== "open" ||
+                  current.head.sha !== ciRun.head_sha ||
+                  current.mergeable_state === "behind" ||
+                  current.mergeable_state === "dirty" ||
+                  current.mergeable === false
+                ) {
+                  await addLabel(number, "maintenance:awaiting-ci");
+                  counters.awaiting += 1;
+                  summary.push(`- #${number}: head or mergeability moved after CI verification.`);
+                  continue;
+                }
+
+                try {
+                  const merge = await github.rest.pulls.merge({
+                    owner,
+                    repo,
+                    pull_number: number,
+                    sha: current.head.sha,
+                    merge_method: "squash",
+                  });
+                  if (merge.data.merged) {
+                    counters.merged += 1;
+                    summary.push(`- #${number}: merged exact head \`${current.head.sha}\` after complete CI success.`);
+                    continue;
+                  }
+                  throw new Error(merge.data.message ?? "GitHub rejected the merge");
+                } catch (error) {
+                  await addLabel(number, "maintenance:awaiting-ci");
+                  counters.awaiting += 1;
+                  summary.push(`- #${number}: merge gate deferred the PR: ${error.message}.`);
+                  continue;
+                }
+              }
+
+              const rerunMarker = `<!-- nightly-dependabot-rerun:${current.head.sha}:${localDate} -->`;
+              const priorRerun = await findMarker(number, rerunMarker);
+              if (!priorRerun) {
+                await github.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: ciRun.id });
+                await commentOnce(
+                  number,
+                  rerunMarker,
+                  "Nightly maintenance is retrying failed exact-head CI jobs once before rebuilding the dependency branch.",
+                );
+                await addLabel(number, "maintenance:retrying");
+                await addLabel(number, "maintenance:awaiting-ci");
+                counters.rerun += 1;
+                summary.push(`- #${number}: retried failed exact-head CI jobs once.`);
+                continue;
+              }
+
+              if (Date.now() - Date.parse(priorRerun.created_at) < recoveryGraceMs) {
+                await addLabel(number, "maintenance:awaiting-ci");
+                counters.awaiting += 1;
+                summary.push(`- #${number}: waiting for the bounded CI retry.`);
+                continue;
+              }
+
+              const rebuildMarker = `<!-- nightly-dependabot-failure-recreate:${number}:${localDate} -->`;
+              const priorRebuild = await findMarker(number, rebuildMarker);
+              if (!priorRebuild) {
+                await commentOnce(
+                  number,
+                  rebuildMarker,
+                  "@dependabot recreate\n\nExact-head CI still failed after one retry. The authorized nightly maintainer is rebuilding the branch once before declaring a compatibility repair.",
+                );
+                await addLabel(number, "maintenance:retrying");
+                await addLabel(number, "maintenance:awaiting-ci");
+                counters.recreated += 1;
+                summary.push(`- #${number}: requested one rebuild after persistent CI failure.`);
+                continue;
+              }
+
+              if (Date.now() - Date.parse(priorRebuild.created_at) < recoveryGraceMs) {
+                await addLabel(number, "maintenance:awaiting-ci");
+                counters.awaiting += 1;
+                summary.push(`- #${number}: waiting for the bounded failure rebuild.`);
+                continue;
+              }
+
+              const details = await failureDetails(ciRun.id);
+              const failureMarker = `<!-- nightly-dependabot-failure:${current.head.sha} -->`;
+              await commentOnce(
+                number,
+                failureMarker,
+                `Nightly maintenance exhausted synchronization, one failed-job retry, and one clean branch rebuild for this exact head. It will not merge while CI is failing.\n\nPersistent failing checks:\n${details}`,
+              );
+              await addLabel(number, "maintenance:needs-repair");
+              await removeLabel(number, "maintenance:retrying");
+              await removeLabel(number, "maintenance:awaiting-ci");
+              counters.blocked += 1;
+              summary.push(`- #${number}: persistent exact-head CI failure requires a compatibility repair.`);
+            }
+
+            const repairIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              labels: "maintenance:needs-repair",
+              per_page: 100,
+            });
+            const repairPulls = repairIssues.filter((issue) => issue.pull_request);
+            const allIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "all",
+              per_page: 100,
+            });
+            const backlog = allIssues.find((issue) => issue.title === backlogTitle && !issue.pull_request);
+
+            if (repairPulls.length) {
+              const body = [
+                "# Dependabot maintenance backlog",
+                "",
+                `Last reconciliation: **${localDate}** (\`${localTimeZone}\`)`,
+                "",
+                "These automated dependency PRs remain open because their dependency-only boundary or exact-head CI has not yet passed:",
+                "",
+                ...repairPulls.map((issue) => `- #${issue.number} — ${issue.title}`),
+                "",
+                `Authoritative run: ${context.serverUrl}/${repository}/actions/runs/${context.runId}`,
+              ].join("\n");
+              if (backlog) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: backlog.number,
+                  state: "open",
+                  body,
+                  labels: ["maintenance:needs-repair"],
+                });
+              } else {
+                await github.rest.issues.create({
+                  owner,
+                  repo,
+                  title: backlogTitle,
+                  body,
+                  labels: ["maintenance:needs-repair"],
+                });
+              }
+            } else if (backlog?.state === "open") {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: backlog.number,
+                state: "closed",
+                state_reason: "completed",
+              });
+            }
+
+            const resultLines = [
+              `- Local maintenance date: \`${localDate}\``,
+              `- Timezone: \`${localTimeZone}\``,
+              `- Processed: \`${counters.processed}\``,
+              `- Merged: \`${counters.merged}\``,
+              `- Synchronized: \`${counters.synchronized}\``,
+              `- Recreated: \`${counters.recreated}\``,
+              `- CI reruns: \`${counters.rerun}\``,
+              `- Awaiting external completion: \`${counters.awaiting}\``,
+              `- Persistent repair cases: \`${repairPulls.length}\``,
+              `- Skipped after state changes: \`${counters.skipped}\``,
+              "",
+              ...summary,
+            ];
+            await core.summary
+              .addHeading("Nightly Dependabot maintenance")
+              .addRaw(resultLines.join("\n"))
+              .write();

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -108,30 +108,54 @@ def test_nightly_maintenance_runs_at_local_one_and_covers_every_dependabot_pr() 
     nightly = (WORKFLOWS / "nightly-dependabot-maintenance.yml").read_text()
 
     assert 'cron: "0 8,9 * * *"' in nightly
-    assert 'LOCAL_TZ="America/Los_Angeles"' in nightly
-    assert '"$EVENT_NAME" == "schedule" && "$LOCAL_HOUR" != "01"' in nightly
-    assert "actions/workflows/$WORKFLOW_FILE/runs?event=schedule" in nightly
-    assert "pulls?state=open&base=main&per_page=100" in nightly
-    assert '.user.login == "dependabot[bot]"' in nightly
-    assert 'head_repo" != "$REPO"' in nightly
+    assert 'const localTimeZone = "America/Los_Angeles"' in nightly
+    assert 'context.eventName === "schedule" && localHour !== "01"' in nightly
+    assert 'workflow_id: workflowFile' in nightly
+    assert 'workflows: ["CI"]' in nightly
+    assert 'github.rest.pulls.list' in nightly
+    assert 'pull.user?.login === "dependabot[bot]"' in nightly
+    assert 'current.head?.repo?.full_name !== repository' in nightly
+    assert 'current.head?.ref?.startsWith("dependabot/")' in nightly
 
 
 def test_nightly_maintenance_has_bounded_recovery_and_exact_head_merge() -> None:
     nightly = (WORKFLOWS / "nightly-dependabot-maintenance.yml").read_text()
 
-    assert "reported_changed_files" in nightly
-    assert "returned_changed_files" in nightly
-    assert "dependency_paths_are_bounded" in nightly
-    assert "control_plane_patches_are_bounded" in nightly
-    assert "commits_are_dependabot_only" in nightly
-    assert "pulls/$number/update-branch" in nightly
+    assert "metadataComplete" in nightly
+    assert "pathsAreBounded" in nightly
+    assert "controlPlanePatchesAreBounded" in nightly
+    assert "commits.every(commitIsTrusted)" in nightly
+    assert 'github.request("PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch"' in nightly
     assert "@dependabot recreate" in nightly
-    assert 'gh run rerun "$ci_run_id" --failed' in nightly
-    assert "actions/workflows/ci.yml/runs?head_sha=$sha&event=pull_request" in nightly
-    assert '-f sha="$head_sha"' in nightly
-    assert '-f merge_method="squash"' in nightly
+    assert "reRunWorkflowFailedJobs" in nightly
+    assert 'workflow_id: "ci.yml"' in nightly
+    assert "head_sha: headSha" in nightly
+    assert "sha: current.head.sha" in nightly
+    assert 'merge_method: "squash"' in nightly
     assert "maintenance:needs-repair" in nightly
-    assert 'if [[ "$ci_conclusion" != "success" ]]' in nightly
+    assert 'ciRun.conclusion === "success"' in nightly
+    assert "recoveryGraceMs" in nightly
+    assert "cancel-in-progress: true" in nightly
+
+
+def test_nightly_maintenance_accepts_only_its_bounded_sync_commits() -> None:
+    nightly = (WORKFLOWS / "nightly-dependabot-maintenance.yml").read_text()
+
+    assert 'commit.author?.login === "github-actions[bot]"' in nightly
+    assert "^Merge branch 'main' into dependabot[/]" in nightly
+    assert "commit.parents.length === 2" in nightly
+    assert 'commit.author?.login === "dependabot[bot]"' in nightly
+    assert 'removeLabel(number, "maintenance:needs-repair")' in nightly
+
+
+def test_nightly_maintenance_uses_pinned_github_script_without_checkout() -> None:
+    nightly = (WORKFLOWS / "nightly-dependabot-maintenance.yml").read_text()
+
+    assert (
+        "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3"
+        in nightly
+    )
+    assert "actions/checkout" not in nightly
 
 
 def test_pr_reconciler_requires_a_complete_changed_file_listing() -> None:

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -110,11 +110,11 @@ def test_nightly_maintenance_runs_at_local_one_and_covers_every_dependabot_pr() 
     assert 'cron: "0 8,9 * * *"' in nightly
     assert 'const localTimeZone = "America/Los_Angeles"' in nightly
     assert 'context.eventName === "schedule" && localHour !== "01"' in nightly
-    assert 'workflow_id: workflowFile' in nightly
+    assert "workflow_id: workflowFile" in nightly
     assert 'workflows: ["CI"]' in nightly
-    assert 'github.rest.pulls.list' in nightly
+    assert "github.rest.pulls.list" in nightly
     assert 'pull.user?.login === "dependabot[bot]"' in nightly
-    assert 'current.head?.repo?.full_name !== repository' in nightly
+    assert "current.head?.repo?.full_name !== repository" in nightly
     assert 'current.head?.ref?.startsWith("dependabot/")' in nightly
 
 
@@ -151,10 +151,7 @@ def test_nightly_maintenance_accepts_only_its_bounded_sync_commits() -> None:
 def test_nightly_maintenance_uses_pinned_github_script_without_checkout() -> None:
     nightly = (WORKFLOWS / "nightly-dependabot-maintenance.yml").read_text()
 
-    assert (
-        "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3"
-        in nightly
-    )
+    assert "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3" in nightly
     assert "actions/checkout" not in nightly
 
 


### PR DESCRIPTION
## First-run finding

The initial production execution correctly synchronized the oldest Dependabot PR with current `main`, but GitHub authored that safe update-branch merge commit as `github-actions[bot]`. The next validation pass allowed only commits authored directly by Dependabot, so it conservatively—but incorrectly—marked the branch outside the dependency-only boundary.

## Fix

- Accept a maintainer synchronization commit only when all of these are true:
  - author is `github-actions[bot]`;
  - message is exactly in the bounded `Merge branch 'main' into dependabot/...` family;
  - the commit has exactly two parents;
  - the PR itself still has verified same-repository Dependabot identity and dependency-only files.
- Continue rejecting arbitrary maintainer commits and every unexpected file or control-plane patch.
- Clear stale `maintenance:needs-repair` labels after the stronger boundary succeeds.
- Replace the long polling loop with a fast event-driven pass:
  - 01:00 local schedule starts the sweep;
  - completed `CI` runs continue the exact-head recovery/merge loop;
  - workflow-path pushes perform immediate acceptance testing;
  - concurrency coalesces overlapping events.
- Retain one retry and one branch rebuild per bounded recovery window, with a 30-minute grace period before declaring a persistent repair case.
- Pin `actions/github-script` v9 to its exact release commit; no PR code is checked out.

## Safety

The write-capable workflow still does not check out or execute PR code, does not reference repository secrets, and cannot deploy. It consumes GitHub metadata and results from the existing read-only exact-head CI. Merge remains squash-only and bound to the current head SHA after complete CI success.

## Regression coverage

Contracts now require the exact bounded sync-commit signature, pinned action SHA, event-driven continuation, coalesced concurrency, complete file/commit metadata, exact-head CI, and removal of stale false-positive repair labels.