### PR TITLE
fix(ops): read DSH logs from the exact DAG root

### DIFF
--- a/scripts/diagnose_webapp_observation.sh
+++ b/scripts/diagnose_webapp_observation.sh
@@ -168,12 +168,16 @@ PY
 printf '%s\n' '__WEBAPP_LOGS__'
 for candidate in airflow-worker worker; do
   if compose ps --services --status running | grep -qx "$candidate"; then
-    compose_with_timeout 12s exec -T "$candidate" sh -lc '
-      find /opt/airflow/logs -type f \
-        \( -path "*大沙河国际网球中心巡检*" -o -path "*dsh_ydmap_watcher*" \) \
-        -mmin -180 -size -5M -print0 2>/dev/null \
-        | xargs -0 -r grep -hE "\[WEBAPP\]|Error checking 大沙河国际网球中心|start to check 大沙河国际网球中心" 2>/dev/null \
-        | tail -n 240
+    compose_with_timeout 30s exec -T "$candidate" sh -lc '
+      printf "%s\n" "__DSH_LOG_ROOTS__"
+      find /opt/airflow/logs -mindepth 1 -maxdepth 1 -type d -printf "%p\n" 2>/dev/null \
+        | grep -E "大沙河|dsh" \
+        | head -n 40 || true
+      for root in /opt/airflow/logs/*大沙河国际网球中心巡检* /opt/airflow/logs/*dsh_ydmap_watcher*; do
+        [ -d "$root" ] || continue
+        find "$root" -type f -mmin -240 -size -5M \
+          -exec grep -hE "\[WEBAPP\]|Error checking 大沙河国际网球中心|start to check 大沙河国际网球中心" {} + 2>/dev/null
+      done | tail -n 300
     ' || true
   fi
 done


### PR DESCRIPTION
## Summary
- avoid recursively scanning the entire Airflow log tree during Web observation diagnosis
- discover the top-level Dashah DAG log root and inspect only recent bounded files beneath it
- retain the existing filters for Dashah scrape errors and Web observation publication events

## Why
The first repaired diagnosis reached production safely but the full-tree scan exceeded its 12-second guard and returned only `canceled`, so the incident window remained unreadable.

## Safety
- read-only diagnostics only; no production deploy
- no change to the 3-minute Dashah inspection cadence or any other venue schedule
- no live WeChat/email send
- scan remains bounded by exact DAG roots, a 4-hour age filter, file-size limits, a 30-second command timeout, and an output tail

## Validation
- full repository CI required before merge