### PR TITLE
fix(ci): unblock Dependabot PR approvals

### DIFF
--- a/.github/workflows/dependabot-ci-approval.yml
+++ b/.github/workflows/dependabot-ci-approval.yml
@@ -1,0 +1,224 @@
+name: Dependabot CI Approval
+run-name: dependabot/ci-approval/${{ github.run_id }}
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/dependabot-ci-approval.yml"
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: dependabot-ci-approval
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'action_required'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Approve verified exact-head Dependabot CI
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          retries: 3
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const repository = `${owner}/${repo}`;
+            const dependabotEmail = "49699333+dependabot[bot]@users.noreply.github.com";
+            const allowedActors = new Set(["dependabot[bot]", "github-actions[bot]"]);
+
+            const dependencyPathPatterns = [
+              /^pyproject[.]toml$/,
+              /^(?:uv|poetry)[.]lock$/,
+              /^Pipfile(?:[.]lock)?$/,
+              /^requirements(?:-[^/]+)?[.]txt$/,
+              /^requirements[/].+[.]txt$/,
+              /^webapp[/](?:package[.]json|package-lock[.]json|npm-shrinkwrap[.]json)$/,
+              /^(?:docker[/][^/]+[/])?Dockerfile(?:[.].+)?$/,
+              /^[.]github[/]workflows[/][^/]+[.]ya?ml$/,
+              /^[.]github[/]actions[/].+[/]action[.]ya?ml$/,
+            ];
+
+            function pathsAreBounded(files) {
+              return (
+                files.length > 0 &&
+                files.every((file) =>
+                  dependencyPathPatterns.some((pattern) => pattern.test(file.filename)),
+                )
+              );
+            }
+
+            function changedLines(patch) {
+              return (patch ?? "")
+                .split("\n")
+                .filter((line) => line.startsWith("+") || line.startsWith("-"))
+                .filter((line) => !line.startsWith("+++") && !line.startsWith("---"))
+                .map((line) => line.slice(1));
+            }
+
+            function controlPlanePatchesAreBounded(files) {
+              for (const file of files) {
+                const isWorkflow = /^[.]github[/]workflows[/][^/]+[.]ya?ml$/.test(file.filename);
+                const isAction = /^[.]github[/]actions[/].+[/]action[.]ya?ml$/.test(file.filename);
+                const isDockerfile = /(?:^|[/])Dockerfile(?:[.].+)?$/.test(file.filename);
+                if (!isWorkflow && !isAction && !isDockerfile) continue;
+                if (!file.patch) return false;
+
+                const lines = changedLines(file.patch);
+                if (lines.length === 0) return false;
+
+                if (isWorkflow || isAction) {
+                  const usesOnly = lines.every((line) =>
+                    /^\s*(?:-\s*)?uses:\s+\S+@\S+(?:\s+#.*)?$/.test(line),
+                  );
+                  if (!usesOnly) return false;
+                }
+
+                if (isDockerfile) {
+                  const fromOnly = lines.every((line) =>
+                    /^\s*FROM\s+(?:--platform=\S+\s+)?\S+(?:\s+[Aa][Ss]\s+\S+)?\s*$/.test(line),
+                  );
+                  if (!fromOnly) return false;
+                }
+              }
+              return true;
+            }
+
+            function commitIsTrusted(commit) {
+              const dependabotCommit =
+                commit.author?.login === "dependabot[bot]" ||
+                commit.commit?.author?.email === dependabotEmail;
+              const maintainerSyncCommit =
+                commit.author?.login === "github-actions[bot]" &&
+                /^Merge branch 'main' into dependabot[/]/.test(commit.commit?.message ?? "") &&
+                Array.isArray(commit.parents) &&
+                commit.parents.length === 2;
+              return dependabotCommit || maintainerSyncCommit;
+            }
+
+            async function pullNumbersFor(run) {
+              const embedded = (run.pull_requests ?? [])
+                .map((pull) => pull.number)
+                .filter((number) => Number.isInteger(number));
+              if (embedded.length > 0) return [...new Set(embedded)];
+
+              const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: run.head_sha,
+              });
+              return [...new Set(associated.data.map((pull) => pull.number))];
+            }
+
+            async function approveVerifiedRun(run) {
+              if (
+                run.name !== "CI" ||
+                run.event !== "pull_request" ||
+                run.status !== "completed" ||
+                run.conclusion !== "action_required" ||
+                !allowedActors.has(run.actor?.login) ||
+                !allowedActors.has(run.triggering_actor?.login ?? run.actor?.login)
+              ) {
+                return `run ${run.id}: skipped because workflow identity or actor was not trusted`;
+              }
+
+              const pullNumbers = await pullNumbersFor(run);
+              for (const number of pullNumbers) {
+                const current = (
+                  await github.rest.pulls.get({ owner, repo, pull_number: number })
+                ).data;
+
+                if (
+                  current.state !== "open" ||
+                  current.draft ||
+                  current.user?.login !== "dependabot[bot]" ||
+                  current.base?.ref !== "main" ||
+                  current.head?.repo?.full_name !== repository ||
+                  !current.head?.ref?.startsWith("dependabot/") ||
+                  current.head.sha !== run.head_sha ||
+                  (current.body ?? "").includes("Maintainer changes")
+                ) {
+                  continue;
+                }
+
+                const files = await github.paginate(github.rest.pulls.listFiles, {
+                  owner,
+                  repo,
+                  pull_number: number,
+                  per_page: 100,
+                });
+                const commits = await github.paginate(github.rest.pulls.listCommits, {
+                  owner,
+                  repo,
+                  pull_number: number,
+                  per_page: 100,
+                });
+                const metadataComplete =
+                  files.length === current.changed_files && commits.length === current.commits;
+                const boundaryOk =
+                  metadataComplete &&
+                  pathsAreBounded(files) &&
+                  controlPlanePatchesAreBounded(files) &&
+                  commits.every(commitIsTrusted);
+
+                if (!boundaryOk) {
+                  return `run ${run.id} / PR #${number}: refused because the dependency-only boundary was not proven`;
+                }
+
+                try {
+                  await github.request(
+                    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve",
+                    { owner, repo, run_id: run.id },
+                  );
+                  return `run ${run.id} / PR #${number}: approved exact head ${run.head_sha}`;
+                } catch (error) {
+                  if (error.status === 409 || error.status === 422) {
+                    return `run ${run.id} / PR #${number}: no longer awaiting approval`;
+                  }
+                  throw error;
+                }
+              }
+
+              return `run ${run.id}: refused because no open exact-head Dependabot PR matched`;
+            }
+
+            let runs;
+            if (context.eventName === "workflow_run") {
+              runs = [context.payload.workflow_run];
+            } else {
+              runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner,
+                repo,
+                workflow_id: "ci.yml",
+                event: "pull_request",
+                status: "action_required",
+                per_page: 100,
+              });
+            }
+
+            runs.sort((left, right) => Date.parse(left.created_at) - Date.parse(right.created_at));
+            const results = [];
+            for (const run of runs) {
+              results.push(await approveVerifiedRun(run));
+            }
+
+            core.summary.addHeading("Verified Dependabot CI approvals");
+            if (results.length === 0) {
+              core.summary.addRaw("No action-required CI runs were found.\n");
+            } else {
+              core.summary.addList(results);
+            }
+            await core.summary.write();

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -66,6 +66,7 @@ def test_write_capable_pr_automation_never_executes_pr_code_or_deploys() -> None
     workflow_names = [
         "dependabot-triage.yml",
         "dependabot-reconcile.yml",
+        "dependabot-ci-approval.yml",
         "nightly-dependabot-maintenance.yml",
         "pr-reconciler.yml",
     ]
@@ -153,6 +154,22 @@ def test_nightly_maintenance_uses_pinned_github_script_without_checkout() -> Non
 
     assert "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3" in nightly
     assert "actions/checkout" not in nightly
+
+
+def test_dependabot_ci_approval_only_approves_verified_exact_head_runs() -> None:
+    approval = (WORKFLOWS / "dependabot-ci-approval.yml").read_text()
+
+    assert 'workflows: ["CI"]' in approval
+    assert 'run.conclusion !== "action_required"' in approval
+    assert 'allowedActors = new Set(["dependabot[bot]", "github-actions[bot]"])' in approval
+    assert 'current.user?.login !== "dependabot[bot]"' in approval
+    assert "current.head.sha !== run.head_sha" in approval
+    assert "metadataComplete" in approval
+    assert "pathsAreBounded(files)" in approval
+    assert "controlPlanePatchesAreBounded(files)" in approval
+    assert "commits.every(commitIsTrusted)" in approval
+    assert '"POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve"' in approval
+    assert "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3" in approval
 
 
 def test_pr_reconciler_requires_a_complete_changed_file_listing() -> None:


### PR DESCRIPTION
## Root cause

The nightly maintainer correctly synchronized Dependabot branches, but the resulting exact-head `CI` runs were completed with `action_required` before any job started. Because the maintainer requires exact-head CI success, all affected PRs remained under `maintenance:awaiting-ci`.

## Fix

- Add a narrowly scoped `Dependabot CI Approval` workflow.
- On an `action_required` CI run, verify all of the following before approval:
  - workflow is the repository `CI` workflow;
  - actor is Dependabot or the bounded `github-actions[bot]` branch synchronizer;
  - PR is open, non-draft, targets `main`, and comes from a same-repository `dependabot/` branch;
  - the run SHA is still the PR's current exact head;
  - the complete file and commit listings are available;
  - every changed path is dependency-only;
  - workflow changes modify only `uses:` version lines and Docker changes modify only `FROM` lines;
  - commits are Dependabot-authored or the exact bounded two-parent synchronization commit.
- The initial push-triggered sweep approves the current backlog; later `workflow_run` events approve new verified Dependabot runs automatically.
- Keep the workflow read-only with respect to repository contents and do not check out or execute PR code.

## Regression coverage

Extend the PR automation safety contract so the approval workflow is included in the no-checkout/no-secrets/no-deployment boundary and must retain exact-head, complete-metadata, dependency-only validation before using GitHub's approval endpoint.