### PR TITLE
fix(web): 区分真实巡检频率与状态同步时间

### DIFF
--- a/docs/operations/venue-status-display.md
+++ b/docs/operations/venue-status-display.md
@@ -1,0 +1,12 @@
+# Venue status display semantics
+
+The Web venue list separates two different clocks:
+
+- **Inspection cadence** is the configured Airflow schedule: 15 seconds for Shenzhen Bay, 3 minutes for Dashah International, and 1 minute for the other active tennis venues unless the policy declares another exception.
+- **Status sync time** is the most recent observation timestamp currently visible through the existing Cloudflare observation heartbeat and dashboard caches.
+
+A card that says `正常 · 1分钟/次` and `状态同步 4分钟前` means that Airflow continues to inspect the venue once per minute while the unchanged Web status snapshot was last forwarded or exposed four minutes ago. It does not mean the venue skipped four inspection cycles.
+
+This presentation is intentionally client-only. It does not add an API endpoint, Worker invocation, D1 read or write, cache invalidation, scheduled job, or static asset request. The five-minute unchanged-observation heartbeat and the existing 120-second edge/client dashboard caches remain unchanged. A real availability, health, or error change still bypasses observation deduplication immediately and enters the notification pipeline on the first matching inspection.
+
+The cadence labels must remain aligned with `config/venue-schedule-policy.yaml`; regression coverage enforces the current default and explicit exceptions.

--- a/tests/webapp_subscription_weekdays_wiring_test.py
+++ b/tests/webapp_subscription_weekdays_wiring_test.py
@@ -19,7 +19,7 @@ def test_public_venue_popularity_uses_unique_followers_and_stable_order():
 
     assert "COUNT(DISTINCT s.email)" in worker
     assert "ORDER BY subscriber_count DESC" in worker
-    assert "热门优先 · 按关注人数从高到低排序" in ui
+    assert "热门优先 · 时间为最近一次状态同步" in ui
     assert "right.subscriberCount - left.subscriberCount" in ui
 
 

--- a/tests/webapp_venue_status_display_test.py
+++ b/tests/webapp_venue_status_display_test.py
@@ -9,10 +9,7 @@ def test_web_venue_cadence_labels_match_the_airflow_policy() -> None:
     policy = yaml.safe_load((ROOT / "config/venue-schedule-policy.yaml").read_text())
     source = (ROOT / "webapp/src/venue-inspection-display.ts").read_text()
 
-    assert (
-        f"DEFAULT_INSPECTION_CADENCE_SECONDS = {policy['default_interval_seconds']}"
-        in source
-    )
+    assert f"DEFAULT_INSPECTION_CADENCE_SECONDS = {policy['default_interval_seconds']}" in source
 
     exception_ids = {
         "深圳湾网球场巡检": "szw",

--- a/tests/webapp_venue_status_display_test.py
+++ b/tests/webapp_venue_status_display_test.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_web_venue_cadence_labels_match_the_airflow_policy() -> None:
+    policy = yaml.safe_load((ROOT / "config/venue-schedule-policy.yaml").read_text())
+    source = (ROOT / "webapp/src/venue-inspection-display.ts").read_text()
+
+    assert (
+        f"DEFAULT_INSPECTION_CADENCE_SECONDS = {policy['default_interval_seconds']}"
+        in source
+    )
+
+    exception_ids = {
+        "深圳湾网球场巡检": "szw",
+        "大沙河国际网球中心巡检": "dsh",
+    }
+    for dag_id, venue_id in exception_ids.items():
+        interval = policy["exceptions"][dag_id]["interval_seconds"]
+        assert f"{venue_id}: {interval}" in source
+
+
+def test_web_labels_status_sync_without_adding_an_api_path() -> None:
+    prototype = (ROOT / "webapp/src/Prototype.tsx").read_text()
+    helper = (ROOT / "webapp/src/venue-inspection-display.ts").read_text()
+
+    assert 'from "./venue-inspection-display"' in prototype
+    assert "状态同步 ${formatRelative(venue.lastInspectionAt)}" in prototype
+    assert "巡检与页面同步分开" in prototype
+    assert "30 秒刷新显示" in prototype
+    assert "fetch(" not in helper
+    assert "/api/" not in helper

--- a/webapp/cloudflare/venue-inspection-display.test.ts
+++ b/webapp/cloudflare/venue-inspection-display.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_INSPECTION_CADENCE_SECONDS,
+  formatInspectionCadence,
+  inspectionCadenceSeconds,
+} from "../src/venue-inspection-display";
+
+describe("venue inspection cadence display", () => {
+  it("keeps the one-minute default for ordinary venues", () => {
+    expect(DEFAULT_INSPECTION_CADENCE_SECONDS).toBe(60);
+    expect(inspectionCadenceSeconds("gba")).toBe(60);
+    expect(formatInspectionCadence("gba")).toBe("1分钟/次");
+  });
+
+  it("shows the approved Shenzhen Bay low-latency exception", () => {
+    expect(inspectionCadenceSeconds("szw")).toBe(15);
+    expect(formatInspectionCadence("szw")).toBe("15秒/次");
+  });
+
+  it("shows the resource-safe Dashah International exception", () => {
+    expect(inspectionCadenceSeconds("dsh")).toBe(180);
+    expect(formatInspectionCadence("dsh")).toBe("3分钟/次");
+  });
+});

--- a/webapp/src/Prototype.tsx
+++ b/webapp/src/Prototype.tsx
@@ -49,6 +49,7 @@ import { LULU_LABELS, resolveLuluState } from "./lulu";
 import { AdminPanel, CommunityPanel } from "./OperationsPanel";
 import { BottomSheet, KeyboardInput, MobileScroll, useKeyboard } from "./mobile";
 import { isTextEntry, useNativeKeyboardViewport } from "./nativeKeyboard";
+import { formatInspectionCadence } from "./venue-inspection-display";
 
 type Panel = "create" | "help" | "subscriptions" | "priority" | "community" | "admin" | "coffee" | null;
 
@@ -966,9 +967,9 @@ export default function Prototype() {
             <div className="section-heading">
               <div>
                 <h2 id="venue-heading">场地运行状态</h2>
-                <p>热门优先 · 按关注人数从高到低排序</p>
+                <p>热门优先 · 时间为最近一次状态同步</p>
               </div>
-              <span><ArrowsClockwiseIcon size={17} />30 秒自动更新</span>
+              <span><ArrowsClockwiseIcon size={17} />30 秒刷新显示</span>
             </div>
 
             <div className="venue-list">
@@ -976,6 +977,7 @@ export default function Prototype() {
                 (() => {
                   const VenueIcon = VENUE_ICONS[venue.id];
                   const venueState = resolveVenueDisplayState(availability, venue.healthy);
+                  const inspectionCadence = formatInspectionCadence(venue.id);
                   return (
                     <article className="venue-row" key={venue.id}>
                       <span className={`venue-icon venue-icon-${VENUE_ACCENTS[venue.id]}`}>
@@ -985,13 +987,17 @@ export default function Prototype() {
                         <h3>{venue.name}</h3>
                         <p>{venue.subscriberCount > 0 ? `${venue.subscriberCount} 人关注` : "暂无关注"}</p>
                       </div>
-                      <div className="venue-health">
+                      <div
+                        className="venue-health"
+                        title={venueState === "unknown" ? undefined
+                          : `实际巡检频率：${inspectionCadence}；页面时间为最近一次状态同步记录`}
+                      >
                         <strong className={venueState}><CheckCircleIcon size={16} weight="fill" />
                           {venueState === "unknown" ? (availability === "loading" ? "正在读取" : "状态未知")
-                            : venueState === "healthy" ? "巡检正常" : "巡检异常"}
+                            : venueState === "healthy" ? `正常 · ${inspectionCadence}` : `异常 · ${inspectionCadence}`}
                         </strong>
                         <span>{venueState === "unknown" ? (availability === "loading" ? "请稍候" : "点击刷新重试")
-                          : formatRelative(venue.lastInspectionAt)}</span>
+                          : `状态同步 ${formatRelative(venue.lastInspectionAt)}`}</span>
                       </div>
                       <div className="venue-mail">
                         <strong className={venue.lastNotificationAt ? "" : "muted"}>
@@ -1113,7 +1119,12 @@ export default function Prototype() {
             </div>
             <div className="help-row">
               <span>2</span>
-              <div><strong>系统持续巡检</strong><p>Airflow 按场地开放节奏检查未来可订情况。</p></div>
+              <div>
+                <strong>巡检与页面同步分开</strong>
+                <p>
+                  场地按 15 秒、1 分钟或 3 分钟持续巡检。为节省 Cloudflare 免费额度，页面复用缓存并低频同步状态；“4 分钟前”表示状态同步时间，不是巡检间隔，空位变化仍会立即进入通知链路。
+                </p>
+              </div>
             </div>
             <div className="help-row">
               <span>3</span>

--- a/webapp/src/venue-inspection-display.ts
+++ b/webapp/src/venue-inspection-display.ts
@@ -1,0 +1,19 @@
+import type { VenueId } from "./api";
+
+export const DEFAULT_INSPECTION_CADENCE_SECONDS = 60;
+
+const INSPECTION_CADENCE_SECONDS: Partial<Record<VenueId, number>> = {
+  szw: 15,
+  dsh: 180,
+};
+
+export function inspectionCadenceSeconds(venueId: VenueId): number {
+  return INSPECTION_CADENCE_SECONDS[venueId] ?? DEFAULT_INSPECTION_CADENCE_SECONDS;
+}
+
+export function formatInspectionCadence(venueId: VenueId): string {
+  const seconds = inspectionCadenceSeconds(venueId);
+  if (seconds < 60) return `${seconds}秒/次`;
+  if (seconds % 60 === 0) return `${seconds / 60}分钟/次`;
+  return `${seconds}秒/次`;
+}

--- a/webapp/src/venue-inspection-display.ts
+++ b/webapp/src/venue-inspection-display.ts
@@ -1,17 +1,15 @@
-import type { VenueId } from "./api";
-
 export const DEFAULT_INSPECTION_CADENCE_SECONDS = 60;
 
-const INSPECTION_CADENCE_SECONDS: Partial<Record<VenueId, number>> = {
+const INSPECTION_CADENCE_SECONDS: Readonly<Record<string, number>> = {
   szw: 15,
   dsh: 180,
 };
 
-export function inspectionCadenceSeconds(venueId: VenueId): number {
+export function inspectionCadenceSeconds(venueId: string): number {
   return INSPECTION_CADENCE_SECONDS[venueId] ?? DEFAULT_INSPECTION_CADENCE_SECONDS;
 }
 
-export function formatInspectionCadence(venueId: VenueId): string {
+export function formatInspectionCadence(venueId: string): string {
   const seconds = inspectionCadenceSeconds(venueId);
   if (seconds < 60) return `${seconds}秒/次`;
   if (seconds % 60 === 0) return `${seconds / 60}分钟/次`;


### PR DESCRIPTION
## 根因

Web 卡片当前把 `lastInspectionAt` 直接显示成“X 分钟前”，但该字段经过 5 分钟未变化观测去重和现有 120 秒缓存后，表达的是最近一次 Web 状态同步记录，不等于 Airflow 的真实巡检间隔。因此每分钟正常运行的场地也会显示“4 分钟前”。

## 变更

- 在每个场地状态中同时显示真实配置频率：
  - 深圳湾：`15秒/次`
  - 大沙河国际网球中心：`3分钟/次`
  - 其余场地默认：`1分钟/次`
- 将相对时间明确标记为“状态同步 X 分钟前”，避免误认为 Airflow 停止巡检。
- 将“30 秒自动更新”改为更准确的“30 秒刷新显示”。
- 在帮助说明中解释巡检、观测去重和页面缓存是不同链路。
- 新增 TypeScript 单测、Python 跨配置契约测试和运维语义文档。

## Cloudflare 成本约束

这是纯前端展示修复：

- 不新增 API endpoint 或请求；
- 不新增 Worker invocation、D1 read/write、cron 或缓存失效；
- 不修改 5 分钟观测心跳、120 秒边缘缓存或 120 秒客户端缓存；
- 不修改任何场地 DAG 调度频率；
- 空位、健康或错误状态发生变化时，仍在首个匹配巡检立即进入通知链路。

## 验证

- `webapp/cloudflare/venue-inspection-display.test.ts` 覆盖 15 秒、1 分钟、3 分钟标签。
- `tests/webapp_venue_status_display_test.py` 校验前端频率与 `config/venue-schedule-policy.yaml` 一致，并防止引入新的 API 路径。
- 权威门禁为本 PR 精确 head SHA 的 `CI / verify`。
- 不发送真实邮件或微信消息。
