### PR TITLE
fix(release): retry Worker identity during propagation

### DIFF
--- a/scripts/webapp_deployment_identity.py
+++ b/scripts/webapp_deployment_identity.py
@@ -76,11 +76,7 @@ def deployment_is_propagating(payload: dict[str, Any]) -> bool:
     checks = payload.get("checks")
     if not isinstance(checks, dict) or checks.get("exact_deployment_commit") is not False:
         return False
-    other_checks = [
-        value
-        for name, value in checks.items()
-        if name != "exact_deployment_commit"
-    ]
+    other_checks = [value for name, value in checks.items() if name != "exact_deployment_commit"]
     return bool(other_checks) and all(value is True for value in other_checks)
 
 

--- a/scripts/webapp_deployment_identity.py
+++ b/scripts/webapp_deployment_identity.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from typing import Any
 
 import yaml
 from _ops import REPO_ROOT, OpsError, emit
 
 COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+Inspector = Callable[..., dict[str, Any]]
 
 
 def request_json(url: str, *, timeout_seconds: float = 15) -> tuple[int, Any]:
@@ -69,24 +72,68 @@ def inspect_deployment_identity(*, base_url: str, expected_commit: str) -> dict[
     return evaluate_deployment_identity(status, payload, expected_commit)
 
 
+def deployment_is_propagating(payload: dict[str, Any]) -> bool:
+    checks = payload.get("checks")
+    if not isinstance(checks, dict) or checks.get("exact_deployment_commit") is not False:
+        return False
+    other_checks = [
+        value
+        for name, value in checks.items()
+        if name != "exact_deployment_commit"
+    ]
+    return bool(other_checks) and all(value is True for value in other_checks)
+
+
+def wait_for_deployment_identity(
+    *,
+    base_url: str,
+    expected_commit: str,
+    propagation_timeout_seconds: float,
+    retry_interval_seconds: float,
+    inspector: Inspector = inspect_deployment_identity,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    deadline = monotonic() + propagation_timeout_seconds
+    attempts = 0
+    while True:
+        attempts += 1
+        payload = inspector(base_url=base_url, expected_commit=expected_commit)
+        payload = {**payload, "attempts": attempts}
+        if payload["ok"] or not deployment_is_propagating(payload):
+            return payload
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            return payload
+        sleeper(min(retry_interval_seconds, remaining))
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Verify the deployed Worker identity without querying D1."
     )
     parser.add_argument("--expected-commit", required=True)
     parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--propagation-timeout-seconds", type=float, default=90)
+    parser.add_argument("--retry-interval-seconds", type=float, default=2)
     args = parser.parse_args()
 
     if not COMMIT_PATTERN.fullmatch(args.expected_commit):
         raise OpsError("expected commit must be a full SHA-1")
+    if args.propagation_timeout_seconds < 0:
+        raise OpsError("propagation timeout must not be negative")
+    if args.retry_interval_seconds <= 0:
+        raise OpsError("retry interval must be positive")
 
     runtime_target = yaml.safe_load(
         (REPO_ROOT / "config" / "runtime-target.yaml").read_text(encoding="utf-8")
     )
     target = runtime_target["managed_services"]["webapp"]
-    payload = inspect_deployment_identity(
+    payload = wait_for_deployment_identity(
         base_url=str(target["public_base_url"]),
         expected_commit=args.expected_commit,
+        propagation_timeout_seconds=args.propagation_timeout_seconds,
+        retry_interval_seconds=args.retry_interval_seconds,
     )
     emit(payload, args.format)
     if not payload["ok"]:

--- a/tests/webapp_deployment_identity_test.py
+++ b/tests/webapp_deployment_identity_test.py
@@ -47,12 +47,8 @@ class WebappDeploymentIdentityTest(TestCase):
         old_commit = self.identity("b" * 40, commit)
         unhealthy = self.identity("b" * 40, commit, healthy=False)
 
-        self.assertTrue(
-            webapp_deployment_identity.deployment_is_propagating(old_commit)
-        )
-        self.assertFalse(
-            webapp_deployment_identity.deployment_is_propagating(unhealthy)
-        )
+        self.assertTrue(webapp_deployment_identity.deployment_is_propagating(old_commit))
+        self.assertFalse(webapp_deployment_identity.deployment_is_propagating(unhealthy))
 
     def test_waits_for_the_exact_commit_during_edge_propagation(self) -> None:
         commit = "a" * 40

--- a/tests/webapp_deployment_identity_test.py
+++ b/tests/webapp_deployment_identity_test.py
@@ -12,35 +12,92 @@ import webapp_deployment_identity  # noqa: E402
 
 
 class WebappDeploymentIdentityTest(TestCase):
-    def test_accepts_exact_healthy_worker_without_d1_payload(self) -> None:
-        commit = "a" * 40
-        result = webapp_deployment_identity.evaluate_deployment_identity(
-            200,
+    def identity(
+        self,
+        deployed_commit: str,
+        expected_commit: str,
+        *,
+        healthy: bool = True,
+    ) -> dict[str, object]:
+        return webapp_deployment_identity.evaluate_deployment_identity(
+            200 if healthy else 503,
             {
-                "ok": True,
-                "deploymentCommit": commit,
+                "ok": healthy,
+                "deploymentCommit": deployed_commit,
                 "capabilities": {"priorityWeatherBypass": True},
             },
-            commit,
+            expected_commit,
         )
+
+    def test_accepts_exact_healthy_worker_without_d1_payload(self) -> None:
+        commit = "a" * 40
+        result = self.identity(commit, commit)
         self.assertTrue(result["ok"])
         self.assertFalse(result["d1_checked"])
 
     def test_rejects_wrong_commit_or_unhealthy_worker(self) -> None:
         commit = "a" * 40
-        wrong_commit = webapp_deployment_identity.evaluate_deployment_identity(
-            200,
-            {
-                "ok": True,
-                "deploymentCommit": "b" * 40,
-                "capabilities": {"priorityWeatherBypass": True},
-            },
-            commit,
-        )
-        unhealthy = webapp_deployment_identity.evaluate_deployment_identity(
-            503,
-            {"ok": False, "deploymentCommit": commit},
-            commit,
-        )
+        wrong_commit = self.identity("b" * 40, commit)
+        unhealthy = self.identity(commit, commit, healthy=False)
         self.assertFalse(wrong_commit["ok"])
         self.assertFalse(unhealthy["ok"])
+
+    def test_only_an_otherwise_healthy_old_commit_is_propagating(self) -> None:
+        commit = "a" * 40
+        old_commit = self.identity("b" * 40, commit)
+        unhealthy = self.identity("b" * 40, commit, healthy=False)
+
+        self.assertTrue(
+            webapp_deployment_identity.deployment_is_propagating(old_commit)
+        )
+        self.assertFalse(
+            webapp_deployment_identity.deployment_is_propagating(unhealthy)
+        )
+
+    def test_waits_for_the_exact_commit_during_edge_propagation(self) -> None:
+        commit = "a" * 40
+        responses = iter(
+            [
+                self.identity("b" * 40, commit),
+                self.identity(commit, commit),
+            ]
+        )
+        sleeps: list[float] = []
+        times = iter([100.0, 100.0])
+
+        result = webapp_deployment_identity.wait_for_deployment_identity(
+            base_url="https://example.test",
+            expected_commit=commit,
+            propagation_timeout_seconds=90,
+            retry_interval_seconds=2,
+            inspector=lambda **_kwargs: next(responses),
+            monotonic=lambda: next(times),
+            sleeper=sleeps.append,
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["attempts"], 2)
+        self.assertEqual(sleeps, [2])
+
+    def test_does_not_retry_an_unhealthy_service(self) -> None:
+        commit = "a" * 40
+        calls = 0
+
+        def inspect(**_kwargs):
+            nonlocal calls
+            calls += 1
+            return self.identity(commit, commit, healthy=False)
+
+        result = webapp_deployment_identity.wait_for_deployment_identity(
+            base_url="https://example.test",
+            expected_commit=commit,
+            propagation_timeout_seconds=90,
+            retry_interval_seconds=2,
+            inspector=inspect,
+            monotonic=lambda: 100.0,
+            sleeper=lambda _seconds: self.fail("unexpected retry"),
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["attempts"], 1)
+        self.assertEqual(calls, 1)


### PR DESCRIPTION
## Summary

Prevent a successful Cloudflare Worker deployment from being reported as failed while the custom-domain edge is still propagating the new version.

- Retry only when `/api/healthz` is otherwise healthy and the sole failed check is the exact deployment commit.
- Stop immediately for unhealthy service, missing capability, or HTTP failure.
- Bound the propagation window to 90 seconds with a two-second interval.
- Keep the check independent of D1 so it remains usable when the Workers Free D1 quota is exhausted.
- Report the number of identity attempts for auditability.

## Production evidence

The first apply of commit `42d254d0c13e64bd6a0d3560af9b95ca3014f5a2` successfully uploaded and deployed the Worker but checked the custom domain about half a second later and still read the previous commit. Re-running the same protected apply succeeded once the already-deployed version had propagated. This change turns that known propagation window into a bounded retry rather than requiring a duplicate release.

## Safety

Unexpected health failures still fail closed. The retry does not bypass exact-commit verification, D1 migration gates, build checks, or production environment protections.

## Verification

- [x] Tests cover exact success, propagation classification, old-to-new commit retry, and immediate failure for an unhealthy service.
- [ ] CI / verify