### PR TITLE
chore(release): prepare 0.6.6 desktop workspace release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ and operational changes.
 
 ## Unreleased
 
+## [0.6.6] - 2026-08-31
+
+### Added
+
+- Add a dedicated desktop browser workspace for viewports at 900px and above
+  while continuing to use the existing mobile state, validation, API, and
+  subscription logic.
+- Add a 1180px two-column layout with a high-density venue grid and a sticky
+  subscription task pane so users can monitor courts and create reminders in
+  parallel.
+
+### Changed
+
+- Present shared mobile bottom sheets as centered, viewport-safe desktop dialogs
+  with multi-column form controls, internal scrolling, and Escape-key dismissal.
+- Restore desktop pointer, hover, scrollbar, visible keyboard-focus, and reduced-
+  motion behavior without changing the protected narrow-screen runtime.
+- Keep viewports below 900px on the existing compact/mobile interaction model and
+  cover the 899/900px breakpoint plus the 1440px workspace in Chromium tests.
+
 ## [0.6.5] - 2026-08-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wechat-on-airflow"
-version = "0.6.5"
+version = "0.6.6"
 description = "Airflow workflows for Shenzhen tennis availability notifications."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/src/wechat_airflow/__init__.py
+++ b/src/wechat_airflow/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime code for the production Airflow workflows."""
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"


### PR DESCRIPTION
## Summary

Prepare the already-deployed adaptive desktop Web workspace as the repository's formal `0.6.6` named release.

## Changes

- Align `pyproject.toml` and `wechat_airflow.__version__` to `0.6.6`.
- Add the `0.6.6` user-visible desktop workspace notes to `CHANGELOG.md`.
- Do not change the tested Web implementation, Worker routes, D1 schema, Airflow runtime, or WeChat sender.

## Release context

The functional desktop change was merged in #174 and is already healthy on the production exact-commit deployment. After this metadata PR passes CI and merges, the protected `/release ship 0.6.6 <merge-sha> scope=auto sender=false` path will re-verify the final target, deploy only the resolved Web component, run exact-commit production health, and create the immutable tag and GitHub Release.
