### PR TITLE
chore(release): prepare 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and operational changes.
 
 ## Unreleased
 
+## [0.6.2] - 2026-08-30
+
 ### Added
 
 - Let Web subscribers choose one or more weekdays, including one-tap daily,
@@ -20,6 +22,15 @@ and operational changes.
 - Order the public venue list and subscription selector by unique active
   follower count, with a deterministic name/ID tie-breaker and visible
   popularity labels.
+
+### Fixed
+
+- Distinguish each venue's configured Airflow inspection cadence from the most
+  recent Cloudflare-backed status synchronization time, so a cached “4 minutes
+  ago” record is not mistaken for a missed one-minute poll.
+- Keep the display correction within the existing five-minute observation
+  heartbeat and 120-second edge/client dashboard caches, adding no Worker route,
+  D1 read/write, cron, or venue polling change.
 
 ## [0.6.1] - 2026-08-30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wechat-on-airflow"
-version = "0.6.1"
+version = "0.6.2"
 description = "Airflow workflows for Shenzhen tennis availability notifications."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/src/wechat_airflow/__init__.py
+++ b/src/wechat_airflow/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime code for the production Airflow workflows."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"


### PR DESCRIPTION
## Release

Prepare patch release `0.6.2` for the Web venue-status semantics correction merged in #164.

## Included user-visible changes

- Show each venue's configured Airflow cadence separately from the most recent Cloudflare-backed status sync time.
- Clarify that a cached “4 分钟前” record does not mean a one-minute Airflow poll was missed.
- Preserve the existing five-minute observation heartbeat, 120-second edge/client caches, all venue schedules, and the immediate notification path for real state changes.

## Cloudflare cost boundary

The runtime change remains display-only and adds no API route, Worker invocation pattern, D1 read/write, cron, or cache invalidation.

## Release contract

- `pyproject.toml`: `0.6.2`
- `src/wechat_airflow/__init__.py`: `0.6.2`
- `CHANGELOG.md`: matching `0.6.2` section

After exact-head CI succeeds, this PR can be squash-merged and shipped via issue 39 using `scope=auto sender=false`; the planner should resolve to Web-only deployment.
