### PR TITLE
fix(ci): make Dependabot approval recovery event-complete

### DIFF
--- a/.github/workflows/dependabot-ci-approval.yml
+++ b/.github/workflows/dependabot-ci-approval.yml
@@ -2,6 +2,10 @@ name: Dependabot CI Approval
 run-name: dependabot/ci-approval/${{ github.run_id }}
 
 on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  schedule:
+    - cron: "*/5 * * * *"
   workflow_run:
     workflows: ["CI"]
     types: [completed]
@@ -16,15 +20,13 @@ permissions:
   contents: read
   pull-requests: read
 
-concurrency:
-  group: dependabot-ci-approval
-  cancel-in-progress: false
-
 jobs:
   approve:
     if: >-
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'action_required'
+      (github.event_name != 'workflow_run' ||
+       github.event.workflow_run.conclusion == 'action_required') &&
+      (github.event_name != 'pull_request_target' ||
+       github.event.pull_request.user.login == 'dependabot[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -195,21 +197,64 @@ jobs:
               return `run ${run.id}: refused because no open exact-head Dependabot PR matched`;
             }
 
-            let runs;
-            if (context.eventName === "workflow_run") {
-              runs = [context.payload.workflow_run];
-            } else {
-              runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+            async function currentDependabotHeads() {
+              const pulls = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: "open",
+                base: "main",
+                per_page: 100,
+              });
+              return new Set(
+                pulls
+                  .filter((pull) =>
+                    pull.user?.login === "dependabot[bot]" &&
+                    pull.head?.repo?.full_name === repository &&
+                    pull.head?.ref?.startsWith("dependabot/"),
+                  )
+                  .map((pull) => pull.head.sha),
+              );
+            }
+
+            async function actionRequiredRuns(headSha = null) {
+              const options = {
                 owner,
                 repo,
                 workflow_id: "ci.yml",
                 event: "pull_request",
                 status: "action_required",
                 per_page: 100,
-              });
+              };
+              if (headSha) options.head_sha = headSha;
+              return github.paginate(github.rest.actions.listWorkflowRuns, options);
             }
 
-            runs.sort((left, right) => Date.parse(left.created_at) - Date.parse(right.created_at));
+            async function waitForExactHeadActionRequired(headSha) {
+              for (let attempt = 0; attempt < 8; attempt += 1) {
+                const runs = await actionRequiredRuns(headSha);
+                const exact = runs.filter((run) => run.head_sha === headSha);
+                if (exact.length > 0) return exact;
+                await new Promise((resolve) => setTimeout(resolve, 5000));
+              }
+              return [];
+            }
+
+            let runs;
+            if (context.eventName === "workflow_run") {
+              runs = [context.payload.workflow_run];
+            } else if (context.eventName === "pull_request_target") {
+              const pull = context.payload.pull_request;
+              runs = await waitForExactHeadActionRequired(pull.head.sha);
+            } else {
+              const currentHeads = await currentDependabotHeads();
+              runs = (await actionRequiredRuns()).filter((run) =>
+                currentHeads.has(run.head_sha),
+              );
+            }
+
+            runs = [...new Map(runs.map((run) => [run.id, run])).values()]
+              .sort((left, right) => Date.parse(left.created_at) - Date.parse(right.created_at));
+
             const results = [];
             for (const run of runs) {
               results.push(await approveVerifiedRun(run));
@@ -217,7 +262,7 @@ jobs:
 
             core.summary.addHeading("Verified Dependabot CI approvals");
             if (results.length === 0) {
-              core.summary.addRaw("No action-required CI runs were found.\n");
+              core.summary.addRaw("No current exact-head action-required CI runs were found.\n");
             } else {
               core.summary.addList(results);
             }

--- a/tests/pr_automation_safety_test.py
+++ b/tests/pr_automation_safety_test.py
@@ -160,8 +160,14 @@ def test_dependabot_ci_approval_only_approves_verified_exact_head_runs() -> None
     approval = (WORKFLOWS / "dependabot-ci-approval.yml").read_text()
 
     assert 'workflows: ["CI"]' in approval
+    assert "pull_request_target:" in approval
+    assert "types: [opened, reopened, synchronize]" in approval
+    assert 'cron: "*/5 * * * *"' in approval
     assert 'run.conclusion !== "action_required"' in approval
     assert 'allowedActors = new Set(["dependabot[bot]", "github-actions[bot]"])' in approval
+    assert 'context.eventName === "pull_request_target"' in approval
+    assert "waitForExactHeadActionRequired" in approval
+    assert "currentDependabotHeads" in approval
     assert 'current.user?.login !== "dependabot[bot]"' in approval
     assert "current.head.sha !== run.head_sha" in approval
     assert "metadataComplete" in approval


### PR DESCRIPTION
## Root cause

The first approval sweep unblocked the existing `action_required` runs, but GitHub does not reliably emit the expected `workflow_run: completed` continuation for a CI run that never started because it required approval. When `main` advanced and the nightly maintainer synchronized every Dependabot branch again, the new exact-head CI runs returned to `action_required` without waking the approval workflow.

## Fix

- Listen to `pull_request_target` `opened`, `reopened`, and `synchronize` events for Dependabot PRs.
- Poll briefly for the matching exact-head `action_required` CI run, then apply the existing full identity, commit, file-list, dependency-only, workflow-line, and Docker-line validation before approval.
- Add a five-minute scheduled sweep as a durable recovery path for missed or reordered events.
- Retain manual, push-path, and rare `workflow_run` continuations.
- Filter sweep candidates to current heads of open same-repository Dependabot PRs so stale historical approval attempts are ignored.
- Remove global serialization; every approval remains idempotent and exact-head bound.

## Safety

The workflow still does not check out or execute PR code, read repository secrets, or dispatch any deployment. Only the GitHub Actions approval endpoint is writable, and only after the exact current Dependabot head passes the complete dependency-only boundary.

## Regression coverage

Require both the immediate PR synchronization trigger and the five-minute recovery sweep in the automation safety contract, while retaining all exact-head and no-execution assertions.