### PR TITLE
chore(release): prepare 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ and operational changes.
 
 ## Unreleased
 
+## [0.6.3] - 2026-08-30
+
+### Changed
+
+- Merge the standalone header help button into the existing More menu, keeping
+  the same help sheet while simplifying the narrow-screen header to support
+  author and More actions only.
+- Add mobile interaction coverage for opening Help from More and preserving the
+  320px header layout.
+
 ## [0.6.2] - 2026-08-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wechat-on-airflow"
-version = "0.6.2"
+version = "0.6.3"
 description = "Airflow workflows for Shenzhen tennis availability notifications."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/src/wechat_airflow/__init__.py
+++ b/src/wechat_airflow/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime code for the production Airflow workflows."""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"


### PR DESCRIPTION
## Release

Prepare patch release `0.6.3` for the Web header cleanup merged in #166.

## Included user-visible change

- Remove the standalone question-mark help button from the top-right header.
- Add `查看帮助` with the same question-mark icon inside the existing More menu.
- Preserve the existing Help bottom sheet and all help content.
- Preserve narrow-screen layout and interaction coverage.

## Runtime scope

This is a Web-only UI release. It does not change Worker APIs, D1, Airflow schedules, email delivery, or WeChat delivery.

## Release contract

- `pyproject.toml`: `0.6.3`
- `src/wechat_airflow/__init__.py`: `0.6.3`
- `CHANGELOG.md`: matching `0.6.3` section

After exact-head CI succeeds, merge and ship through Production Control with `scope=auto sender=false`.