### PR TITLE
fix(web): 将帮助入口合并到更多菜单

### DIFF
--- a/tests/webapp_header_actions_test.py
+++ b/tests/webapp_header_actions_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_footer_actions_move_into_accessible_header_menu():
+def test_footer_actions_and_help_move_into_accessible_header_menu():
     source = (ROOT / "webapp/src/Prototype.tsx").read_text(encoding="utf-8")
 
     assert 'aria-label="更多功能"' in source
@@ -11,11 +11,16 @@ def test_footer_actions_move_into_accessible_header_menu():
     assert 'onSelect={() => openPanel("subscriptions")}' in source
     assert 'onSelect={() => openPanel("community")}' in source
     assert 'onSelect={() => openPanel("admin")}' in source
+    assert 'onSelect={() => openPanel("help")}' in source
+    assert "<span>查看帮助</span>" in source
+    assert "<QuestionIcon size={20}" in source
     assert "href={GITHUB_REPOSITORY_URL}" in source
     assert 'target="_blank"' in source
     assert 'rel="noopener noreferrer"' in source
     assert "项目开源地址" in source
     assert 'className="subscriptions-link"' not in source
+    assert 'className="icon-button"' not in source
+    assert 'aria-label="查看帮助"' not in source
 
 
 def test_more_menu_pointer_transfer_cannot_start_mobile_scroll_drag():

--- a/webapp/src/Prototype.tsx
+++ b/webapp/src/Prototype.tsx
@@ -811,6 +811,13 @@ export default function Prototype() {
                         <span>管理后台</span>
                       </DropdownMenu.Item>
                     ) : null}
+                    <DropdownMenu.Item
+                      className="more-menu-item"
+                      onSelect={() => openPanel("help")}
+                    >
+                      <QuestionIcon size={20} weight="bold" aria-hidden="true" />
+                      <span>查看帮助</span>
+                    </DropdownMenu.Item>
                     <DropdownMenu.Separator className="more-menu-separator" />
                     <DropdownMenu.Item className="more-menu-item" asChild>
                       <a
@@ -826,15 +833,6 @@ export default function Prototype() {
                   </DropdownMenu.Content>
                 </DropdownMenu.Portal>
               </DropdownMenu.Root>
-              <button
-                className="icon-button"
-                type="button"
-                aria-label="查看帮助"
-                title="查看帮助"
-                onClick={() => openPanel("help")}
-              >
-                <QuestionIcon size={23} weight="bold" />
-              </button>
             </div>
           </header>
 

--- a/webapp/tests/mobile-v2.spec.ts
+++ b/webapp/tests/mobile-v2.spec.ts
@@ -20,9 +20,10 @@ test.describe("mobile v2 presentation", () => {
     const primaryButton = await page.locator(".primary-button").boundingBox();
     expect(primaryButton?.height ?? 0).toBeGreaterThanOrEqual(52);
 
-    const helpButton = await page.locator(".icon-button").boundingBox();
-    expect(helpButton?.width ?? 0).toBeGreaterThanOrEqual(44);
-    expect(helpButton?.height ?? 0).toBeGreaterThanOrEqual(44);
+    const moreButton = page.getByRole("button", { name: "更多功能", exact: true });
+    const moreButtonBox = await moreButton.boundingBox();
+    expect(moreButtonBox?.width ?? 0).toBeGreaterThanOrEqual(44);
+    expect(moreButtonBox?.height ?? 0).toBeGreaterThanOrEqual(44);
 
     const coffeeButton = page.getByRole("button", { name: "请作者喝咖啡", exact: true });
     await expect(coffeeButton).toBeVisible();
@@ -215,12 +216,14 @@ test.describe("mobile v2 presentation", () => {
     expect(sessionCalls).toBe(0);
   });
 
-  test("keeps both header actions inside a 320px viewport", async ({ page }) => {
+  test("keeps the merged header actions inside a 320px viewport", async ({ page }) => {
     await page.setViewportSize({ width: 320, height: 720 });
     await page.goto("/");
 
     await expect(page.getByRole("button", { name: "请作者喝咖啡", exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: "查看帮助", exact: true })).toBeVisible();
+    const moreButton = page.getByRole("button", { name: "更多功能", exact: true });
+    await expect(moreButton).toBeVisible();
+    await expect(page.getByRole("button", { name: "查看帮助", exact: true })).toHaveCount(0);
     const headerFits = await page.locator(".product-header").evaluate((header) => {
       const viewportWidth = document.documentElement.clientWidth;
       const bounds = [header, ...Array.from(header.children)].map((element) => element.getBoundingClientRect());
@@ -228,6 +231,15 @@ test.describe("mobile v2 presentation", () => {
         && bounds.every((rect) => rect.left >= -0.5 && rect.right <= viewportWidth + 0.5);
     });
     expect(headerFits).toBe(true);
+
+    await moreButton.click();
+    const helpItem = page.getByRole("menuitem", { name: "查看帮助", exact: true });
+    await expect(helpItem).toBeVisible();
+    await helpItem.click();
+    const helpDialog = page.getByRole("dialog");
+    await expect(helpDialog.getByText("提醒如何工作", { exact: true })).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(helpDialog).toBeHidden();
 
     await page.getByRole("button", { name: "请作者喝咖啡", exact: true }).click();
     const qrImage = page.getByRole("img", { name: "微信支付收款二维码，收款人 Tt（**添）" });


### PR DESCRIPTION
## 变更

- 将右上角独立的问号帮助按钮移除；
- 在“更多”下拉菜单中新增带问号图标的“查看帮助”菜单项；
- 继续复用现有帮助 Bottom Sheet，帮助内容和交互保持不变；
- 更新移动端交互测试，验证 320px 宽度下右上角只保留“支持作者 + 更多”，并可从“更多 → 查看帮助”正常打开帮助面板；
- 更新源码契约测试，防止独立帮助按钮回归。

## 验证

- Python Header Actions 契约测试；
- Web TypeScript 构建与测试；
- Playwright 移动端布局和帮助入口交互回归；
- 不涉及 Worker API、D1、Airflow、微信发送或生产发布。
