### PR TITLE
docs: record FFT Qianhai 0.6.1 production evidence

### DIFF
--- a/docs/production-evidence/0.6.1-fft-qianhai.md
+++ b/docs/production-evidence/0.6.1-fft-qianhai.md
@@ -1,0 +1,76 @@
+# FFTENNIS前海国际网球中心生产验收（0.6.1）
+
+## 发布身份
+
+- 发布版本：`0.6.1`
+- 生产提交：`c8f0f7115b9b498cb660e7507d91aa66abfcff7e`
+- 功能 PR：`#157`
+- PR 精确提交 CI：`33292316364`
+- 合并后主分支 CI：`33292431515`
+- 受保护生产发布：`33292553534`
+- 发布后只读验收：`33292964981`
+- 部署组件：Web、Airflow
+- 未部署组件：WeChat sender
+
+Git 标签 `0.6.1` 和 GitHub Release 均指向上述生产提交。
+
+## 接口验证
+
+归档小程序的场地查询链路使用 PosPal 只读接口：
+
+1. `Store/GetStoreDataFast`
+2. `AppointmentVenue/LoadClassroomProjectList`
+3. `AppointmentVenue/AppointmentVenueConfig`
+4. `AppointmentVenue/LoadValidClassRoomApptSettingV2`
+
+门店公开标识为 `5934657`，项目公开标识为
+`1756717886546691955`。隔离验证使用标准 TLS 证书校验，连续查询三天均返回
+`success`，无需登录态、Cookie、openid、session_key 或业务 Token，也不会创建
+订场、锁场、订单、支付或取消操作。
+
+生产只发布 1–6 号标准双打场。7–8 号非标单打场、9–10 号发球机场，以及名称
+包含小场、匹克、练习、非标或发球机的场地，在 Web 观测和 WeChat 处理前即被
+过滤。
+
+## Web 验收
+
+生产发布应用了 D1 迁移 `0015_add_fft_qianhai_venue.sql`。发布后只读健康检查
+确认：
+
+- `/api/healthz` 返回健康，并报告精确生产提交
+  `c8f0f7115b9b498cb660e7507d91aa66abfcff7e`。
+- `/api/bootstrap` 返回 `26` 个场地，不包含邮箱地址。
+- 场地 `fft_qianhai` 存在，名称为 `FFTENNIS前海国际网球中心`。
+- 该场地 `lastInspectionAt` 为 `2026-08-30T04:39:00.621Z`。
+- 未认证的观测写入仍被拒绝。
+
+## Airflow 验收
+
+生产运行 Airflow `3.3.0`，应用镜像为
+`wechat-on-airflow:3.3.0-c8f0f71`。发布后健康检查确认：
+
+- 精确部署提交匹配。
+- `import_error_count = 0`。
+- 无缺失 DAG、无缺失必要 Variable、无暂停活动 DAG。
+- 无最近运行失败，所有目标服务健康。
+- `FFTENNIS前海国际网球中心巡检` 已自然运行并连续成功三次：
+  - `2026-08-30T04:36:51.196799Z`
+  - `2026-08-30T04:37:51.196799Z`
+  - `2026-08-30T04:38:51.196799Z`
+
+首次成功巡检只建立通知基线，不发送历史余量，避免上线时刷屏。后续按一分钟周期
+巡检并仅处理新增可订时段。
+
+## 通知与残余风险
+
+本次发布和验收未发送真实验证邮件或 WeChat 测试消息。历史
+`WECHAT_SEND_FALLBACK_OUTBOX` 仍保留 `200` 条事故记录，最新历史失败时间为
+`2026-08-29T02:37:27.860929Z`；这些记录未自动重放，也不是本次 FFT 接入产生的
+新故障。
+
+## 回滚
+
+Web 的前一发布身份为 `8ec8f53b978f1a7cdb3131b5b088124e357cbb93`；Airflow
+发布前运行提交为 `11783bf6c510eb9ccde982ac4bb68d06a7cca3de`。如需回滚，应
+通过受保护的精确提交发布流程分别恢复对应组件。D1 的 FFT 场地行属于增量数据，
+回滚旧 Web 会隐藏该场地，但不应删除或覆盖该行。


### PR DESCRIPTION
## Summary

Record the completed FFTENNIS前海国际网球中心 production rollout and read-only acceptance evidence for release `0.6.1`.

## Evidence

- Release commit: `c8f0f7115b9b498cb660e7507d91aa66abfcff7e`
- Feature PR: #157
- Exact-head CI: `33292316364`
- Main CI: `33292431515`
- Protected ship: `33292553534`
- Post-deploy acceptance: `33292964981`
- Web: exact commit, 26 venues, no email, FFT venue fresh
- Airflow: three consecutive natural successes, no paused/missing DAGs, variables, imports, or recent failures

Documentation only. No runtime, migration, notification, or deployment behavior changes.