### PR TITLE
fix(free-tier): eliminate D1 read amplification and deploy safely

### DIFF
--- a/.github/workflows/production-webapp.yml
+++ b/.github/workflows/production-webapp.yml
@@ -86,6 +86,33 @@ jobs:
           OPERATION: ${{ inputs.operation }}
           TARGET_COMMIT: ${{ inputs.target_commit }}
         run: |
+          set -euo pipefail
+
+          d1_quota_exhausted() {
+            grep -Eq "exceeded D1's free tier daily row read limit|\[code: 7500\]" <<<"$1"
+          }
+
+          run_d1_command() {
+            local description="$1"
+            shift
+            local output status
+            set +e
+            output="$("$@" 2>&1)"
+            status=$?
+            set -e
+            printf '%s\n' "$output"
+            if [ "$status" -eq 0 ]; then
+              return 0
+            fi
+            if d1_quota_exhausted "$output"; then
+              echo "::warning title=D1 free-tier quota exhausted::$description deferred until the UTC reset; only the quota-specific error was tolerated."
+              return 75
+            fi
+            echo "Unexpected D1 failure during: $description" >&2
+            return "$status"
+          }
+
+          migration_state=not_requested
           case "$OPERATION" in
             health)
               PYTHONPATH=../scripts python ../scripts/webapp_production_health.py \
@@ -95,23 +122,60 @@ jobs:
               npm run build
               npx wrangler deploy --dry-run \
                 --var "DEPLOYMENT_COMMIT:$TARGET_COMMIT"
-              npx wrangler d1 migrations list zacks-tennis-alerts --remote
+              if run_d1_command \
+                "remote migration preflight" \
+                npx wrangler d1 migrations list zacks-tennis-alerts --remote; then
+                migration_state=available
+              else
+                status=$?
+                test "$status" -eq 75
+                migration_state=deferred_quota
+              fi
               ;;
             deploy_apply)
               npm run build
-              # Apply mode includes its own reversible checks so routine releases
-              # do not need a separate preflight workflow run.
               npx wrangler deploy --dry-run \
                 --var "DEPLOYMENT_COMMIT:$TARGET_COMMIT"
-              npx wrangler d1 migrations list zacks-tennis-alerts --remote
-              npx wrangler d1 migrations apply zacks-tennis-alerts --remote
+              if run_d1_command \
+                "remote migration listing" \
+                npx wrangler d1 migrations list zacks-tennis-alerts --remote; then
+                if run_d1_command \
+                  "remote migration apply" \
+                  npx wrangler d1 migrations apply zacks-tennis-alerts --remote; then
+                  migration_state=applied
+                else
+                  status=$?
+                  test "$status" -eq 75
+                  migration_state=deferred_quota
+                fi
+              else
+                status=$?
+                test "$status" -eq 75
+                migration_state=deferred_quota
+              fi
+
               npx wrangler deploy \
                 --message "GitHub release $TARGET_COMMIT" \
                 --var "DEPLOYMENT_COMMIT:$TARGET_COMMIT"
-              PYTHONPATH=../scripts python ../scripts/webapp_production_health.py \
-                --expected-commit "$TARGET_COMMIT" --format json
+
+              if [ "$migration_state" = applied ]; then
+                PYTHONPATH=../scripts python ../scripts/webapp_production_health.py \
+                  --expected-commit "$TARGET_COMMIT" --format json
+              else
+                PYTHONPATH=../scripts python ../scripts/webapp_deployment_identity.py \
+                  --expected-commit "$TARGET_COMMIT" --format json
+              fi
               ;;
             *)
               exit 2
               ;;
           esac
+
+          {
+            echo "## D1 migration state"
+            echo
+            echo "- State: \`$migration_state\`"
+            if [ "$migration_state" = deferred_quota ]; then
+              echo "- Recovery: the deployed Worker will idempotently create the same indexes on the first natural observation or cron after D1 accepts queries again."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/incidents/cloudflare-d1-read-limit-2026-09-02.md
+++ b/docs/incidents/cloudflare-d1-read-limit-2026-09-02.md
@@ -1,0 +1,102 @@
+# Cloudflare D1 Daily Read-Limit Incident — 2026-09-02
+
+## Status
+
+Production Airflow host access, SSH authentication, and the public Web entrypoint
+remain reachable. The outage is inside the Cloudflare Worker data path: D1 has
+exhausted the account's Free-plan daily row-read allowance and rejects database
+queries with Cloudflare error code `7500`.
+
+Until the quota resets or the account moves to Workers Paid, D1-backed Web APIs,
+observation ingestion, delivery reconciliation, subscription data, and admin
+metrics can return HTTP 500. Static assets or an already cached page can still
+appear available, so the symptom can look like a partial server outage.
+
+No production repair has been deployed from this incident branch.
+
+## Evidence
+
+Read-only production diagnosis was run against exact main commit
+`77bd0adb76b1ca716bd928705dddae78b7ea76ac`.
+
+- Ops diagnosis run `33614031324` reached the production host and completed the
+  authenticated Web probe, but `POST /api/internal/reconcile-deliveries`
+  returned HTTP 500 with `D1_ERROR`.
+- Protected Web preflight run `33614245883` exposed the upstream Wrangler
+  message: `Your account has exceeded D1's free tier daily row read limit` with
+  error code `7500`.
+- The most recent successful production diagnostic before the outage showed
+  individual `notification_outbox` aggregate queries reading approximately
+  41,730 to 42,497 rows while returning only a small aggregate result.
+
+The last main commit changed only the Web logo. Its Web deployment completed
+successfully on 2026-08-31, and Airflow was not redeployed for that asset-only
+release. Restarting Airflow or rolling back the logo does not address this
+failure mode.
+
+## Root Cause
+
+Cloudflare began enforcing D1 Free-plan daily limits on 2026-09-01. Production
+reached the 5,000,000-row daily read limit because several frequent queries were
+not bounded by a suitable index as `notification_outbox` accumulated history:
+
+1. global daily delivery-budget checks filtered only by
+   `provider_submitted_at`;
+2. per-recipient daily delivery-budget and dashboard checks filtered by email
+   plus provider timestamps;
+3. delivered-today dashboard checks filtered by status and
+   `provider_delivered_at`;
+4. delivery reconciliation selected and updated rows repeatedly by
+   `message_id` without a `message_id` index.
+
+The earlier free-tier remediation in migration `0009` reduced unchanged
+observation ingestion and indexed `email_delivery_claims`. It did not index
+these remaining `notification_outbox` access paths.
+
+## Remediation
+
+Migration `0016_optimize_notification_outbox_reads.sql` adds three additive,
+partial indexes:
+
+- `notification_outbox_message_id_lookup_idx` bounds provider-message lookup
+  and reconciliation updates;
+- `notification_outbox_submitted_at_lookup_idx` bounds current-day global and
+  recipient submission counts;
+- `notification_outbox_delivered_at_lookup_idx` bounds delivered-today counts.
+
+The indexes exclude rows whose relevant provider fields are still null. This
+keeps pending observation records out of the new indexes and limits D1 write and
+storage amplification.
+
+`tests/webapp_notification_outbox_read_migration_test.py` recreates the existing
+production indexes, applies migration `0016`, and verifies with SQLite
+`EXPLAIN QUERY PLAN` that the four hot query shapes use the new indexes instead
+of `SCAN notification_outbox`.
+
+## Recovery Procedure
+
+The Free-plan quota resets at `00:00 UTC`; for this incident the next reset is
+2026-09-03 00:00 UTC, or 2026-09-03 09:00 in Korea. Moving the account to
+Workers Paid is the immediate alternative if service must recover before that
+reset.
+
+After D1 accepts queries again:
+
+1. let CI verify this branch and review the draft pull request;
+2. run protected Web preflight for the exact merged commit;
+3. deploy the Web scope so migration `0016` is applied;
+4. rerun `webapp-observation-diagnose` and delivery reconciliation diagnosis;
+5. monitor D1 rows read and written for a full UTC day, with an operational
+   target below 2,000,000 rows read per day and enough margin below the write
+   limit.
+
+Do not merge or deploy solely because the quota reset makes the site appear
+healthy again. Without the index repair, the same workload can exhaust the next
+UTC day's allowance.
+
+## Rollback
+
+The migration is additive and changes no application behavior or existing
+records. The indexes can remain after an application rollback. Drop them only
+if production measurements show unacceptable write amplification; capture D1
+read/write evidence before doing so.

--- a/docs/incidents/cloudflare-d1-read-limit-2026-09-02.md
+++ b/docs/incidents/cloudflare-d1-read-limit-2026-09-02.md
@@ -4,15 +4,17 @@
 
 Production Airflow host access, SSH authentication, and the public Web entrypoint
 remain reachable. The outage is inside the Cloudflare Worker data path: D1 has
-exhausted the account's Free-plan daily row-read allowance and rejects database
-queries with Cloudflare error code `7500`.
+exhausted the account's Workers Free daily row-read allowance and rejects
+database queries with Cloudflare error code `7500`.
 
-Until the quota resets or the account moves to Workers Paid, D1-backed Web APIs,
-observation ingestion, delivery reconciliation, subscription data, and admin
-metrics can return HTTP 500. Static assets or an already cached page can still
-appear available, so the symptom can look like a partial server outage.
+Until the quota resets, D1-backed Web APIs, observation ingestion, delivery
+reconciliation, subscription data, and admin metrics can return HTTP 500. Static
+assets, `/api/healthz`, or an already cached page can still appear available, so
+the symptom can look like a partial server outage.
 
-No production repair has been deployed from this incident branch.
+The remediation deliberately remains on Workers Free. It does not reduce any
+venue's upstream polling frequency and does not send a real email or WeChat
+probe during release.
 
 ## Evidence
 
@@ -47,16 +49,25 @@ not bounded by a suitable index as `notification_outbox` accumulated history:
 3. delivered-today dashboard checks filtered by status and
    `provider_delivered_at`;
 4. delivery reconciliation selected and updated rows repeatedly by
-   `message_id` without a `message_id` index.
+   `message_id` without a `message_id` index;
+5. every observation scope still crossed the network at least once every five
+   minutes, and an unchanged heartbeat re-entered more Worker layers than needed;
+6. the browser's 30-second refresh loop periodically exhausted its short client
+   cache and created new personalized bootstrap work;
+7. the delivery diagnostic script contained historical aggregate shapes that
+   could themselves read a large fraction of the Outbox during an incident.
 
 The earlier free-tier remediation in migration `0009` reduced unchanged
-observation ingestion and indexed `email_delivery_claims`. It did not index
-these remaining `notification_outbox` access paths.
+observation ingestion and indexed `email_delivery_claims`. It did not index the
+remaining `notification_outbox` access paths or coalesce heartbeats across
+parallel Airflow task scopes.
 
-## Remediation
+## Free-Tier Remediation
+
+### Indexed Outbox reads
 
 Migration `0016_optimize_notification_outbox_reads.sql` adds three additive,
-partial indexes:
+partial indexes and runs `PRAGMA optimize`:
 
 - `notification_outbox_message_id_lookup_idx` bounds provider-message lookup
   and reconciliation updates;
@@ -66,37 +77,110 @@ partial indexes:
 
 The indexes exclude rows whose relevant provider fields are still null. This
 keeps pending observation records out of the new indexes and limits D1 write and
-storage amplification.
+storage amplification. Migration tests verify the four production query shapes
+with `EXPLAIN QUERY PLAN` and reject a full `SCAN notification_outbox`.
 
-`tests/webapp_notification_outbox_read_migration_test.py` recreates the existing
-production indexes, applies migration `0016`, and verifies with SQLite
-`EXPLAIN QUERY PLAN` that the four hot query shapes use the new indexes instead
-of `SCAN notification_outbox`.
+### Sparse server liveness, not browser-driven health
+
+A browser refresh cannot prove that an Airflow watcher is alive; it only rereads
+whatever D1 already contains. The repair therefore removes frequent per-task
+heartbeats but retains one sparse, lightweight liveness update per venue.
+
+The Airflow publisher now keeps an atomic, process-independent fingerprint file
+in the shared Airflow logs volume:
+
+- every real slot, health, or error change bypasses throttling immediately;
+- unchanged polls do not call the Worker;
+- parallel day/task scopes share one venue-level liveness budget;
+- at most one unchanged publication per venue is allowed every eight minutes,
+  below the existing ten-minute venue-health freshness window;
+- after a failed Web publication, unchanged retries are limited to once every
+  two minutes while a new state change still bypasses the backoff;
+- cached WeChat gate state is retained without rewriting the Airflow metadata
+  database on every unchanged response.
+
+When an unchanged publication reaches the Worker, it updates only the indexed
+observation timestamp and `venue_status`. It does not rescan subscriptions,
+rewrite observed slots, create Outbox rows, reconcile delivery, or fetch a
+WeChat gate. A changed fingerprint still enters the complete business path.
+Subscription and priority mutations invalidate the observation fingerprints so
+a newly eligible subscriber is matched on the next natural venue poll even when
+the availability payload itself has not changed.
+
+### User-driven dashboard network refresh
+
+The existing refresh control continues to use `?refresh=1` and bypasses both
+client and edge caches. Automatic UI renders reuse the in-memory dashboard for
+one day, so the 30-second presentation loop no longer creates periodic network
+or D1 work. Verification, identity changes, subscription create/cancel, and
+priority redemption invalidate the cache immediately. The private edge cache is
+retained for five minutes as a second layer for page loads and concurrent tabs.
+
+### Bounded diagnostics
+
+`diagnose_email_delivery_metrics.sh` now requires an indexed current-day or
+retention-window predicate for Outbox aggregates. The only older-than-retention
+check is an existence probe with `LIMIT 1`; it no longer calculates an exact
+all-history count during routine diagnosis.
+
+### Quota-exhaustion release path
+
+The protected Web release still fails closed for all unexpected database,
+authentication, migration, and configuration errors. It tolerates only the
+known D1 Free row-read quota message or error code `7500`:
+
+1. build and dry-run the exact main commit;
+2. attempt the normal migration listing and apply;
+3. if and only if D1 reports the known exhausted quota, defer the migration;
+4. deploy the Worker repair and verify its exact commit through `/api/healthz`,
+   which does not query D1;
+5. deploy the matching Airflow publisher;
+6. after D1 accepts queries, the five-minute Worker cron idempotently creates
+   the same indexes once, records a schema marker, and resumes normal work.
+
+Schema repair is not executed on the observation request hot path. The normal
+D1 migration remains authoritative whenever the database is available.
+
+## Expected Budget
+
+There are currently 26 Web venues. With one unchanged liveness publication per
+venue every eight minutes, the theoretical maximum is 4,680 unchanged Worker
+requests per day before task runtime and inactive periods reduce it. Each uses a
+primary-key state lookup and, only when due, two small state writes. Real changes
+add a comparatively small number of full ingests.
+
+The operational acceptance targets remain:
+
+- D1 rows read below 2,000,000 per UTC day;
+- D1 rows written below 30,000 per UTC day;
+- total Worker requests below 80,000 per UTC day;
+- Workers `exceededCpu` equal to zero;
+- no active venue DAG polling schedule changed;
+- availability and health changes visible on the first matching poll.
 
 ## Recovery Procedure
 
 The Free-plan quota resets at `00:00 UTC`; for this incident the next reset is
-2026-09-03 00:00 UTC, or 2026-09-03 09:00 in Korea. Moving the account to
-Workers Paid is the immediate alternative if service must recover before that
-reset.
+2026-09-03 00:00 UTC, or 2026-09-03 09:00 in Korea.
 
-After D1 accepts queries again:
+The repair can be deployed before the reset because its protected release path
+does not require a successful D1 query when the exact quota-specific error is
+observed. After the reset:
 
-1. let CI verify this branch and review the draft pull request;
-2. run protected Web preflight for the exact merged commit;
-3. deploy the Web scope so migration `0016` is applied;
-4. rerun `webapp-observation-diagnose` and delivery reconciliation diagnosis;
-5. monitor D1 rows read and written for a full UTC day, with an operational
-   target below 2,000,000 rows read per day and enough margin below the write
-   limit.
+1. confirm the schema marker and migration `0016` are applied;
+2. verify `/api/bootstrap` and an unauthenticated observation probe;
+3. observe natural venue cycles without injecting a production slot;
+4. run the bounded observation and delivery diagnostics once;
+5. monitor a complete UTC day of D1 rows read/written and Worker invocations.
 
-Do not merge or deploy solely because the quota reset makes the site appear
-healthy again. Without the index repair, the same workload can exhaust the next
-UTC day's allowance.
+A quota reset alone is not acceptance. Without the code and index repair, the
+same workload can exhaust the next UTC day's allowance.
 
 ## Rollback
 
-The migration is additive and changes no application behavior or existing
-records. The indexes can remain after an application rollback. Drop them only
-if production measurements show unacceptable write amplification; capture D1
-read/write evidence before doing so.
+The D1 migration is additive and changes no existing records. The indexes can
+remain after an application rollback. The Airflow local state file contains
+only fingerprints, timestamps, and the already redacted gate decision; deleting
+it causes a safe fail-open full publication on the next poll. A component
+rollback must use the prior exact Web and Airflow commits through their protected
+workflows.

--- a/docs/incidents/cloudflare-d1-read-limit-2026-09-02.md
+++ b/docs/incidents/cloudflare-d1-read-limit-2026-09-02.md
@@ -90,22 +90,33 @@ The Airflow publisher now keeps an atomic, process-independent fingerprint file
 in the shared Airflow logs volume:
 
 - every real slot, health, or error change bypasses throttling immediately;
-- unchanged polls do not call the Worker;
-- parallel day/task scopes share one venue-level liveness budget;
-- at most one unchanged publication per venue is allowed every eight minutes,
-  below the existing ten-minute venue-health freshness window;
-- after a failed Web publication, unchanged retries are limited to once every
-  two minutes while a new state change still bypasses the backoff;
+- unchanged observations with no available slots do not call the Worker between
+  sparse liveness updates;
+- parallel empty day/task scopes share one venue-level liveness budget;
+- at most one unchanged empty publication per venue is allowed every eight
+  minutes, below the existing ten-minute venue-health freshness window;
+- observations that contain available slots continue to reach the Worker on
+  every natural poll so a newly created subscription can match existing
+  availability immediately;
+- after a failed Web publication, an identical retry is limited to once every
+  two minutes, but a different slot, health, or error fingerprint still bypasses
+  the backoff;
+- a failed changed fingerprint is never hidden by an older successful venue
+  heartbeat;
 - cached WeChat gate state is retained without rewriting the Airflow metadata
   database on every unchanged response.
 
-When an unchanged publication reaches the Worker, it updates only the indexed
-observation timestamp and `venue_status`. It does not rescan subscriptions,
-rewrite observed slots, create Outbox rows, reconcile delivery, or fetch a
-WeChat gate. A changed fingerprint still enters the complete business path.
-Subscription and priority mutations invalidate the observation fingerprints so
-a newly eligible subscriber is matched on the next natural venue poll even when
-the availability payload itself has not changed.
+For available-slot observations, the Worker performs only an indexed fingerprint
+lookup when the state is otherwise unchanged. When a sparse empty heartbeat is
+due, it updates only the indexed observation timestamp and `venue_status`. That
+path does not rescan subscriptions, rewrite observed slots, create Outbox rows,
+reconcile delivery, or fetch a WeChat gate. A changed fingerprint still enters
+the complete business path.
+
+Subscription and priority mutations invalidate the Worker observation
+fingerprints. Because available-slot observations are not suppressed on the
+Airflow host, a newly eligible subscriber is matched on the next natural venue
+poll even when the availability payload itself has not changed.
 
 ### User-driven dashboard network refresh
 
@@ -143,11 +154,12 @@ D1 migration remains authoritative whenever the database is available.
 
 ## Expected Budget
 
-There are currently 26 Web venues. With one unchanged liveness publication per
-venue every eight minutes, the theoretical maximum is 4,680 unchanged Worker
-requests per day before task runtime and inactive periods reduce it. Each uses a
-primary-key state lookup and, only when due, two small state writes. Real changes
-add a comparatively small number of full ingests.
+There are currently 26 Web venues. Empty and unchanged observations are reduced
+to at most 4,680 lightweight Worker requests per day across all venues before
+inactive periods and task runtime reduce the actual count. Observations that
+contain availability intentionally continue at the configured natural polling
+schedule so subscription changes are not starved. Their unchanged Worker path
+uses one indexed state lookup rather than a full business ingest.
 
 The operational acceptance targets remain:
 
@@ -156,7 +168,9 @@ The operational acceptance targets remain:
 - total Worker requests below 80,000 per UTC day;
 - Workers `exceededCpu` equal to zero;
 - no active venue DAG polling schedule changed;
-- availability and health changes visible on the first matching poll.
+- availability and health changes visible on the first matching poll;
+- a subscription created while slots already exist is evaluated on the next
+  natural venue poll.
 
 ## Recovery Procedure
 

--- a/scripts/diagnose_email_delivery_metrics.sh
+++ b/scripts/diagnose_email_delivery_metrics.sh
@@ -9,24 +9,27 @@ wrangler() {
 }
 
 # Keep diagnostics aggregate/redacted: no recipient addresses, subjects, bodies,
-# request IDs, provider message IDs, or delivery reasons are printed.
+# request IDs, provider message IDs, or delivery reasons are printed. Every
+# notification_outbox query is bounded by an indexed provider timestamp or uses
+# an existence probe that stops at the first legacy row.
 printf '%s\n' '__EMAIL_DELIVERY_METRICS__'
 wrangler d1 execute zacks-tennis-alerts --remote --json --command "
 WITH day AS (
   SELECT datetime('now','+8 hours','start of day','-8 hours') AS start_utc
 )
 SELECT
-  COUNT(DISTINCT CASE WHEN provider_submitted_at >= day.start_utc THEN message_id END) AS submitted_today,
+  COUNT(DISTINCT message_id) AS submitted_today,
   COUNT(DISTINCT CASE WHEN status='delivered' AND provider_delivered_at >= day.start_utc THEN message_id END) AS delivered_today,
-  COUNT(DISTINCT CASE WHEN status='failed' AND provider_submitted_at >= day.start_utc THEN message_id END) AS failed_today,
-  COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc THEN message_id END) AS pending_today,
-  COUNT(DISTINCT CASE WHEN provider_submitted_at >= day.start_utc AND provider_checked_at IS NOT NULL THEN message_id END) AS checked_today,
-  COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc AND provider_checked_at IS NULL THEN message_id END) AS never_checked_today,
-  COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc AND provider_status='not_found' THEN message_id END) AS not_found_today,
-  COUNT(DISTINCT CASE WHEN status='submitted' AND provider_submitted_at >= day.start_utc AND provider_status LIKE 'check_error:%' THEN message_id END) AS check_error_today,
-  COUNT(DISTINCT CASE WHEN provider_submitted_at >= day.start_utc AND message_id LIKE 'worker:%' THEN message_id END) AS placeholder_message_ids_today,
-  COUNT(DISTINCT CASE WHEN provider_submitted_at >= day.start_utc THEN email END) AS recipients_today
-FROM notification_outbox, day;
+  COUNT(DISTINCT CASE WHEN status='failed' THEN message_id END) AS failed_today,
+  COUNT(DISTINCT CASE WHEN status='submitted' THEN message_id END) AS pending_today,
+  COUNT(DISTINCT CASE WHEN provider_checked_at IS NOT NULL THEN message_id END) AS checked_today,
+  COUNT(DISTINCT CASE WHEN status='submitted' AND provider_checked_at IS NULL THEN message_id END) AS never_checked_today,
+  COUNT(DISTINCT CASE WHEN status='submitted' AND provider_status='not_found' THEN message_id END) AS not_found_today,
+  COUNT(DISTINCT CASE WHEN status='submitted' AND provider_status LIKE 'check_error:%' THEN message_id END) AS check_error_today,
+  COUNT(DISTINCT CASE WHEN message_id LIKE 'worker:%' THEN message_id END) AS placeholder_message_ids_today,
+  COUNT(DISTINCT email) AS recipients_today
+FROM notification_outbox, day
+WHERE provider_submitted_at >= day.start_utc;
 "
 
 printf '%s\n' '__ADMIN_IDENTITY_DELIVERY_METRICS__'
@@ -35,19 +38,20 @@ WITH day AS (
   SELECT datetime('now','+8 hours','start of day','-8 hours') AS start_utc
 )
 SELECT
-  COUNT(DISTINCT CASE WHEN n.provider_submitted_at >= day.start_utc THEN n.message_id END) AS submitted_today,
+  COUNT(DISTINCT n.message_id) AS submitted_today,
   COUNT(DISTINCT CASE WHEN n.status='delivered' AND n.provider_delivered_at >= day.start_utc THEN n.message_id END) AS delivered_today,
-  COUNT(DISTINCT CASE WHEN n.status='failed' AND n.provider_submitted_at >= day.start_utc THEN n.message_id END) AS failed_today,
-  COUNT(DISTINCT CASE WHEN n.status='submitted' AND n.provider_submitted_at >= day.start_utc THEN n.message_id END) AS pending_today,
-  COUNT(DISTINCT CASE WHEN n.provider_submitted_at >= day.start_utc AND n.provider_checked_at IS NOT NULL THEN n.message_id END) AS checked_today
+  COUNT(DISTINCT CASE WHEN n.status='failed' THEN n.message_id END) AS failed_today,
+  COUNT(DISTINCT CASE WHEN n.status='submitted' THEN n.message_id END) AS pending_today,
+  COUNT(DISTINCT CASE WHEN n.provider_checked_at IS NOT NULL THEN n.message_id END) AS checked_today
 FROM notification_outbox n, day
-WHERE EXISTS (
-  SELECT 1
-    FROM user_roles roles
-   WHERE roles.email = n.email
-     AND roles.role = 'admin'
-     AND roles.revoked_at IS NULL
-);
+WHERE n.provider_submitted_at >= day.start_utc
+  AND EXISTS (
+    SELECT 1
+      FROM user_roles roles
+     WHERE roles.email = n.email
+       AND roles.role = 'admin'
+       AND roles.revoked_at IS NULL
+  );
 "
 
 printf '%s\n' '__PROVIDER_STATUS_BREAKDOWN__'
@@ -86,25 +90,34 @@ WITH bounds AS (
   SELECT
     datetime('now','-48 hours') AS recent_cutoff,
     datetime('now','-30 days') AS retention_cutoff
+), retained AS (
+  SELECT outbox.message_id, outbox.provider_submitted_at
+    FROM notification_outbox outbox, bounds
+   WHERE outbox.status='submitted'
+     AND outbox.message_id IS NOT NULL
+     AND outbox.message_id NOT LIKE 'worker:%'
+     AND outbox.provider_submitted_at >= bounds.retention_cutoff
 )
 SELECT
   COUNT(DISTINCT CASE
-    WHEN provider_submitted_at >= bounds.recent_cutoff THEN message_id END
+    WHEN retained.provider_submitted_at >= bounds.recent_cutoff THEN retained.message_id END
   ) AS recent_pending,
   COUNT(DISTINCT CASE
-    WHEN provider_submitted_at >= bounds.retention_cutoff
-     AND provider_submitted_at < bounds.recent_cutoff THEN message_id END
+    WHEN retained.provider_submitted_at < bounds.recent_cutoff THEN retained.message_id END
   ) AS queryable_backlog,
-  COUNT(DISTINCT CASE
-    WHEN provider_submitted_at < bounds.retention_cutoff THEN message_id END
-  ) AS retention_expired,
-  COUNT(DISTINCT message_id) AS total_pending,
-  MIN(provider_submitted_at) AS oldest_pending_at,
-  MAX(provider_submitted_at) AS newest_pending_at
-FROM notification_outbox, bounds
-WHERE status='submitted'
-  AND message_id IS NOT NULL
-  AND message_id NOT LIKE 'worker:%';
+  EXISTS(
+    SELECT 1
+      FROM notification_outbox legacy, bounds legacy_bounds
+     WHERE legacy.status='submitted'
+       AND legacy.message_id IS NOT NULL
+       AND legacy.message_id NOT LIKE 'worker:%'
+       AND legacy.provider_submitted_at < legacy_bounds.retention_cutoff
+     LIMIT 1
+  ) AS has_retention_expired,
+  COUNT(DISTINCT retained.message_id) AS total_pending,
+  MIN(retained.provider_submitted_at) AS oldest_pending_at,
+  MAX(retained.provider_submitted_at) AS newest_pending_at
+FROM retained, bounds;
 "
 
 printf '%s\n' '__VENUE_NOTIFICATION_COVERAGE__'

--- a/scripts/webapp_deployment_identity.py
+++ b/scripts/webapp_deployment_identity.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import urllib.error
+import urllib.request
+from typing import Any
+
+import yaml
+from _ops import REPO_ROOT, OpsError, emit
+
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+def request_json(url: str, *, timeout_seconds: float = 15) -> tuple[int, Any]:
+    request = urllib.request.Request(
+        url,
+        method="GET",
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "wechat-on-airflow-webapp-identity/1.0",
+        },
+    )
+    try:
+        response = urllib.request.urlopen(request, timeout=timeout_seconds)
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        raw = exc.read()
+    except urllib.error.URLError as exc:
+        raise OpsError(f"web application request failed: {exc.reason}") from exc
+    else:
+        status = response.status
+        raw = response.read()
+
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise OpsError(f"web application returned invalid JSON with HTTP {status}") from exc
+    return status, value
+
+
+def evaluate_deployment_identity(
+    status: int,
+    payload: Any,
+    expected_commit: str,
+) -> dict[str, Any]:
+    checks = {
+        "health_http_ok": status == 200,
+        "service_healthy": isinstance(payload, dict) and payload.get("ok") is True,
+        "priority_weather_bypass_enabled": isinstance(payload, dict)
+        and isinstance(payload.get("capabilities"), dict)
+        and payload["capabilities"].get("priorityWeatherBypass") is True,
+        "exact_deployment_commit": isinstance(payload, dict)
+        and payload.get("deploymentCommit") == expected_commit,
+    }
+    return {
+        "ok": all(checks.values()),
+        "expected_commit": expected_commit,
+        "deployed_commit": payload.get("deploymentCommit") if isinstance(payload, dict) else None,
+        "d1_checked": False,
+        "checks": checks,
+    }
+
+
+def inspect_deployment_identity(*, base_url: str, expected_commit: str) -> dict[str, Any]:
+    status, payload = request_json(f"{base_url.rstrip('/')}/api/healthz")
+    return evaluate_deployment_identity(status, payload, expected_commit)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify the deployed Worker identity without querying D1."
+    )
+    parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args()
+
+    if not COMMIT_PATTERN.fullmatch(args.expected_commit):
+        raise OpsError("expected commit must be a full SHA-1")
+
+    runtime_target = yaml.safe_load(
+        (REPO_ROOT / "config" / "runtime-target.yaml").read_text(encoding="utf-8")
+    )
+    target = runtime_target["managed_services"]["webapp"]
+    payload = inspect_deployment_identity(
+        base_url=str(target["public_base_url"]),
+        expected_commit=args.expected_commit,
+    )
+    emit(payload, args.format)
+    if not payload["ok"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except OpsError as exc:
+        print(f"webapp-deployment-identity: {exc}")
+        raise SystemExit(1) from exc

--- a/src/wechat_airflow/notifications/observation_cache.py
+++ b/src/wechat_airflow/notifications/observation_cache.py
@@ -243,6 +243,7 @@ def decide_observation_delivery(
 ) -> ObservationDeliveryDecision:
     current_time = time.time() if now is None else now
     venue_id = _string_field(payload, "venue_id", "venueId")
+    has_available_slots = bool(_canonical_slots(payload.get("slots")))
     key, fingerprint = observation_identity(payload)
     if not observation_cache_enabled():
         return ObservationDeliveryDecision(
@@ -283,18 +284,22 @@ def decide_observation_delivery(
                 OBSERVATION_FAILURE_RETRY_SECONDS_ENV,
                 DEFAULT_OBSERVATION_FAILURE_RETRY_SECONDS,
             )
-            fingerprint_was_forwarded = entry["last_success_at"] > 0
+            retry_pending = heartbeat["last_attempt_at"] > heartbeat["last_success_at"]
             if (
-                fingerprint_was_forwarded
+                retry_pending
+                and current_time - heartbeat["last_attempt_at"] < retry_seconds
+            ):
+                action: ObservationAction = "skip_retry"
+            elif has_available_slots:
+                action = "forward"
+                _reserve_venue_attempt(state, venue_id, current_time)
+                _write_state(path, state)
+            elif (
+                entry["last_success_at"] > 0
                 and heartbeat["last_success_at"] > 0
                 and current_time - heartbeat["last_success_at"] < heartbeat_seconds
             ):
-                action: ObservationAction = "skip_success"
-            elif (
-                heartbeat["last_attempt_at"] > heartbeat["last_success_at"]
-                and current_time - heartbeat["last_attempt_at"] < retry_seconds
-            ):
-                action = "skip_retry"
+                action = "skip_success"
             else:
                 action = "forward"
                 _reserve_venue_attempt(state, venue_id, current_time)

--- a/src/wechat_airflow/notifications/observation_cache.py
+++ b/src/wechat_airflow/notifications/observation_cache.py
@@ -17,9 +17,9 @@ OBSERVATION_CACHE_PATH_ENV = "WEBAPP_OBSERVATION_STATE_PATH"
 OBSERVATION_HEARTBEAT_SECONDS_ENV = "WEBAPP_OBSERVATION_HEARTBEAT_SECONDS"
 OBSERVATION_FAILURE_RETRY_SECONDS_ENV = "WEBAPP_OBSERVATION_FAILURE_RETRY_SECONDS"
 DEFAULT_OBSERVATION_CACHE_PATH = Path("/opt/airflow/logs/webapp-observation-state.json")
-DEFAULT_OBSERVATION_HEARTBEAT_SECONDS = 300.0
+DEFAULT_OBSERVATION_HEARTBEAT_SECONDS = 480.0
 DEFAULT_OBSERVATION_FAILURE_RETRY_SECONDS = 120.0
-_STATE_VERSION = 1
+_STATE_VERSION = 2
 
 ObservationAction = Literal["forward", "skip_success", "skip_retry"]
 
@@ -31,9 +31,15 @@ class CacheEntry(TypedDict):
     gate: dict[str, Any] | None
 
 
+class VenueHeartbeat(TypedDict):
+    last_attempt_at: float
+    last_success_at: float
+
+
 class CacheState(TypedDict):
     version: int
     entries: dict[str, CacheEntry]
+    venues: dict[str, VenueHeartbeat]
 
 
 @dataclass(frozen=True)
@@ -43,6 +49,7 @@ class ObservationDeliveryDecision:
     fingerprint: str
     gate: dict[str, Any] | None
     enabled: bool
+    venue_id: str = ""
 
 
 def _configured_seconds(name: str, fallback: float) -> float:
@@ -134,7 +141,7 @@ def _entry_gate(entry: object) -> dict[str, Any] | None:
 
 
 def _empty_state() -> CacheState:
-    return {"version": _STATE_VERSION, "entries": {}}
+    return {"version": _STATE_VERSION, "entries": {}, "venues": {}}
 
 
 def _read_state(path: Path) -> CacheState:
@@ -144,24 +151,37 @@ def _read_state(path: Path) -> CacheState:
         return _empty_state()
     if not isinstance(value, dict):
         return _empty_state()
-    raw_entries = value.get("entries")
-    if not isinstance(raw_entries, dict):
-        return _empty_state()
 
+    raw_entries = value.get("entries")
     entries: dict[str, CacheEntry] = {}
-    for key, raw_entry in raw_entries.items():
-        if not isinstance(raw_entry, Mapping):
-            continue
-        try:
-            entries[str(key)] = {
-                "fingerprint": str(raw_entry.get("fingerprint") or ""),
-                "last_attempt_at": float(raw_entry.get("last_attempt_at") or 0),
-                "last_success_at": float(raw_entry.get("last_success_at") or 0),
-                "gate": _entry_gate(raw_entry),
-            }
-        except (TypeError, ValueError):
-            continue
-    return {"version": _STATE_VERSION, "entries": entries}
+    if isinstance(raw_entries, dict):
+        for key, raw_entry in raw_entries.items():
+            if not isinstance(raw_entry, Mapping):
+                continue
+            try:
+                entries[str(key)] = {
+                    "fingerprint": str(raw_entry.get("fingerprint") or ""),
+                    "last_attempt_at": float(raw_entry.get("last_attempt_at") or 0),
+                    "last_success_at": float(raw_entry.get("last_success_at") or 0),
+                    "gate": _entry_gate(raw_entry),
+                }
+            except (TypeError, ValueError):
+                continue
+
+    raw_venues = value.get("venues")
+    venues: dict[str, VenueHeartbeat] = {}
+    if isinstance(raw_venues, dict):
+        for venue_id, raw_heartbeat in raw_venues.items():
+            if not isinstance(raw_heartbeat, Mapping):
+                continue
+            try:
+                venues[str(venue_id)] = {
+                    "last_attempt_at": float(raw_heartbeat.get("last_attempt_at") or 0),
+                    "last_success_at": float(raw_heartbeat.get("last_success_at") or 0),
+                }
+            except (TypeError, ValueError):
+                continue
+    return {"version": _STATE_VERSION, "entries": entries, "venues": venues}
 
 
 def _write_state(path: Path, state: CacheState) -> None:
@@ -196,48 +216,104 @@ def _locked_state(path: Path) -> Iterator[CacheState]:
             fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
 
 
+def _latest_gate(state: CacheState, venue_id: str) -> dict[str, Any] | None:
+    candidates: list[tuple[float, dict[str, Any]]] = []
+    prefix = f"{venue_id}:"
+    for key, entry in state["entries"].items():
+        if not key.startswith(prefix):
+            continue
+        gate = _entry_gate(entry)
+        if gate is not None:
+            candidates.append((entry["last_success_at"], gate))
+    return max(candidates, key=lambda item: item[0])[1] if candidates else None
+
+
+def _reserve_venue_attempt(state: CacheState, venue_id: str, current_time: float) -> None:
+    heartbeat = state["venues"].setdefault(
+        venue_id,
+        {"last_attempt_at": 0.0, "last_success_at": 0.0},
+    )
+    heartbeat["last_attempt_at"] = current_time
+
+
 def decide_observation_delivery(
     payload: Mapping[str, object],
     *,
     now: float | None = None,
 ) -> ObservationDeliveryDecision:
     current_time = time.time() if now is None else now
+    venue_id = _string_field(payload, "venue_id", "venueId")
     key, fingerprint = observation_identity(payload)
     if not observation_cache_enabled():
-        return ObservationDeliveryDecision("forward", key, fingerprint, None, False)
+        return ObservationDeliveryDecision(
+            "forward",
+            key,
+            fingerprint,
+            None,
+            False,
+            venue_id,
+        )
 
     path = observation_cache_path()
     try:
         with _locked_state(path) as state:
             entry = state["entries"].get(key)
+            gate = _latest_gate(state, venue_id)
             if entry is None or entry["fingerprint"] != fingerprint:
+                _reserve_venue_attempt(state, venue_id, current_time)
+                _write_state(path, state)
                 return ObservationDeliveryDecision(
                     "forward",
                     key,
                     fingerprint,
-                    _entry_gate(entry),
+                    gate,
                     True,
+                    venue_id,
                 )
-            gate = _entry_gate(entry)
-            last_success = entry["last_success_at"]
-            last_attempt = entry["last_attempt_at"]
-            heartbeat = _configured_seconds(
+
+            heartbeat = state["venues"].setdefault(
+                venue_id,
+                {"last_attempt_at": 0.0, "last_success_at": 0.0},
+            )
+            heartbeat_seconds = _configured_seconds(
                 OBSERVATION_HEARTBEAT_SECONDS_ENV,
                 DEFAULT_OBSERVATION_HEARTBEAT_SECONDS,
             )
-            retry = _configured_seconds(
+            retry_seconds = _configured_seconds(
                 OBSERVATION_FAILURE_RETRY_SECONDS_ENV,
                 DEFAULT_OBSERVATION_FAILURE_RETRY_SECONDS,
             )
-            if last_success > 0 and current_time - last_success < heartbeat:
+            if (
+                heartbeat["last_success_at"] > 0
+                and current_time - heartbeat["last_success_at"] < heartbeat_seconds
+            ):
                 action: ObservationAction = "skip_success"
-            elif last_attempt > last_success and current_time - last_attempt < retry:
+            elif (
+                heartbeat["last_attempt_at"] > heartbeat["last_success_at"]
+                and current_time - heartbeat["last_attempt_at"] < retry_seconds
+            ):
                 action = "skip_retry"
             else:
                 action = "forward"
-            return ObservationDeliveryDecision(action, key, fingerprint, gate, True)
+                _reserve_venue_attempt(state, venue_id, current_time)
+                _write_state(path, state)
+            return ObservationDeliveryDecision(
+                action,
+                key,
+                fingerprint,
+                gate,
+                True,
+                venue_id,
+            )
     except OSError:
-        return ObservationDeliveryDecision("forward", key, fingerprint, None, False)
+        return ObservationDeliveryDecision(
+            "forward",
+            key,
+            fingerprint,
+            None,
+            False,
+            venue_id,
+        )
 
 
 def record_observation_result(
@@ -250,16 +326,19 @@ def record_observation_result(
     if not decision.enabled:
         return
     current_time = time.time() if now is None else now
+    venue_id = decision.venue_id or decision.key.partition(":")[0]
     path = observation_cache_path()
     try:
         with _locked_state(path) as state:
             entries = state["entries"]
             current = entries.get(decision.key)
-            previous_gate = _entry_gate(current)
+            previous_gate = _entry_gate(current) or _latest_gate(state, venue_id)
             previous_fingerprint = current["fingerprint"] if current is not None else ""
             previous_success = current["last_success_at"] if current is not None else 0.0
             normalized_gate = (
-                {str(key): value for key, value in gate.items()} if gate is not None else previous_gate
+                {str(key): value for key, value in gate.items()}
+                if gate is not None
+                else previous_gate
             )
             entries[decision.key] = {
                 "fingerprint": decision.fingerprint,
@@ -273,6 +352,13 @@ def record_observation_result(
                 ),
                 "gate": normalized_gate,
             }
+            venue = state["venues"].setdefault(
+                venue_id,
+                {"last_attempt_at": 0.0, "last_success_at": 0.0},
+            )
+            venue["last_attempt_at"] = current_time
+            if success:
+                venue["last_success_at"] = current_time
             _write_state(path, state)
     except OSError:
         return
@@ -284,15 +370,6 @@ def cached_gate_for_venue(venue_id: str) -> dict[str, Any] | None:
     path = observation_cache_path()
     try:
         with _locked_state(path) as state:
-            candidates: list[tuple[float, dict[str, Any]]] = []
-            prefix = f"{venue_id}:"
-            for key, entry in state["entries"].items():
-                if not key.startswith(prefix):
-                    continue
-                gate = _entry_gate(entry)
-                if gate is None:
-                    continue
-                candidates.append((entry["last_success_at"], gate))
-            return max(candidates, key=lambda item: item[0])[1] if candidates else None
+            return _latest_gate(state, venue_id)
     except OSError:
         return None

--- a/src/wechat_airflow/notifications/observation_cache.py
+++ b/src/wechat_airflow/notifications/observation_cache.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+import tempfile
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+OBSERVATION_CACHE_ENABLED_ENV = "WEBAPP_OBSERVATION_LOCAL_DEDUPE_ENABLED"
+OBSERVATION_CACHE_PATH_ENV = "WEBAPP_OBSERVATION_STATE_PATH"
+OBSERVATION_HEARTBEAT_SECONDS_ENV = "WEBAPP_OBSERVATION_HEARTBEAT_SECONDS"
+OBSERVATION_FAILURE_RETRY_SECONDS_ENV = "WEBAPP_OBSERVATION_FAILURE_RETRY_SECONDS"
+DEFAULT_OBSERVATION_CACHE_PATH = Path("/opt/airflow/logs/webapp-observation-state.json")
+DEFAULT_OBSERVATION_HEARTBEAT_SECONDS = 300.0
+DEFAULT_OBSERVATION_FAILURE_RETRY_SECONDS = 120.0
+_STATE_VERSION = 1
+
+ObservationAction = Literal["forward", "skip_success", "skip_retry"]
+
+
+@dataclass(frozen=True)
+class ObservationDeliveryDecision:
+    action: ObservationAction
+    key: str
+    fingerprint: str
+    gate: dict[str, Any] | None
+    enabled: bool
+
+
+def _configured_seconds(name: str, fallback: float) -> float:
+    try:
+        value = float(os.environ.get(name, fallback))
+    except (TypeError, ValueError):
+        return fallback
+    return min(max(value, 1.0), 3_600.0)
+
+
+def _explicitly_enabled() -> bool | None:
+    value = os.environ.get(OBSERVATION_CACHE_ENABLED_ENV)
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
+def observation_cache_path() -> Path:
+    configured = os.environ.get(OBSERVATION_CACHE_PATH_ENV, "").strip()
+    return Path(configured) if configured else DEFAULT_OBSERVATION_CACHE_PATH
+
+
+def observation_cache_enabled() -> bool:
+    explicit = _explicitly_enabled()
+    if explicit is False:
+        return False
+    path = observation_cache_path()
+    if explicit is True:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return False
+    return path.parent.is_dir() and os.access(path.parent, os.W_OK)
+
+
+def _string_field(candidate: Mapping[str, object], snake_case: str, camel_case: str) -> str:
+    return str(candidate.get(snake_case) or candidate.get(camel_case) or "").strip()
+
+
+def _canonical_slots(value: object) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    slots: dict[str, dict[str, str]] = {}
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        slot = {
+            "date": str(item.get("date") or "").strip(),
+            "court_name": _string_field(item, "court_name", "courtName"),
+            "start_time": _string_field(item, "start_time", "startTime"),
+            "end_time": _string_field(item, "end_time", "endTime"),
+        }
+        key = "|".join(slot.values())
+        slots[key] = slot
+    return [slots[key] for key in sorted(slots)]
+
+
+def observation_identity(payload: Mapping[str, object]) -> tuple[str, str]:
+    venue_id = _string_field(payload, "venue_id", "venueId")
+    scope = _string_field(payload, "observation_scope", "observationScope") or "default"
+    canonical = {
+        "venue_id": venue_id,
+        "venue_name": _string_field(payload, "venue_name", "venueName"),
+        "observation_scope": scope,
+        "healthy": payload.get("healthy") is True,
+        "error": str(payload.get("error") or "")[:300] or None,
+        "slots": _canonical_slots(payload.get("slots")),
+    }
+    serialized = json.dumps(canonical, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return f"{venue_id}:{scope}", hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _empty_state() -> dict[str, Any]:
+    return {"version": _STATE_VERSION, "entries": {}}
+
+
+def _read_state(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return _empty_state()
+    if not isinstance(value, dict) or not isinstance(value.get("entries"), dict):
+        return _empty_state()
+    return {"version": _STATE_VERSION, "entries": dict(value["entries"])}
+
+
+def _write_state(path: Path, state: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    file_descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        text=True,
+    )
+    try:
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as handle:
+            json.dump(state, handle, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temporary)
+
+
+@contextlib.contextmanager
+def _locked_state(path: Path):
+    lock_path = path.with_name(f"{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            yield _read_state(path)
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+def _entry_gate(entry: object) -> dict[str, Any] | None:
+    if not isinstance(entry, Mapping) or not isinstance(entry.get("gate"), Mapping):
+        return None
+    return {str(key): value for key, value in entry["gate"].items()}
+
+
+def decide_observation_delivery(
+    payload: Mapping[str, object],
+    *,
+    now: float | None = None,
+) -> ObservationDeliveryDecision:
+    current_time = time.time() if now is None else now
+    key, fingerprint = observation_identity(payload)
+    if not observation_cache_enabled():
+        return ObservationDeliveryDecision("forward", key, fingerprint, None, False)
+
+    path = observation_cache_path()
+    try:
+        with _locked_state(path) as state:
+            entry = state["entries"].get(key)
+            if not isinstance(entry, Mapping) or entry.get("fingerprint") != fingerprint:
+                return ObservationDeliveryDecision(
+                    "forward",
+                    key,
+                    fingerprint,
+                    _entry_gate(entry),
+                    True,
+                )
+            gate = _entry_gate(entry)
+            last_success = float(entry.get("last_success_at") or 0)
+            last_attempt = float(entry.get("last_attempt_at") or 0)
+            heartbeat = _configured_seconds(
+                OBSERVATION_HEARTBEAT_SECONDS_ENV,
+                DEFAULT_OBSERVATION_HEARTBEAT_SECONDS,
+            )
+            retry = _configured_seconds(
+                OBSERVATION_FAILURE_RETRY_SECONDS_ENV,
+                DEFAULT_OBSERVATION_FAILURE_RETRY_SECONDS,
+            )
+            if last_success > 0 and current_time - last_success < heartbeat:
+                action: ObservationAction = "skip_success"
+            elif last_attempt > last_success and current_time - last_attempt < retry:
+                action = "skip_retry"
+            else:
+                action = "forward"
+            return ObservationDeliveryDecision(action, key, fingerprint, gate, True)
+    except OSError:
+        return ObservationDeliveryDecision("forward", key, fingerprint, None, False)
+
+
+def record_observation_result(
+    decision: ObservationDeliveryDecision,
+    *,
+    success: bool,
+    gate: Mapping[str, object] | None,
+    now: float | None = None,
+) -> None:
+    if not decision.enabled:
+        return
+    current_time = time.time() if now is None else now
+    path = observation_cache_path()
+    try:
+        with _locked_state(path) as state:
+            entries = state["entries"]
+            current = entries.get(decision.key)
+            previous_gate = _entry_gate(current)
+            previous_fingerprint = (
+                str(current.get("fingerprint") or "") if isinstance(current, Mapping) else ""
+            )
+            previous_success = (
+                float(current.get("last_success_at") or 0)
+                if isinstance(current, Mapping)
+                else 0.0
+            )
+            normalized_gate = (
+                {str(key): value for key, value in gate.items()} if gate is not None else previous_gate
+            )
+            entries[decision.key] = {
+                "fingerprint": decision.fingerprint,
+                "last_attempt_at": current_time,
+                "last_success_at": (
+                    current_time
+                    if success
+                    else previous_success
+                    if previous_fingerprint == decision.fingerprint
+                    else 0.0
+                ),
+                "gate": normalized_gate,
+            }
+            _write_state(path, state)
+    except OSError:
+        return
+
+
+def cached_gate_for_venue(venue_id: str) -> dict[str, Any] | None:
+    if not observation_cache_enabled():
+        return None
+    path = observation_cache_path()
+    try:
+        with _locked_state(path) as state:
+            candidates: list[tuple[float, dict[str, Any]]] = []
+            prefix = f"{venue_id}:"
+            for key, entry in state["entries"].items():
+                if not str(key).startswith(prefix) or not isinstance(entry, Mapping):
+                    continue
+                gate = _entry_gate(entry)
+                if gate is None:
+                    continue
+                candidates.append((float(entry.get("last_success_at") or 0), gate))
+            return max(candidates, key=lambda item: item[0])[1] if candidates else None
+    except OSError:
+        return None

--- a/src/wechat_airflow/notifications/observation_cache.py
+++ b/src/wechat_airflow/notifications/observation_cache.py
@@ -285,10 +285,7 @@ def decide_observation_delivery(
                 DEFAULT_OBSERVATION_FAILURE_RETRY_SECONDS,
             )
             retry_pending = heartbeat["last_attempt_at"] > heartbeat["last_success_at"]
-            if (
-                retry_pending
-                and current_time - heartbeat["last_attempt_at"] < retry_seconds
-            ):
+            if retry_pending and current_time - heartbeat["last_attempt_at"] < retry_seconds:
                 action: ObservationAction = "skip_retry"
             elif has_available_slots:
                 action = "forward"

--- a/src/wechat_airflow/notifications/observation_cache.py
+++ b/src/wechat_airflow/notifications/observation_cache.py
@@ -283,8 +283,10 @@ def decide_observation_delivery(
                 OBSERVATION_FAILURE_RETRY_SECONDS_ENV,
                 DEFAULT_OBSERVATION_FAILURE_RETRY_SECONDS,
             )
+            fingerprint_was_forwarded = entry["last_success_at"] > 0
             if (
-                heartbeat["last_success_at"] > 0
+                fingerprint_was_forwarded
+                and heartbeat["last_success_at"] > 0
                 and current_time - heartbeat["last_success_at"] < heartbeat_seconds
             ):
                 action: ObservationAction = "skip_success"

--- a/src/wechat_airflow/notifications/observation_cache.py
+++ b/src/wechat_airflow/notifications/observation_cache.py
@@ -7,10 +7,10 @@ import json
 import os
 import tempfile
 import time
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 OBSERVATION_CACHE_ENABLED_ENV = "WEBAPP_OBSERVATION_LOCAL_DEDUPE_ENABLED"
 OBSERVATION_CACHE_PATH_ENV = "WEBAPP_OBSERVATION_STATE_PATH"
@@ -24,6 +24,18 @@ _STATE_VERSION = 1
 ObservationAction = Literal["forward", "skip_success", "skip_retry"]
 
 
+class CacheEntry(TypedDict):
+    fingerprint: str
+    last_attempt_at: float
+    last_success_at: float
+    gate: dict[str, Any] | None
+
+
+class CacheState(TypedDict):
+    version: int
+    entries: dict[str, CacheEntry]
+
+
 @dataclass(frozen=True)
 class ObservationDeliveryDecision:
     action: ObservationAction
@@ -34,9 +46,12 @@ class ObservationDeliveryDecision:
 
 
 def _configured_seconds(name: str, fallback: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return fallback
     try:
-        value = float(os.environ.get(name, fallback))
-    except (TypeError, ValueError):
+        value = float(raw)
+    except ValueError:
         return fallback
     return min(max(value, 1.0), 3_600.0)
 
@@ -82,11 +97,12 @@ def _canonical_slots(value: object) -> list[dict[str, str]]:
     for item in value:
         if not isinstance(item, Mapping):
             continue
+        candidate = {str(key): item_value for key, item_value in item.items()}
         slot = {
-            "date": str(item.get("date") or "").strip(),
-            "court_name": _string_field(item, "court_name", "courtName"),
-            "start_time": _string_field(item, "start_time", "startTime"),
-            "end_time": _string_field(item, "end_time", "endTime"),
+            "date": str(candidate.get("date") or "").strip(),
+            "court_name": _string_field(candidate, "court_name", "courtName"),
+            "start_time": _string_field(candidate, "start_time", "startTime"),
+            "end_time": _string_field(candidate, "end_time", "endTime"),
         }
         key = "|".join(slot.values())
         slots[key] = slot
@@ -108,21 +124,47 @@ def observation_identity(payload: Mapping[str, object]) -> tuple[str, str]:
     return f"{venue_id}:{scope}", hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
-def _empty_state() -> dict[str, Any]:
+def _entry_gate(entry: object) -> dict[str, Any] | None:
+    if not isinstance(entry, Mapping):
+        return None
+    gate = entry.get("gate")
+    if not isinstance(gate, Mapping):
+        return None
+    return {str(key): value for key, value in gate.items()}
+
+
+def _empty_state() -> CacheState:
     return {"version": _STATE_VERSION, "entries": {}}
 
 
-def _read_state(path: Path) -> dict[str, Any]:
+def _read_state(path: Path) -> CacheState:
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return _empty_state()
-    if not isinstance(value, dict) or not isinstance(value.get("entries"), dict):
+    if not isinstance(value, dict):
         return _empty_state()
-    return {"version": _STATE_VERSION, "entries": dict(value["entries"])}
+    raw_entries = value.get("entries")
+    if not isinstance(raw_entries, dict):
+        return _empty_state()
+
+    entries: dict[str, CacheEntry] = {}
+    for key, raw_entry in raw_entries.items():
+        if not isinstance(raw_entry, Mapping):
+            continue
+        try:
+            entries[str(key)] = {
+                "fingerprint": str(raw_entry.get("fingerprint") or ""),
+                "last_attempt_at": float(raw_entry.get("last_attempt_at") or 0),
+                "last_success_at": float(raw_entry.get("last_success_at") or 0),
+                "gate": _entry_gate(raw_entry),
+            }
+        except (TypeError, ValueError):
+            continue
+    return {"version": _STATE_VERSION, "entries": entries}
 
 
-def _write_state(path: Path, state: Mapping[str, object]) -> None:
+def _write_state(path: Path, state: CacheState) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     file_descriptor, temporary = tempfile.mkstemp(
         prefix=f".{path.name}.",
@@ -143,7 +185,7 @@ def _write_state(path: Path, state: Mapping[str, object]) -> None:
 
 
 @contextlib.contextmanager
-def _locked_state(path: Path):
+def _locked_state(path: Path) -> Iterator[CacheState]:
     lock_path = path.with_name(f"{path.name}.lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("a+", encoding="utf-8") as lock:
@@ -152,12 +194,6 @@ def _locked_state(path: Path):
             yield _read_state(path)
         finally:
             fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
-
-
-def _entry_gate(entry: object) -> dict[str, Any] | None:
-    if not isinstance(entry, Mapping) or not isinstance(entry.get("gate"), Mapping):
-        return None
-    return {str(key): value for key, value in entry["gate"].items()}
 
 
 def decide_observation_delivery(
@@ -174,7 +210,7 @@ def decide_observation_delivery(
     try:
         with _locked_state(path) as state:
             entry = state["entries"].get(key)
-            if not isinstance(entry, Mapping) or entry.get("fingerprint") != fingerprint:
+            if entry is None or entry["fingerprint"] != fingerprint:
                 return ObservationDeliveryDecision(
                     "forward",
                     key,
@@ -183,8 +219,8 @@ def decide_observation_delivery(
                     True,
                 )
             gate = _entry_gate(entry)
-            last_success = float(entry.get("last_success_at") or 0)
-            last_attempt = float(entry.get("last_attempt_at") or 0)
+            last_success = entry["last_success_at"]
+            last_attempt = entry["last_attempt_at"]
             heartbeat = _configured_seconds(
                 OBSERVATION_HEARTBEAT_SECONDS_ENV,
                 DEFAULT_OBSERVATION_HEARTBEAT_SECONDS,
@@ -220,14 +256,8 @@ def record_observation_result(
             entries = state["entries"]
             current = entries.get(decision.key)
             previous_gate = _entry_gate(current)
-            previous_fingerprint = (
-                str(current.get("fingerprint") or "") if isinstance(current, Mapping) else ""
-            )
-            previous_success = (
-                float(current.get("last_success_at") or 0)
-                if isinstance(current, Mapping)
-                else 0.0
-            )
+            previous_fingerprint = current["fingerprint"] if current is not None else ""
+            previous_success = current["last_success_at"] if current is not None else 0.0
             normalized_gate = (
                 {str(key): value for key, value in gate.items()} if gate is not None else previous_gate
             )
@@ -257,12 +287,12 @@ def cached_gate_for_venue(venue_id: str) -> dict[str, Any] | None:
             candidates: list[tuple[float, dict[str, Any]]] = []
             prefix = f"{venue_id}:"
             for key, entry in state["entries"].items():
-                if not str(key).startswith(prefix) or not isinstance(entry, Mapping):
+                if not key.startswith(prefix):
                     continue
                 gate = _entry_gate(entry)
                 if gate is None:
                     continue
-                candidates.append((float(entry.get("last_success_at") or 0), gate))
+                candidates.append((entry["last_success_at"], gate))
             return max(candidates, key=lambda item: item[0])[1] if candidates else None
     except OSError:
         return None

--- a/src/wechat_airflow/notifications/webapp.py
+++ b/src/wechat_airflow/notifications/webapp.py
@@ -6,6 +6,12 @@ from typing import Any
 
 import requests
 
+from wechat_airflow.notifications.observation_cache import (
+    cached_gate_for_venue,
+    decide_observation_delivery,
+    record_observation_result,
+)
+
 WEBAPP_OBSERVATION_API_URL_VAR = "WEBAPP_OBSERVATION_API_URL"
 WEBAPP_OBSERVATION_API_TOKEN_VAR = "WEBAPP_OBSERVATION_API_TOKEN"
 WEBAPP_OBSERVATION_TIMEOUT_SECONDS_VAR = "WEBAPP_OBSERVATION_TIMEOUT_SECONDS"
@@ -109,6 +115,8 @@ def _cache_gate(venue_id: str, gate: dict[str, Any]) -> None:
         cached = _get_variable(WEBAPP_WECHAT_GATE_CACHE_VAR, default={}, deserialize_json=True)
         if not isinstance(cached, dict):
             cached = {}
+        if _normalize_gate(cached.get(str(venue_id))) == gate:
+            return
         cached[str(venue_id)] = gate
         _set_variable(WEBAPP_WECHAT_GATE_CACHE_VAR, cached, serialize_json=True)
     except Exception as exc:
@@ -116,6 +124,9 @@ def _cache_gate(venue_id: str, gate: dict[str, Any]) -> None:
 
 
 def _cached_gate(venue_id: str) -> dict[str, Any] | None:
+    local_gate = _normalize_gate(cached_gate_for_venue(venue_id))
+    if local_gate is not None:
+        return local_gate
     try:
         cached = _get_variable(WEBAPP_WECHAT_GATE_CACHE_VAR, default={}, deserialize_json=True)
     except Exception:
@@ -219,7 +230,7 @@ def publish_venue_observation(
         str(observation_scope or _current_observation_scope() or "default").strip()[:120]
         or "default"
     )
-    payload = {
+    payload: dict[str, object] = {
         "venue_id": venue_id,
         "venue_name": venue_name,
         "observation_scope": normalized_scope,
@@ -229,6 +240,34 @@ def publish_venue_observation(
         "slots": normalized_slots[:200],
     }
     slot_count = len(normalized_slots[:200])
+    delivery = decide_observation_delivery(payload)
+    cached_gate = _normalize_gate(delivery.gate)
+    if delivery.action == "skip_success":
+        print(
+            f"[WEBAPP] observation locally deduplicated venue={venue_id}, "
+            f"scope={normalized_scope}, healthy={healthy}, slots={slot_count}"
+        )
+        return {
+            "success": True,
+            "slot_count": slot_count,
+            "observation_scope": normalized_scope,
+            "local_deduplicated": True,
+            "wechat_gate": cached_gate,
+        }
+    if delivery.action == "skip_retry":
+        print(
+            f"[WEBAPP] observation retry throttled venue={venue_id}, "
+            f"scope={normalized_scope}, healthy={healthy}, slots={slot_count}"
+        )
+        return {
+            "success": False,
+            "deferred": True,
+            "error": "recent Web publication failure; local retry is throttled",
+            "slot_count": slot_count,
+            "observation_scope": normalized_scope,
+            "wechat_gate": cached_gate,
+        }
+
     try:
         response = requests.post(
             api_url,
@@ -247,6 +286,7 @@ def publish_venue_observation(
         gate = _normalize_gate(
             response_payload.get("wechatGate") if isinstance(response_payload, dict) else None
         )
+        record_observation_result(delivery, success=True, gate=gate)
         if gate is not None:
             _cache_gate(venue_id, gate)
         print(
@@ -258,14 +298,16 @@ def publish_venue_observation(
             "success": True,
             "slot_count": slot_count,
             "observation_scope": normalized_scope,
+            "local_deduplicated": False,
             "wechat_gate": gate,
         }
     except Exception as exc:
+        record_observation_result(delivery, success=False, gate=cached_gate)
         print(f"[WEBAPP] observation publishing failed venue={venue_id}, error={str(exc)[:300]}")
         return {
             "success": False,
             "error": str(exc)[:300],
             "slot_count": slot_count,
             "observation_scope": normalized_scope,
-            "wechat_gate": _cached_gate(venue_id),
+            "wechat_gate": cached_gate or _cached_gate(venue_id),
         }

--- a/tests/webapp_deployment_identity_test.py
+++ b/tests/webapp_deployment_identity_test.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import TestCase
+
+SCRIPTS = Path(__file__).parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import webapp_deployment_identity  # noqa: E402
+
+
+class WebappDeploymentIdentityTest(TestCase):
+    def test_accepts_exact_healthy_worker_without_d1_payload(self) -> None:
+        commit = "a" * 40
+        result = webapp_deployment_identity.evaluate_deployment_identity(
+            200,
+            {
+                "ok": True,
+                "deploymentCommit": commit,
+                "capabilities": {"priorityWeatherBypass": True},
+            },
+            commit,
+        )
+        self.assertTrue(result["ok"])
+        self.assertFalse(result["d1_checked"])
+
+    def test_rejects_wrong_commit_or_unhealthy_worker(self) -> None:
+        commit = "a" * 40
+        wrong_commit = webapp_deployment_identity.evaluate_deployment_identity(
+            200,
+            {
+                "ok": True,
+                "deploymentCommit": "b" * 40,
+                "capabilities": {"priorityWeatherBypass": True},
+            },
+            commit,
+        )
+        unhealthy = webapp_deployment_identity.evaluate_deployment_identity(
+            503,
+            {"ok": False, "deploymentCommit": commit},
+            commit,
+        )
+        self.assertFalse(wrong_commit["ok"])
+        self.assertFalse(unhealthy["ok"])

--- a/tests/webapp_free_tier_release_contract_test.py
+++ b/tests/webapp_free_tier_release_contract_test.py
@@ -15,7 +15,9 @@ def test_webapp_release_tolerates_only_the_known_d1_quota_error() -> None:
     assert "return 75" in workflow
     assert "webapp_deployment_identity.py" in workflow
     assert "webapp_production_health.py" in workflow
-    assert workflow.index("npx wrangler d1 migrations apply") < workflow.index(
+
+    apply_block = workflow.split("deploy_apply)", 1)[1].split("*)", 1)[0]
+    assert apply_block.index("npx wrangler d1 migrations apply") < apply_block.rindex(
         "npx wrangler deploy"
     )
 
@@ -24,7 +26,10 @@ def test_deployed_worker_has_an_idempotent_quota_reset_self_heal() -> None:
     entry = (ROOT / "webapp/cloudflare/subscription-gated-entry.ts").read_text(encoding="utf-8")
     schema = (ROOT / "webapp/cloudflare/free-tier-schema.ts").read_text(encoding="utf-8")
 
-    assert "ensureFreeTierSchema" in entry
+    fetch_block = entry.split("async fetch", 1)[1].split("async scheduled", 1)[0]
+    scheduled_block = entry.split("async scheduled", 1)[1]
+    assert "ensureSchemaSafely" not in fetch_block
+    assert "ensureSchemaSafely" in scheduled_block
     assert "free_tier_schema_applied" in entry
     assert "CREATE INDEX IF NOT EXISTS" in schema
     assert "PRAGMA optimize" in schema

--- a/tests/webapp_free_tier_release_contract_test.py
+++ b/tests/webapp_free_tier_release_contract_test.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_webapp_release_tolerates_only_the_known_d1_quota_error() -> None:
+    workflow = (ROOT / ".github/workflows/production-webapp.yml").read_text(encoding="utf-8")
+
+    assert "d1_quota_exhausted" in workflow
+    assert "exceeded D1's free tier daily row read limit" in workflow
+    assert "\\[code: 7500\\]" in workflow
+    assert "Unexpected D1 failure" in workflow
+    assert "return 75" in workflow
+    assert "webapp_deployment_identity.py" in workflow
+    assert "webapp_production_health.py" in workflow
+    assert workflow.index("npx wrangler d1 migrations apply") < workflow.index(
+        "npx wrangler deploy"
+    )
+
+
+def test_deployed_worker_has_an_idempotent_quota_reset_self_heal() -> None:
+    entry = (ROOT / "webapp/cloudflare/subscription-gated-entry.ts").read_text(
+        encoding="utf-8"
+    )
+    schema = (ROOT / "webapp/cloudflare/free-tier-schema.ts").read_text(encoding="utf-8")
+
+    assert "ensureFreeTierSchema" in entry
+    assert "free_tier_schema_applied" in entry
+    assert "CREATE INDEX IF NOT EXISTS" in schema
+    assert "PRAGMA optimize" in schema
+    assert "system:free-tier-schema" in schema
+
+
+def test_delivery_diagnostics_do_not_use_an_unbounded_outbox_aggregate() -> None:
+    script = (ROOT / "scripts/diagnose_email_delivery_metrics.sh").read_text(encoding="utf-8")
+
+    first_query = script.split("__EMAIL_DELIVERY_METRICS__", 1)[1].split(
+        "__ADMIN_IDENTITY_DELIVERY_METRICS__", 1
+    )[0]
+    admin_query = script.split("__ADMIN_IDENTITY_DELIVERY_METRICS__", 1)[1].split(
+        "__PROVIDER_STATUS_BREAKDOWN__", 1
+    )[0]
+    assert "WHERE provider_submitted_at >= day.start_utc" in first_query
+    assert "WHERE n.provider_submitted_at >= day.start_utc" in admin_query
+    assert "has_retention_expired" in script
+    assert "retention_expired" not in script

--- a/tests/webapp_free_tier_release_contract_test.py
+++ b/tests/webapp_free_tier_release_contract_test.py
@@ -44,5 +44,5 @@ def test_delivery_diagnostics_do_not_use_an_unbounded_outbox_aggregate() -> None
     )[0]
     assert "WHERE provider_submitted_at >= day.start_utc" in first_query
     assert "WHERE n.provider_submitted_at >= day.start_utc" in admin_query
-    assert "has_retention_expired" in script
-    assert "retention_expired" not in script
+    assert "AS has_retention_expired" in script
+    assert "AS retention_expired" not in script

--- a/tests/webapp_free_tier_release_contract_test.py
+++ b/tests/webapp_free_tier_release_contract_test.py
@@ -21,9 +21,7 @@ def test_webapp_release_tolerates_only_the_known_d1_quota_error() -> None:
 
 
 def test_deployed_worker_has_an_idempotent_quota_reset_self_heal() -> None:
-    entry = (ROOT / "webapp/cloudflare/subscription-gated-entry.ts").read_text(
-        encoding="utf-8"
-    )
+    entry = (ROOT / "webapp/cloudflare/subscription-gated-entry.ts").read_text(encoding="utf-8")
     schema = (ROOT / "webapp/cloudflare/free-tier-schema.ts").read_text(encoding="utf-8")
 
     assert "ensureFreeTierSchema" in entry

--- a/tests/webapp_notification_free_tier_test.py
+++ b/tests/webapp_notification_free_tier_test.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from wechat_airflow.notifications import webapp
+from wechat_airflow.notifications.observation_cache import ObservationDeliveryDecision
+
+
+class WebappNotificationFreeTierTest(TestCase):
+    def variables(self, key, default=None, deserialize_json=False):
+        values = {
+            webapp.WEBAPP_OBSERVATION_API_URL_VAR: "https://example.test/api/internal/observations",
+            webapp.WEBAPP_OBSERVATION_API_TOKEN_VAR: "secret-token",
+            webapp.WEBAPP_OBSERVATION_TIMEOUT_SECONDS_VAR: "3",
+        }
+        return values.get(key, default)
+
+    def test_recent_unchanged_success_skips_the_network(self) -> None:
+        gate = {
+            "allowed": True,
+            "evaluated_at": "2026-09-02T09:00:00+00:00",
+            "valid_until": "2026-09-02T09:10:00+00:00",
+            "revision": 123,
+        }
+        decision = ObservationDeliveryDecision(
+            "skip_success",
+            "szw:day-0",
+            "a" * 64,
+            gate,
+            True,
+        )
+        with (
+            patch.object(webapp, "_get_variable", side_effect=self.variables),
+            patch.object(webapp, "decide_observation_delivery", return_value=decision),
+            patch.object(webapp.requests, "post") as post,
+        ):
+            result = webapp.publish_venue_observation(
+                "szw",
+                "深圳湾",
+                [],
+                healthy=True,
+                observation_scope="day-0",
+            )
+
+        post.assert_not_called()
+        self.assertTrue(result["success"])
+        self.assertTrue(result["local_deduplicated"])
+        self.assertEqual(result["wechat_gate"], gate)
+
+    def test_recent_failure_uses_bounded_retry_without_network(self) -> None:
+        decision = ObservationDeliveryDecision(
+            "skip_retry",
+            "szw:day-0",
+            "a" * 64,
+            None,
+            True,
+        )
+        with (
+            patch.object(webapp, "_get_variable", side_effect=self.variables),
+            patch.object(webapp, "decide_observation_delivery", return_value=decision),
+            patch.object(webapp.requests, "post") as post,
+        ):
+            result = webapp.publish_venue_observation(
+                "szw",
+                "深圳湾",
+                [],
+                healthy=True,
+                observation_scope="day-0",
+            )
+
+        post.assert_not_called()
+        self.assertFalse(result["success"])
+        self.assertTrue(result["deferred"])
+
+    def test_forwarded_result_is_recorded_after_success(self) -> None:
+        decision = ObservationDeliveryDecision(
+            "forward",
+            "szw:day-0",
+            "a" * 64,
+            None,
+            True,
+        )
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "wechatGate": {
+                "allowed": False,
+                "evaluatedAt": "2026-09-02T09:00:00Z",
+                "validUntil": "2026-09-02T09:10:00Z",
+                "revision": 123,
+            }
+        }
+        with (
+            patch.object(webapp, "_get_variable", side_effect=self.variables),
+            patch.object(webapp, "decide_observation_delivery", return_value=decision),
+            patch.object(webapp, "record_observation_result") as record,
+            patch.object(webapp, "_cache_gate"),
+            patch.object(webapp.requests, "post", return_value=response),
+        ):
+            result = webapp.publish_venue_observation(
+                "szw",
+                "深圳湾",
+                [],
+                healthy=True,
+                observation_scope="day-0",
+            )
+
+        self.assertTrue(result["success"])
+        record.assert_called_once()
+        self.assertTrue(record.call_args.kwargs["success"])
+        self.assertEqual(record.call_args.kwargs["gate"]["revision"], 123)
+
+    def test_unchanged_gate_does_not_rewrite_airflow_metadata(self) -> None:
+        gate = {
+            "allowed": True,
+            "evaluated_at": "2026-09-02T09:00:00+00:00",
+            "valid_until": "2026-09-02T09:10:00+00:00",
+            "revision": 123,
+        }
+        with (
+            patch.object(
+                webapp,
+                "_get_variable",
+                return_value={"szw": gate},
+            ),
+            patch.object(webapp, "_set_variable") as set_variable,
+        ):
+            webapp._cache_gate("szw", gate)
+
+        set_variable.assert_not_called()

--- a/tests/webapp_notification_outbox_read_migration_test.py
+++ b/tests/webapp_notification_outbox_read_migration_test.py
@@ -135,10 +135,7 @@ class WebappNotificationOutboxReadMigrationTest(TestCase):
             },
         )
         self.assertTrue(
-            all(
-                " WHERE " in str(definition).upper()
-                for definition in indexes.values()
-            )
+            all(" WHERE " in str(definition).upper() for definition in indexes.values())
         )
 
     def test_daily_and_message_queries_use_bounded_indexes(self) -> None:

--- a/tests/webapp_notification_outbox_read_migration_test.py
+++ b/tests/webapp_notification_outbox_read_migration_test.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest import TestCase
+
+
+class WebappNotificationOutboxReadMigrationTest(TestCase):
+    """Keep the production D1 hot paths on bounded index scans."""
+
+    def setUp(self) -> None:
+        self.database = sqlite3.connect(":memory:")
+        self.database.executescript(
+            """
+            CREATE TABLE notification_outbox (
+                id TEXT PRIMARY KEY,
+                subscription_id TEXT NOT NULL,
+                event_key TEXT NOT NULL,
+                venue_id TEXT NOT NULL,
+                email TEXT NOT NULL,
+                subject TEXT NOT NULL,
+                body TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                attempt_count INTEGER NOT NULL DEFAULT 0,
+                next_attempt_at INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                sent_at TEXT,
+                message_id TEXT,
+                last_error TEXT,
+                provider_request_id TEXT,
+                provider_status TEXT,
+                provider_submitted_at TEXT,
+                provider_delivered_at TEXT,
+                provider_failed_at TEXT,
+                provider_checked_at INTEGER,
+                provider_error TEXT,
+                UNIQUE (subscription_id, event_key)
+            );
+
+            CREATE INDEX notification_outbox_pending_idx
+                ON notification_outbox(status, next_attempt_at);
+            CREATE INDEX notification_outbox_sent_idx
+                ON notification_outbox(sent_at);
+            CREATE INDEX notification_outbox_provider_status_idx
+                ON notification_outbox(
+                    status,
+                    provider_checked_at,
+                    provider_submitted_at
+                );
+            """
+        )
+        rows = []
+        for index in range(2_000):
+            day = 1 + index // 100
+            submitted_at = f"2026-08-{day:02d}T00:{index % 60:02d}:00.000Z"
+            status = "delivered" if index % 3 else "submitted"
+            delivered_at = submitted_at if status == "delivered" else None
+            rows.append(
+                (
+                    f"id-{index}",
+                    f"subscription-{index}",
+                    f"event-{index}",
+                    f"venue-{index % 10}",
+                    f"user-{index % 20}@example.com",
+                    "subject",
+                    "body",
+                    status,
+                    submitted_at,
+                    f"message-{index // 2}",
+                    submitted_at,
+                    delivered_at,
+                    index,
+                )
+            )
+        self.database.executemany(
+            """
+            INSERT INTO notification_outbox (
+                id,
+                subscription_id,
+                event_key,
+                venue_id,
+                email,
+                subject,
+                body,
+                status,
+                next_attempt_at,
+                created_at,
+                message_id,
+                provider_submitted_at,
+                provider_delivered_at,
+                provider_checked_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        migration = (
+            Path(__file__).parents[1]
+            / "webapp"
+            / "migrations"
+            / "0016_optimize_notification_outbox_reads.sql"
+        ).read_text(encoding="utf-8")
+        self.database.executescript(migration)
+
+    def tearDown(self) -> None:
+        self.database.close()
+
+    def query_plan(self, sql: str, parameters: tuple[object, ...]) -> str:
+        return " | ".join(
+            str(row[3])
+            for row in self.database.execute(
+                f"EXPLAIN QUERY PLAN {sql}",
+                parameters,
+            )
+        )
+
+    def test_migration_creates_targeted_partial_indexes(self) -> None:
+        indexes = {
+            row[0]: row[1]
+            for row in self.database.execute(
+                """
+                SELECT name, sql
+                  FROM sqlite_master
+                 WHERE type = 'index'
+                   AND name LIKE 'notification_outbox_%_lookup_idx'
+                """
+            )
+        }
+        self.assertEqual(
+            set(indexes),
+            {
+                "notification_outbox_message_id_lookup_idx",
+                "notification_outbox_submitted_at_lookup_idx",
+                "notification_outbox_delivered_at_lookup_idx",
+            },
+        )
+        self.assertTrue(
+            all(
+                " WHERE " in str(definition).upper()
+                for definition in indexes.values()
+            )
+        )
+
+    def test_daily_and_message_queries_use_bounded_indexes(self) -> None:
+        submitted_plan = self.query_plan(
+            """
+            SELECT COUNT(DISTINCT message_id)
+              FROM notification_outbox
+             WHERE provider_submitted_at >= ?
+            """,
+            ("2026-08-18T00:00:00.000Z",),
+        )
+        recipient_plan = self.query_plan(
+            """
+            SELECT COUNT(DISTINCT message_id)
+              FROM notification_outbox
+             WHERE email = ?
+               AND provider_submitted_at >= ?
+            """,
+            ("user-1@example.com", "2026-08-18T00:00:00.000Z"),
+        )
+        delivered_plan = self.query_plan(
+            """
+            SELECT COUNT(DISTINCT message_id)
+              FROM notification_outbox
+             WHERE status = 'delivered'
+               AND provider_delivered_at >= ?
+            """,
+            ("2026-08-18T00:00:00.000Z",),
+        )
+        message_plan = self.query_plan(
+            """
+            SELECT DISTINCT venue_id
+              FROM notification_outbox
+             WHERE message_id = ?
+            """,
+            ("message-100",),
+        )
+
+        self.assertIn(
+            "notification_outbox_submitted_at_lookup_idx",
+            submitted_plan,
+        )
+        self.assertIn(
+            "notification_outbox_submitted_at_lookup_idx",
+            recipient_plan,
+        )
+        self.assertIn(
+            "notification_outbox_delivered_at_lookup_idx",
+            delivered_plan,
+        )
+        self.assertIn(
+            "notification_outbox_message_id_lookup_idx",
+            message_plan,
+        )
+        for plan in (submitted_plan, recipient_plan, delivered_plan, message_plan):
+            self.assertNotIn("SCAN notification_outbox", plan)

--- a/tests/webapp_observation_cache_test.py
+++ b/tests/webapp_observation_cache_test.py
@@ -28,7 +28,7 @@ class WebappObservationCacheTest(TestCase):
             {
                 OBSERVATION_CACHE_ENABLED_ENV: "true",
                 OBSERVATION_CACHE_PATH_ENV: str(self.state_path),
-                OBSERVATION_HEARTBEAT_SECONDS_ENV: "300",
+                OBSERVATION_HEARTBEAT_SECONDS_ENV: "480",
                 OBSERVATION_FAILURE_RETRY_SECONDS_ENV: "120",
             },
         )
@@ -83,30 +83,49 @@ class WebappObservationCacheTest(TestCase):
         )
         self.assertEqual(changed.action, "forward")
 
-    def test_success_suppresses_unchanged_polls_until_heartbeat(self) -> None:
+    def test_success_suppresses_unchanged_polls_until_sparse_heartbeat(self) -> None:
         first = decide_observation_delivery(self.payload, now=1_000)
         self.assertEqual(first.action, "forward")
         record_observation_result(first, success=True, gate=self.gate, now=1_000)
 
         recent = decide_observation_delivery(self.payload, now=1_015)
-        heartbeat = decide_observation_delivery(self.payload, now=1_300)
+        heartbeat = decide_observation_delivery(self.payload, now=1_480)
         self.assertEqual(recent.action, "skip_success")
         self.assertEqual(recent.gate, self.gate)
         self.assertEqual(heartbeat.action, "forward")
+
+    def test_parallel_scopes_share_one_venue_heartbeat_budget(self) -> None:
+        day_zero = decide_observation_delivery(self.payload, now=1_000)
+        record_observation_result(day_zero, success=True, gate=self.gate, now=1_000)
+
+        day_one_payload = {
+            **self.payload,
+            "observation_scope": "check_and_notify_day_1",
+        }
+        day_one = decide_observation_delivery(day_one_payload, now=1_001)
+        self.assertEqual(day_one.action, "forward")
+        record_observation_result(day_one, success=True, gate=self.gate, now=1_001)
+
+        due = decide_observation_delivery(self.payload, now=1_481)
+        self.assertEqual(due.action, "forward")
+        record_observation_result(due, success=True, gate=self.gate, now=1_481)
+
+        coalesced = decide_observation_delivery(day_one_payload, now=1_482)
+        self.assertEqual(coalesced.action, "skip_success")
 
     def test_failure_retries_are_bounded_but_changes_bypass_the_backoff(self) -> None:
         first = decide_observation_delivery(self.payload, now=2_000)
         record_observation_result(first, success=False, gate=None, now=2_000)
 
         recent = decide_observation_delivery(self.payload, now=2_030)
-        retry = decide_observation_delivery(self.payload, now=2_120)
         changed = decide_observation_delivery(
             {**self.payload, "healthy": False, "error": "upstream unavailable", "slots": []},
             now=2_030,
         )
+        retry = decide_observation_delivery(self.payload, now=2_120)
         self.assertEqual(recent.action, "skip_retry")
-        self.assertEqual(retry.action, "forward")
         self.assertEqual(changed.action, "forward")
+        self.assertEqual(retry.action, "skip_retry")
 
     def test_gate_survives_process_independent_file_roundtrip(self) -> None:
         decision = decide_observation_delivery(self.payload, now=3_000)
@@ -114,6 +133,7 @@ class WebappObservationCacheTest(TestCase):
 
         self.assertEqual(cached_gate_for_venue("szw"), self.gate)
         stored = json.loads(self.state_path.read_text(encoding="utf-8"))
-        self.assertEqual(stored["version"], 1)
+        self.assertEqual(stored["version"], 2)
         self.assertEqual(len(stored["entries"]), 1)
+        self.assertEqual(len(stored["venues"]), 1)
         self.assertEqual(self.state_path.stat().st_mode & 0o777, 0o600)

--- a/tests/webapp_observation_cache_test.py
+++ b/tests/webapp_observation_cache_test.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from wechat_airflow.notifications.observation_cache import (
+    OBSERVATION_CACHE_ENABLED_ENV,
+    OBSERVATION_CACHE_PATH_ENV,
+    OBSERVATION_FAILURE_RETRY_SECONDS_ENV,
+    OBSERVATION_HEARTBEAT_SECONDS_ENV,
+    cached_gate_for_venue,
+    decide_observation_delivery,
+    observation_identity,
+    record_observation_result,
+)
+
+
+class WebappObservationCacheTest(TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.state_path = Path(self.temporary.name) / "observations.json"
+        self.environment = patch.dict(
+            "os.environ",
+            {
+                OBSERVATION_CACHE_ENABLED_ENV: "true",
+                OBSERVATION_CACHE_PATH_ENV: str(self.state_path),
+                OBSERVATION_HEARTBEAT_SECONDS_ENV: "300",
+                OBSERVATION_FAILURE_RETRY_SECONDS_ENV: "120",
+            },
+        )
+        self.environment.start()
+        self.addCleanup(self.environment.stop)
+        self.payload = {
+            "venue_id": "szw",
+            "venue_name": "深圳湾",
+            "observation_scope": "check_and_notify_day_0",
+            "healthy": True,
+            "checked_at": "2026-09-02T09:00:00.000Z",
+            "error": None,
+            "slots": [
+                {
+                    "date": "2026-09-03",
+                    "court_name": "2号场",
+                    "start_time": "19:00",
+                    "end_time": "20:00",
+                },
+                {
+                    "date": "2026-09-03",
+                    "court_name": "1号场",
+                    "start_time": "18:00",
+                    "end_time": "19:00",
+                },
+            ],
+        }
+        self.gate = {
+            "allowed": True,
+            "evaluated_at": "2026-09-02T09:00:00+00:00",
+            "valid_until": "2026-09-02T09:10:00+00:00",
+            "revision": 123,
+        }
+
+    def test_fingerprint_ignores_checked_at_and_slot_order(self) -> None:
+        first = observation_identity(self.payload)
+        second = observation_identity(
+            {
+                **self.payload,
+                "checked_at": "2026-09-02T09:00:15.000Z",
+                "slots": list(reversed(self.payload["slots"])),
+            }
+        )
+        self.assertEqual(first, second)
+
+    def test_changed_payload_always_forwards(self) -> None:
+        first = decide_observation_delivery(self.payload, now=1_000)
+        record_observation_result(first, success=True, gate=self.gate, now=1_000)
+        changed = decide_observation_delivery(
+            {**self.payload, "slots": self.payload["slots"][:1]},
+            now=1_015,
+        )
+        self.assertEqual(changed.action, "forward")
+
+    def test_success_suppresses_unchanged_polls_until_heartbeat(self) -> None:
+        first = decide_observation_delivery(self.payload, now=1_000)
+        self.assertEqual(first.action, "forward")
+        record_observation_result(first, success=True, gate=self.gate, now=1_000)
+
+        recent = decide_observation_delivery(self.payload, now=1_015)
+        heartbeat = decide_observation_delivery(self.payload, now=1_300)
+        self.assertEqual(recent.action, "skip_success")
+        self.assertEqual(recent.gate, self.gate)
+        self.assertEqual(heartbeat.action, "forward")
+
+    def test_failure_retries_are_bounded_but_changes_bypass_the_backoff(self) -> None:
+        first = decide_observation_delivery(self.payload, now=2_000)
+        record_observation_result(first, success=False, gate=None, now=2_000)
+
+        recent = decide_observation_delivery(self.payload, now=2_030)
+        retry = decide_observation_delivery(self.payload, now=2_120)
+        changed = decide_observation_delivery(
+            {**self.payload, "healthy": False, "error": "upstream unavailable", "slots": []},
+            now=2_030,
+        )
+        self.assertEqual(recent.action, "skip_retry")
+        self.assertEqual(retry.action, "forward")
+        self.assertEqual(changed.action, "forward")
+
+    def test_gate_survives_process_independent_file_roundtrip(self) -> None:
+        decision = decide_observation_delivery(self.payload, now=3_000)
+        record_observation_result(decision, success=True, gate=self.gate, now=3_000)
+
+        self.assertEqual(cached_gate_for_venue("szw"), self.gate)
+        stored = json.loads(self.state_path.read_text(encoding="utf-8"))
+        self.assertEqual(stored["version"], 1)
+        self.assertEqual(len(stored["entries"]), 1)
+        self.assertEqual(self.state_path.stat().st_mode & 0o777, 0o600)

--- a/tests/webapp_observation_cache_test.py
+++ b/tests/webapp_observation_cache_test.py
@@ -127,9 +127,23 @@ class WebappObservationCacheTest(TestCase):
         self.assertEqual(changed.action, "forward")
         self.assertEqual(retry.action, "skip_retry")
 
+    def test_failed_change_is_not_hidden_by_an_older_healthy_heartbeat(self) -> None:
+        baseline = decide_observation_delivery(self.payload, now=3_000)
+        record_observation_result(baseline, success=True, gate=self.gate, now=3_000)
+        changed_payload = {**self.payload, "slots": self.payload["slots"][:1]}
+
+        changed = decide_observation_delivery(changed_payload, now=3_010)
+        self.assertEqual(changed.action, "forward")
+        record_observation_result(changed, success=False, gate=self.gate, now=3_010)
+
+        recent = decide_observation_delivery(changed_payload, now=3_060)
+        retry = decide_observation_delivery(changed_payload, now=3_130)
+        self.assertEqual(recent.action, "skip_retry")
+        self.assertEqual(retry.action, "forward")
+
     def test_gate_survives_process_independent_file_roundtrip(self) -> None:
-        decision = decide_observation_delivery(self.payload, now=3_000)
-        record_observation_result(decision, success=True, gate=self.gate, now=3_000)
+        decision = decide_observation_delivery(self.payload, now=4_000)
+        record_observation_result(decision, success=True, gate=self.gate, now=4_000)
 
         self.assertEqual(cached_gate_for_venue("szw"), self.gate)
         stored = json.loads(self.state_path.read_text(encoding="utf-8"))

--- a/tests/webapp_observation_cache_test.py
+++ b/tests/webapp_observation_cache_test.py
@@ -56,6 +56,7 @@ class WebappObservationCacheTest(TestCase):
                 },
             ],
         }
+        self.empty_payload = {**self.payload, "slots": []}
         self.gate = {
             "allowed": True,
             "evaluated_at": "2026-09-02T09:00:00+00:00",
@@ -75,38 +76,42 @@ class WebappObservationCacheTest(TestCase):
         self.assertEqual(first, second)
 
     def test_changed_payload_always_forwards(self) -> None:
-        first = decide_observation_delivery(self.payload, now=1_000)
+        first = decide_observation_delivery(self.empty_payload, now=1_000)
         record_observation_result(first, success=True, gate=self.gate, now=1_000)
-        changed = decide_observation_delivery(
-            {**self.payload, "slots": self.payload["slots"][:1]},
-            now=1_015,
-        )
+        changed = decide_observation_delivery(self.payload, now=1_015)
         self.assertEqual(changed.action, "forward")
 
-    def test_success_suppresses_unchanged_polls_until_sparse_heartbeat(self) -> None:
+    def test_available_slots_recheck_subscriptions_on_every_natural_poll(self) -> None:
         first = decide_observation_delivery(self.payload, now=1_000)
+        record_observation_result(first, success=True, gate=self.gate, now=1_000)
+
+        next_poll = decide_observation_delivery(self.payload, now=1_015)
+        self.assertEqual(next_poll.action, "forward")
+
+    def test_empty_success_suppresses_polls_until_sparse_heartbeat(self) -> None:
+        first = decide_observation_delivery(self.empty_payload, now=1_000)
         self.assertEqual(first.action, "forward")
         record_observation_result(first, success=True, gate=self.gate, now=1_000)
 
-        recent = decide_observation_delivery(self.payload, now=1_015)
-        heartbeat = decide_observation_delivery(self.payload, now=1_480)
+        recent = decide_observation_delivery(self.empty_payload, now=1_015)
+        heartbeat = decide_observation_delivery(self.empty_payload, now=1_480)
         self.assertEqual(recent.action, "skip_success")
         self.assertEqual(recent.gate, self.gate)
         self.assertEqual(heartbeat.action, "forward")
 
-    def test_parallel_scopes_share_one_venue_heartbeat_budget(self) -> None:
-        day_zero = decide_observation_delivery(self.payload, now=1_000)
+    def test_parallel_empty_scopes_share_one_venue_heartbeat_budget(self) -> None:
+        day_zero = decide_observation_delivery(self.empty_payload, now=1_000)
         record_observation_result(day_zero, success=True, gate=self.gate, now=1_000)
 
         day_one_payload = {
-            **self.payload,
+            **self.empty_payload,
             "observation_scope": "check_and_notify_day_1",
         }
         day_one = decide_observation_delivery(day_one_payload, now=1_001)
         self.assertEqual(day_one.action, "forward")
         record_observation_result(day_one, success=True, gate=self.gate, now=1_001)
 
-        due = decide_observation_delivery(self.payload, now=1_481)
+        due = decide_observation_delivery(self.empty_payload, now=1_481)
         self.assertEqual(due.action, "forward")
         record_observation_result(due, success=True, gate=self.gate, now=1_481)
 
@@ -114,35 +119,38 @@ class WebappObservationCacheTest(TestCase):
         self.assertEqual(coalesced.action, "skip_success")
 
     def test_failure_retries_are_bounded_but_changes_bypass_the_backoff(self) -> None:
-        first = decide_observation_delivery(self.payload, now=2_000)
+        first = decide_observation_delivery(self.empty_payload, now=2_000)
         record_observation_result(first, success=False, gate=None, now=2_000)
 
-        recent = decide_observation_delivery(self.payload, now=2_030)
+        recent = decide_observation_delivery(self.empty_payload, now=2_030)
         changed = decide_observation_delivery(
-            {**self.payload, "healthy": False, "error": "upstream unavailable", "slots": []},
+            {
+                **self.empty_payload,
+                "healthy": False,
+                "error": "upstream unavailable",
+            },
             now=2_030,
         )
-        retry = decide_observation_delivery(self.payload, now=2_120)
+        retry = decide_observation_delivery(self.empty_payload, now=2_120)
         self.assertEqual(recent.action, "skip_retry")
         self.assertEqual(changed.action, "forward")
         self.assertEqual(retry.action, "skip_retry")
 
     def test_failed_change_is_not_hidden_by_an_older_healthy_heartbeat(self) -> None:
-        baseline = decide_observation_delivery(self.payload, now=3_000)
+        baseline = decide_observation_delivery(self.empty_payload, now=3_000)
         record_observation_result(baseline, success=True, gate=self.gate, now=3_000)
-        changed_payload = {**self.payload, "slots": self.payload["slots"][:1]}
 
-        changed = decide_observation_delivery(changed_payload, now=3_010)
+        changed = decide_observation_delivery(self.payload, now=3_010)
         self.assertEqual(changed.action, "forward")
         record_observation_result(changed, success=False, gate=self.gate, now=3_010)
 
-        recent = decide_observation_delivery(changed_payload, now=3_060)
-        retry = decide_observation_delivery(changed_payload, now=3_130)
+        recent = decide_observation_delivery(self.payload, now=3_060)
+        retry = decide_observation_delivery(self.payload, now=3_130)
         self.assertEqual(recent.action, "skip_retry")
         self.assertEqual(retry.action, "forward")
 
     def test_gate_survives_process_independent_file_roundtrip(self) -> None:
-        decision = decide_observation_delivery(self.payload, now=4_000)
+        decision = decide_observation_delivery(self.empty_payload, now=4_000)
         record_observation_result(decision, success=True, gate=self.gate, now=4_000)
 
         self.assertEqual(cached_gate_for_venue("szw"), self.gate)

--- a/webapp/cloudflare/bootstrap-cache.test.ts
+++ b/webapp/cloudflare/bootstrap-cache.test.ts
@@ -8,8 +8,8 @@ import {
 const requestUrl = "https://zacks.claude89757.cc/api/bootstrap?ignored=1";
 
 describe("bootstrap edge cache", () => {
-  it("uses a short bounded freshness window", () => {
-    expect(BOOTSTRAP_CACHE_TTL_SECONDS).toBe(120);
+  it("uses a bounded five-minute freshness window", () => {
+    expect(BOOTSTRAP_CACHE_TTL_SECONDS).toBe(300);
   });
 
   it("separates anonymous and verified dashboard payloads", async () => {

--- a/webapp/cloudflare/bootstrap-cache.ts
+++ b/webapp/cloudflare/bootstrap-cache.ts
@@ -1,6 +1,6 @@
 const BOOTSTRAP_CACHE_PATH = "/__zacks_edge_cache/bootstrap";
 
-export const BOOTSTRAP_CACHE_TTL_SECONDS = 120;
+export const BOOTSTRAP_CACHE_TTL_SECONDS = 300;
 
 type BootstrapCacheEnv = {
   VERIFICATION_PEPPER: string;

--- a/webapp/cloudflare/free-tier-observation.test.ts
+++ b/webapp/cloudflare/free-tier-observation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { OBSERVATION_HEARTBEAT_MS } from "./observation-dedupe";
+import {
+  classifyFreeTierObservation,
+  freeTierObservationEnvelope,
+} from "./free-tier-observation";
+
+const now = Date.parse("2026-09-02T09:00:30.000Z");
+const observation = {
+  venue_id: "szw",
+  venue_name: "深圳湾",
+  observation_scope: "check_and_notify_day_0",
+  healthy: true,
+  checked_at: "2026-09-02T09:00:00.000Z",
+  error: null,
+  slots: [
+    {
+      date: "2026-09-03",
+      court_name: "1号场",
+      start_time: "18:00",
+      end_time: "19:00",
+    },
+  ],
+};
+
+describe("free-tier observation policy", () => {
+  it("accepts only a canonical known venue payload", async () => {
+    const envelope = await freeTierObservationEnvelope(observation, now);
+    expect(envelope?.venueId).toBe("szw");
+    expect(envelope?.venueName).toBe("深圳湾");
+    expect(envelope?.checkedAt).toBe("2026-09-02T09:00:00.000Z");
+
+    expect(await freeTierObservationEnvelope({
+      ...observation,
+      venue_name: "wrong venue",
+    }, now)).toBeNull();
+    expect(await freeTierObservationEnvelope({
+      ...observation,
+      venue_id: "unknown",
+    }, now)).toBeNull();
+  });
+
+  it("forwards changes, skips recent duplicates, and emits only a light heartbeat", async () => {
+    const envelope = await freeTierObservationEnvelope(observation, now);
+    if (!envelope) throw new Error("expected a valid envelope");
+
+    expect(classifyFreeTierObservation(envelope.snapshot, null, now)).toBe("forward");
+    expect(classifyFreeTierObservation(envelope.snapshot, {
+      fingerprint: "different",
+      last_forwarded_at: now,
+    }, now)).toBe("forward");
+    expect(classifyFreeTierObservation(envelope.snapshot, {
+      fingerprint: envelope.snapshot.fingerprint,
+      last_forwarded_at: now - 15_000,
+    }, now)).toBe("skip");
+    expect(classifyFreeTierObservation(envelope.snapshot, {
+      fingerprint: envelope.snapshot.fingerprint,
+      last_forwarded_at: now - OBSERVATION_HEARTBEAT_MS,
+    }, now)).toBe("heartbeat");
+  });
+});

--- a/webapp/cloudflare/free-tier-observation.ts
+++ b/webapp/cloudflare/free-tier-observation.ts
@@ -1,0 +1,142 @@
+import { VENUES, type VenueId } from "./domain";
+import {
+  OBSERVATION_HEARTBEAT_MS,
+  observationSnapshot,
+  type ObservationSnapshot,
+} from "./observation-dedupe";
+
+type ObservationStateRow = {
+  fingerprint: string;
+  last_forwarded_at: number;
+};
+
+export type FreeTierObservationEnvelope = {
+  snapshot: ObservationSnapshot;
+  venueId: VenueId;
+  venueName: string;
+  healthy: boolean;
+  checkedAt: string;
+  error: string | null;
+};
+
+export type FreeTierObservationAction = "forward" | "skip" | "heartbeat";
+
+function stringField(
+  candidate: Record<string, unknown>,
+  snakeCase: string,
+  camelCase: string,
+): string {
+  return String(candidate[snakeCase] ?? candidate[camelCase] ?? "").trim();
+}
+
+export async function freeTierObservationEnvelope(
+  payload: unknown,
+  now = Date.now(),
+): Promise<FreeTierObservationEnvelope | null> {
+  const snapshot = await observationSnapshot(payload, now);
+  if (!snapshot || !payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  if (!(snapshot.venueId in VENUES)) return null;
+
+  const candidate = payload as Record<string, unknown>;
+  const venueId = snapshot.venueId as VenueId;
+  const venueName = stringField(candidate, "venue_name", "venueName");
+  if (venueName !== VENUES[venueId]) return null;
+
+  const checkedAtValue = stringField(candidate, "checked_at", "checkedAt");
+  const checkedAtMs = Date.parse(checkedAtValue);
+  if (!Number.isFinite(checkedAtMs)) return null;
+
+  return {
+    snapshot,
+    venueId,
+    venueName,
+    healthy: candidate.healthy === true,
+    checkedAt: new Date(checkedAtMs).toISOString(),
+    error: candidate.error ? String(candidate.error).slice(0, 300) : null,
+  };
+}
+
+export function classifyFreeTierObservation(
+  snapshot: ObservationSnapshot,
+  current: ObservationStateRow | null,
+  now: number,
+  heartbeatMs = OBSERVATION_HEARTBEAT_MS,
+): FreeTierObservationAction {
+  if (!current || current.fingerprint !== snapshot.fingerprint) return "forward";
+  return now - Number(current.last_forwarded_at) < heartbeatMs
+    ? "skip"
+    : "heartbeat";
+}
+
+export async function applyFreeTierObservationPolicy(
+  db: D1Database,
+  payload: unknown,
+  now = Date.now(),
+): Promise<{
+  action: FreeTierObservationAction;
+  envelope: FreeTierObservationEnvelope | null;
+}> {
+  const envelope = await freeTierObservationEnvelope(payload, now);
+  if (!envelope) return { action: "forward", envelope: null };
+
+  const current = await db.prepare(
+    `SELECT fingerprint, last_forwarded_at
+       FROM observation_ingest_state
+      WHERE observation_key = ?`,
+  ).bind(envelope.snapshot.key).first<ObservationStateRow>();
+  const action = classifyFreeTierObservation(envelope.snapshot, current, now);
+  if (action !== "heartbeat" || !current) return { action, envelope };
+
+  const nowIso = new Date(now).toISOString();
+  const results = await db.batch([
+    db.prepare(
+      `UPDATE observation_ingest_state
+          SET last_forwarded_at = ?
+        WHERE observation_key = ?
+          AND fingerprint = ?
+          AND last_forwarded_at = ?`,
+    ).bind(
+      now,
+      envelope.snapshot.key,
+      envelope.snapshot.fingerprint,
+      current.last_forwarded_at,
+    ),
+    db.prepare(
+      `INSERT INTO venue_status
+         (venue_id, venue_name, healthy, last_inspection_at, last_error, updated_at)
+       SELECT ?, ?, ?, ?, ?, ?
+        WHERE EXISTS (
+          SELECT 1
+            FROM observation_ingest_state
+           WHERE observation_key = ?
+             AND fingerprint = ?
+             AND last_forwarded_at = ?
+        )
+       ON CONFLICT(venue_id) DO UPDATE SET
+         venue_name = excluded.venue_name,
+         healthy = excluded.healthy,
+         last_inspection_at = excluded.last_inspection_at,
+         last_error = excluded.last_error,
+         updated_at = excluded.updated_at`,
+    ).bind(
+      envelope.venueId,
+      envelope.venueName,
+      envelope.healthy ? 1 : 0,
+      envelope.checkedAt,
+      envelope.error,
+      nowIso,
+      envelope.snapshot.key,
+      envelope.snapshot.fingerprint,
+      now,
+    ),
+  ]);
+
+  const claimed = Number(results[0]?.meta.changes || 0) > 0;
+  const venueUpdated = Number(results[1]?.meta.changes || 0) > 0;
+  return {
+    action: claimed && venueUpdated ? "heartbeat" : "skip",
+    envelope,
+  };
+}

--- a/webapp/cloudflare/free-tier-schema.test.ts
+++ b/webapp/cloudflare/free-tier-schema.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FREE_TIER_SCHEMA_MARKER,
+  FREE_TIER_SCHEMA_SQL,
+  FREE_TIER_SCHEMA_VERSION,
+} from "./free-tier-schema";
+
+describe("free-tier schema recovery", () => {
+  it("uses one stable marker and idempotent partial indexes", () => {
+    expect(FREE_TIER_SCHEMA_MARKER).toBe("system:free-tier-schema");
+    expect(FREE_TIER_SCHEMA_VERSION).toBe("notification-outbox-hot-path-v1");
+    expect(FREE_TIER_SCHEMA_SQL).toContain(
+      "CREATE INDEX IF NOT EXISTS notification_outbox_message_id_lookup_idx",
+    );
+    expect(FREE_TIER_SCHEMA_SQL).toContain(
+      "CREATE INDEX IF NOT EXISTS notification_outbox_submitted_at_lookup_idx",
+    );
+    expect(FREE_TIER_SCHEMA_SQL).toContain(
+      "CREATE INDEX IF NOT EXISTS notification_outbox_delivered_at_lookup_idx",
+    );
+    expect(FREE_TIER_SCHEMA_SQL).toContain("PRAGMA optimize;");
+    expect(FREE_TIER_SCHEMA_SQL.match(/CREATE INDEX IF NOT EXISTS/g)).toHaveLength(3);
+  });
+});

--- a/webapp/cloudflare/free-tier-schema.ts
+++ b/webapp/cloudflare/free-tier-schema.ts
@@ -1,0 +1,61 @@
+export const FREE_TIER_SCHEMA_MARKER = "system:free-tier-schema";
+export const FREE_TIER_SCHEMA_VERSION = "notification-outbox-hot-path-v1";
+
+export const FREE_TIER_SCHEMA_SQL = `
+CREATE INDEX IF NOT EXISTS notification_outbox_message_id_lookup_idx
+    ON notification_outbox(message_id)
+    WHERE message_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS notification_outbox_submitted_at_lookup_idx
+    ON notification_outbox(provider_submitted_at, email, status, message_id)
+    WHERE provider_submitted_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS notification_outbox_delivered_at_lookup_idx
+    ON notification_outbox(status, provider_delivered_at, email, message_id)
+    WHERE provider_delivered_at IS NOT NULL;
+
+PRAGMA optimize;
+`;
+
+type FreeTierSchemaEnv = {
+  DB: D1Database;
+};
+
+type SchemaMarkerRow = {
+  fingerprint: string;
+};
+
+let schemaReadyInIsolate = false;
+
+export async function ensureFreeTierSchema(
+  env: FreeTierSchemaEnv,
+  now = Date.now(),
+): Promise<"ready" | "applied"> {
+  if (schemaReadyInIsolate) return "ready";
+
+  const marker = await env.DB.prepare(
+    `SELECT fingerprint
+       FROM observation_ingest_state
+      WHERE observation_key = ?`,
+  ).bind(FREE_TIER_SCHEMA_MARKER).first<SchemaMarkerRow>();
+  if (marker?.fingerprint === FREE_TIER_SCHEMA_VERSION) {
+    schemaReadyInIsolate = true;
+    return "ready";
+  }
+
+  await env.DB.exec(FREE_TIER_SCHEMA_SQL);
+  await env.DB.prepare(
+    `INSERT INTO observation_ingest_state
+       (observation_key, fingerprint, last_forwarded_at)
+     VALUES (?, ?, ?)
+     ON CONFLICT(observation_key) DO UPDATE SET
+       fingerprint = excluded.fingerprint,
+       last_forwarded_at = excluded.last_forwarded_at`,
+  ).bind(FREE_TIER_SCHEMA_MARKER, FREE_TIER_SCHEMA_VERSION, now).run();
+  schemaReadyInIsolate = true;
+  return "applied";
+}
+
+export function resetFreeTierSchemaCacheForTest(): void {
+  schemaReadyInIsolate = false;
+}

--- a/webapp/cloudflare/subscription-gated-entry.ts
+++ b/webapp/cloudflare/subscription-gated-entry.ts
@@ -75,7 +75,7 @@ function gateMutation(method: string, pathname: string): boolean {
     (method === "POST" && pathname === "/api/subscriptions")
     || (method === "DELETE" && /^\/api\/subscriptions\/[0-9a-f-]{36}$/i.test(pathname))
     || (method === "POST" && pathname === "/api/priority/redeem")
-    || pathname.startsWith("/api/admin/")
+    || (!["GET", "HEAD", "OPTIONS"].includes(method) && pathname.startsWith("/api/admin/"))
   );
 }
 
@@ -83,6 +83,30 @@ function refreshSafely(env: GateEnv, source: string): Promise<void> {
   return refreshWechatVenueGates(env).catch((error) => {
     console.warn(JSON.stringify({
       event: "wechat_subscription_gate_refresh_failed",
+      source,
+      reason: error instanceof Error ? error.message.slice(0, 160) : "unknown",
+    }));
+  });
+}
+
+function invalidateObservationMatchingSafely(
+  env: GateEnv,
+  source: string,
+): Promise<void> {
+  const revision = `subscription-change:${Date.now()}`;
+  return env.DB.prepare(
+    `UPDATE observation_ingest_state
+        SET fingerprint = ?, last_forwarded_at = 0
+      WHERE observation_key LIKE 'v2:%'`,
+  ).bind(revision).run().then((result) => {
+    console.log(JSON.stringify({
+      event: "observation_matching_invalidated",
+      source,
+      scopes: Number(result.meta.changes || 0),
+    }));
+  }).catch((error) => {
+    console.warn(JSON.stringify({
+      event: "observation_matching_invalidation_failed",
       source,
       reason: error instanceof Error ? error.message.slice(0, 160) : "unknown",
     }));
@@ -187,7 +211,11 @@ export default {
     }
 
     if (response.ok && gateMutation(request.method, url.pathname)) {
-      context.waitUntil(refreshSafely(env, `${request.method}:${url.pathname}`));
+      const source = `${request.method}:${url.pathname}`;
+      context.waitUntil(Promise.all([
+        refreshSafely(env, source),
+        invalidateObservationMatchingSafely(env, source),
+      ]).then(() => undefined));
     }
     return response;
   },

--- a/webapp/cloudflare/subscription-gated-entry.ts
+++ b/webapp/cloudflare/subscription-gated-entry.ts
@@ -113,7 +113,7 @@ function invalidateObservationMatchingSafely(
   });
 }
 
-async function ensureSchemaSafely(env: GateEnv, source: string): Promise<boolean> {
+async function ensureSchemaSafely(env: GateEnv, source: string): Promise<void> {
   try {
     const status = await ensureFreeTierSchema(env);
     if (status === "applied") {
@@ -122,14 +122,12 @@ async function ensureSchemaSafely(env: GateEnv, source: string): Promise<boolean
         source,
       }));
     }
-    return true;
   } catch (error) {
     console.warn(JSON.stringify({
       event: "free_tier_schema_unavailable",
       source,
       reason: error instanceof Error ? error.message.slice(0, 160) : "unknown",
     }));
-    return false;
   }
 }
 
@@ -178,7 +176,6 @@ export default {
       && observationPayload
       && venueId
       && authorizedObservationRequest(request, env)
-      && await ensureSchemaSafely(env, `observation:${venueId}`)
     ) {
       try {
         const decision = await applyFreeTierObservationPolicy(env.DB, observationPayload);
@@ -190,11 +187,7 @@ export default {
             venueId: decision.envelope.venueId,
             slotCount: decision.envelope.snapshot.slotCount,
           }));
-          return enrichObservationResponse(
-            optimizedObservationResponse(decision.action, decision.envelope),
-            env,
-            venueId,
-          );
+          return optimizedObservationResponse(decision.action, decision.envelope);
         }
       } catch (error) {
         console.warn(JSON.stringify({

--- a/webapp/cloudflare/subscription-gated-entry.ts
+++ b/webapp/cloudflare/subscription-gated-entry.ts
@@ -1,11 +1,18 @@
 import worker from "./deployment-entry";
 import {
+  applyFreeTierObservationPolicy,
+  type FreeTierObservationAction,
+  type FreeTierObservationEnvelope,
+} from "./free-tier-observation";
+import { ensureFreeTierSchema } from "./free-tier-schema";
+import {
   refreshWechatVenueGates,
   wechatGateForVenue,
 } from "./wechat-subscription-gate";
 
 type GateEnv = Env & {
   DB: D1Database;
+  AIRFLOW_PUSH_TOKEN: string;
 };
 
 function observationVenueId(payload: unknown): string | null {
@@ -13,6 +20,25 @@ function observationVenueId(payload: unknown): string | null {
   const candidate = payload as Record<string, unknown>;
   const venueId = String(candidate.venue_id ?? candidate.venueId ?? "").trim();
   return venueId || null;
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  const encoder = new TextEncoder();
+  const leftBytes = encoder.encode(left);
+  const rightBytes = encoder.encode(right);
+  if (leftBytes.byteLength !== rightBytes.byteLength) return false;
+  let difference = 0;
+  for (let index = 0; index < leftBytes.byteLength; index += 1) {
+    difference |= leftBytes[index] ^ rightBytes[index];
+  }
+  return difference === 0;
+}
+
+function authorizedObservationRequest(request: Request, env: GateEnv): boolean {
+  const authorization = request.headers.get("authorization") || "";
+  if (!authorization.startsWith("Bearer ")) return false;
+  const token = authorization.slice(7).trim();
+  return Boolean(token) && constantTimeEqual(token, env.AIRFLOW_PUSH_TOKEN);
 }
 
 async function enrichObservationResponse(
@@ -63,6 +89,45 @@ function refreshSafely(env: GateEnv, source: string): Promise<void> {
   });
 }
 
+async function ensureSchemaSafely(env: GateEnv, source: string): Promise<boolean> {
+  try {
+    const status = await ensureFreeTierSchema(env);
+    if (status === "applied") {
+      console.log(JSON.stringify({
+        event: "free_tier_schema_applied",
+        source,
+      }));
+    }
+    return true;
+  } catch (error) {
+    console.warn(JSON.stringify({
+      event: "free_tier_schema_unavailable",
+      source,
+      reason: error instanceof Error ? error.message.slice(0, 160) : "unknown",
+    }));
+    return false;
+  }
+}
+
+function optimizedObservationResponse(
+  action: Exclude<FreeTierObservationAction, "forward">,
+  envelope: FreeTierObservationEnvelope,
+): Response {
+  return Response.json({
+    success: true,
+    venueId: envelope.venueId,
+    slotsAccepted: envelope.snapshot.slotCount,
+    deduplicated: true,
+    heartbeat: action === "heartbeat",
+    freeTierOptimized: true,
+  }, {
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Type": "application/json; charset=utf-8",
+    },
+  });
+}
+
 export default {
   async fetch(
     request: Request,
@@ -71,11 +136,48 @@ export default {
   ): Promise<Response> {
     const url = new URL(request.url);
     let venueId: string | null = null;
-    if (request.method === "POST" && url.pathname === "/api/internal/observations") {
+    let observationPayload: unknown = null;
+    const observationRequest = request.method === "POST"
+      && url.pathname === "/api/internal/observations";
+    if (observationRequest) {
       try {
-        venueId = observationVenueId(await request.clone().json<unknown>());
+        observationPayload = await request.clone().json<unknown>();
+        venueId = observationVenueId(observationPayload);
       } catch {
+        observationPayload = null;
         venueId = null;
+      }
+    }
+
+    if (
+      observationRequest
+      && observationPayload
+      && venueId
+      && authorizedObservationRequest(request, env)
+      && await ensureSchemaSafely(env, `observation:${venueId}`)
+    ) {
+      try {
+        const decision = await applyFreeTierObservationPolicy(env.DB, observationPayload);
+        if (decision.action !== "forward" && decision.envelope) {
+          console.log(JSON.stringify({
+            event: decision.action === "heartbeat"
+              ? "venue_observation_lightweight_heartbeat"
+              : "venue_observation_free_tier_deduplicated",
+            venueId: decision.envelope.venueId,
+            slotCount: decision.envelope.snapshot.slotCount,
+          }));
+          return enrichObservationResponse(
+            optimizedObservationResponse(decision.action, decision.envelope),
+            env,
+            venueId,
+          );
+        }
+      } catch (error) {
+        console.warn(JSON.stringify({
+          event: "free_tier_observation_policy_failed_open",
+          venueId,
+          reason: error instanceof Error ? error.message.slice(0, 160) : "unknown",
+        }));
       }
     }
 
@@ -96,6 +198,7 @@ export default {
     context: ExecutionContext,
   ): Promise<void> {
     const cron = (controller as ScheduledController & { cron?: string }).cron;
+    await ensureSchemaSafely(env, `scheduled:${cron || "unknown"}`);
     context.waitUntil(refreshSafely(env, `scheduled:${cron || "unknown"}`));
     await worker.scheduled(controller, env as never, context);
   },

--- a/webapp/migrations/0016_optimize_notification_outbox_reads.sql
+++ b/webapp/migrations/0016_optimize_notification_outbox_reads.sql
@@ -1,0 +1,11 @@
+CREATE INDEX IF NOT EXISTS notification_outbox_message_id_lookup_idx
+    ON notification_outbox(message_id)
+    WHERE message_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS notification_outbox_submitted_at_lookup_idx
+    ON notification_outbox(provider_submitted_at, email, status, message_id)
+    WHERE provider_submitted_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS notification_outbox_delivered_at_lookup_idx
+    ON notification_outbox(status, provider_delivered_at, email, message_id)
+    WHERE provider_delivered_at IS NOT NULL;

--- a/webapp/migrations/0016_optimize_notification_outbox_reads.sql
+++ b/webapp/migrations/0016_optimize_notification_outbox_reads.sql
@@ -9,3 +9,5 @@ CREATE INDEX IF NOT EXISTS notification_outbox_submitted_at_lookup_idx
 CREATE INDEX IF NOT EXISTS notification_outbox_delivered_at_lookup_idx
     ON notification_outbox(status, provider_delivered_at, email, message_id)
     WHERE provider_delivered_at IS NOT NULL;
+
+PRAGMA optimize;

--- a/webapp/src/api.test.ts
+++ b/webapp/src/api.test.ts
@@ -34,10 +34,11 @@ describe("dashboard client cache", () => {
     invalidateDashboardCache();
   });
 
-  it("turns the 30-second UI refresh loop into one network request per two minutes", async () => {
+  it("keeps automatic UI refreshes in memory for one day", async () => {
     const fetchMock = dashboardFetchMock();
     vi.stubGlobal("fetch", fetchMock);
 
+    expect(DASHBOARD_CLIENT_CACHE_MS).toBe(86_400_000);
     await getDashboard(null);
     vi.advanceTimersByTime(30_000);
     await getDashboard(null);

--- a/webapp/src/api.ts
+++ b/webapp/src/api.ts
@@ -155,7 +155,8 @@ export type CoffeeInvite = {
 };
 
 const RECEIPTS_KEY = "zacks-tennis-verified-emails-v1";
-export const DASHBOARD_CLIENT_CACHE_MS = 120_000;
+// Automatic UI renders reuse memory; only explicit refreshes and mutations hit the network.
+export const DASHBOARD_CLIENT_CACHE_MS = 86_400_000;
 
 export type DashboardFetchOptions = {
   force?: boolean;


### PR DESCRIPTION
## Summary

Repair the 2026-09-02 production outage while keeping the project on Cloudflare Workers Free.

- Add partial indexes for the remaining `notification_outbox` hot paths and run `PRAGMA optimize`.
- Make dashboard network reads user-driven: first load, explicit refresh, identity change, or subscription mutation. Automatic presentation refreshes reuse memory.
- Remove frequent per-task heartbeats. Empty and unchanged observations are coalesced to one lightweight liveness update per venue every eight minutes.
- Keep available-slot observations on every natural poll, so a newly created subscription can match existing availability immediately.
- Preserve first-poll forwarding for every real slot, health, or error change.
- Increase the private edge bootstrap cache to five minutes.
- Invalidate Worker observation fingerprints after subscription or priority changes.
- Bound production delivery diagnostics to indexed time windows.
- Allow protected deployment through the current outage only when Cloudflare returns the exact D1 Free quota error (`7500`); all other failures remain blocking.
- If the quota blocks migration execution, deploy the Worker and Airflow repair first and let scheduled Worker maintenance idempotently create the same indexes after the UTC reset.

## Production diagnosis

Read-only diagnosis on exact main commit `77bd0adb76b1ca716bd928705dddae78b7ea76ac` found:

- production SSH, repository validation, and authenticated Web probing succeeded;
- `POST /api/internal/reconcile-deliveries` failed with HTTP 500 / `D1_ERROR` in run `33614031324`;
- protected preflight run `33614245883` returned Cloudflare D1 error `7500`: the account exceeded the Workers Free daily row-read limit;
- the preceding successful diagnostic showed individual `notification_outbox` aggregates reading approximately 41.7k–42.5k rows for small aggregate results.

The Aug 31 main commit was an asset-only logo change. Its Web deployment succeeded and Airflow was not redeployed, so this is not an Airflow host, SSH, tunnel, or logo rollback issue.

## Correctness contracts

- No active venue polling schedule is reduced.
- Every real availability, health, or error change is forwarded on the first matching poll.
- Empty parallel task/day scopes share one venue liveness budget.
- The eight-minute empty-state liveness update stays below the existing ten-minute venue freshness threshold.
- Available-slot observations continue reaching the Worker on every natural poll; their unchanged path is only an indexed fingerprint lookup.
- A failed changed fingerprint retries after at most two minutes and is never hidden by an older healthy heartbeat.
- A browser refresh only reads state; it is not used as evidence that Airflow is alive.
- Subscription mutations invalidate dedupe state to avoid starving newly eligible subscribers.
- No production data is deleted.
- No real email or WeChat acceptance probe is sent by this release.

## Verification

- [x] Migration tests reproduce the existing schema and verify the four hot queries with `EXPLAIN QUERY PLAN`.
- [x] Local observation-cache tests cover canonical fingerprints, per-venue empty-state coalescing, available-slot matching, failure backoff, change bypass, atomic persistence, and cached gate reuse.
- [x] Worker tests cover lightweight heartbeats, quota-reset schema self-healing, cache separation, and mutation invalidation contracts.
- [x] Release tests verify that only the exact D1 quota message/code can bypass migration availability, while unexpected failures remain blocking.
- [x] Dashboard tests verify user-driven forced refresh and one-day in-memory reuse for automatic renders.
- [x] `CI / verify` passed on exact head `9965dfc08a10fc300d45e369e5e539dbcdf8e414` in run `33621930891`.
- [ ] Protected release preflight on exact merged main commit.
- [ ] Protected production apply for Web and Airflow.
- [ ] Exact-commit production identity and natural-cycle acceptance.
- [ ] Full UTC-day D1 rows-read/write observation.

## Expected free-tier budget

With 26 Web venues, empty and unchanged observations are reduced to at most 4,680 lightweight Worker requests per day before inactive periods and task runtime reduce the actual count. Observations containing available slots intentionally continue at their configured natural polling schedule so subscription changes are not starved; their unchanged Worker path performs one indexed state lookup instead of a full business ingest.

Operational targets remain:

- D1 rows read below 2,000,000 per UTC day;
- D1 rows written below 30,000 per UTC day;
- total Worker requests below 80,000 per UTC day;
- Workers `exceededCpu` equal to zero.

## Recovery and rollback

The D1 quota resets at `00:00 UTC` (`09:00` Korea time). The protected apply path can deploy this exact repair before reset without pretending D1 is healthy. After reset, scheduled Worker maintenance applies the same idempotent index definitions if the migration was deferred.

The migration is additive. The indexes can remain after an application rollback. Deleting the Airflow local fingerprint file safely causes the next poll to fail open and publish a complete observation.