### PR TITLE
fix(free-tier): restore venue status without D1

### DIFF
--- a/src/wechat_airflow/notifications/observation_cache.py
+++ b/src/wechat_airflow/notifications/observation_cache.py
@@ -17,9 +17,7 @@ OBSERVATION_CACHE_PATH_ENV = "WEBAPP_OBSERVATION_STATE_PATH"
 OBSERVATION_FAILURE_RETRY_SECONDS_ENV = "WEBAPP_OBSERVATION_FAILURE_RETRY_SECONDS"
 # Version the default file path whenever a one-time replay is required. Stable
 # empty observations remain heartbeat-free after the first successful forward.
-DEFAULT_OBSERVATION_CACHE_PATH = Path(
-    "/opt/airflow/logs/webapp-observation-state-v4.json"
-)
+DEFAULT_OBSERVATION_CACHE_PATH = Path("/opt/airflow/logs/webapp-observation-state-v4.json")
 DEFAULT_OBSERVATION_FAILURE_RETRY_SECONDS = 120.0
 _STATE_VERSION = 3
 

--- a/src/wechat_airflow/notifications/observation_cache.py
+++ b/src/wechat_airflow/notifications/observation_cache.py
@@ -15,7 +15,11 @@ from typing import Any, Literal, TypedDict
 OBSERVATION_CACHE_ENABLED_ENV = "WEBAPP_OBSERVATION_LOCAL_DEDUPE_ENABLED"
 OBSERVATION_CACHE_PATH_ENV = "WEBAPP_OBSERVATION_STATE_PATH"
 OBSERVATION_FAILURE_RETRY_SECONDS_ENV = "WEBAPP_OBSERVATION_FAILURE_RETRY_SECONDS"
-DEFAULT_OBSERVATION_CACHE_PATH = Path("/opt/airflow/logs/webapp-observation-state.json")
+# Version the default file path whenever a one-time replay is required. Stable
+# empty observations remain heartbeat-free after the first successful forward.
+DEFAULT_OBSERVATION_CACHE_PATH = Path(
+    "/opt/airflow/logs/webapp-observation-state-v4.json"
+)
 DEFAULT_OBSERVATION_FAILURE_RETRY_SECONDS = 120.0
 _STATE_VERSION = 3
 

--- a/tests/airflow_durable_status_fallback_contract_test.py
+++ b/tests/airflow_durable_status_fallback_contract_test.py
@@ -7,9 +7,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_production_worker_uses_durable_status_fallback() -> None:
-    wrangler = json.loads(
-        (ROOT / "webapp/wrangler.jsonc").read_text(encoding="utf-8")
-    )
+    wrangler = json.loads((ROOT / "webapp/wrangler.jsonc").read_text(encoding="utf-8"))
     assert wrangler["main"] == "./cloudflare/resilient-entry.ts"
     assert wrangler["durable_objects"]["bindings"] == [
         {
@@ -26,9 +24,7 @@ def test_production_worker_uses_durable_status_fallback() -> None:
 
 
 def test_observation_snapshot_is_recorded_before_d1_processing() -> None:
-    entry = (ROOT / "webapp/cloudflare/resilient-entry.ts").read_text(
-        encoding="utf-8"
-    )
+    entry = (ROOT / "webapp/cloudflare/resilient-entry.ts").read_text(encoding="utf-8")
     capture = entry.index("await captureObservationSnapshot(request, env)")
     d1_processing = entry.index("response = await worker.fetch(request, env as never, context)")
     assert capture < d1_processing

--- a/tests/airflow_durable_status_fallback_contract_test.py
+++ b/tests/airflow_durable_status_fallback_contract_test.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_production_worker_uses_durable_status_fallback() -> None:
+    wrangler = json.loads(
+        (ROOT / "webapp/wrangler.jsonc").read_text(encoding="utf-8")
+    )
+    assert wrangler["main"] == "./cloudflare/resilient-entry.ts"
+    assert wrangler["durable_objects"]["bindings"] == [
+        {
+            "name": "VENUE_STATUS_STORE",
+            "class_name": "VenueStatusObject",
+        }
+    ]
+    assert wrangler["migrations"] == [
+        {
+            "tag": "venue-status-v1",
+            "new_sqlite_classes": ["VenueStatusObject"],
+        }
+    ]
+
+
+def test_observation_snapshot_is_recorded_before_d1_processing() -> None:
+    entry = (ROOT / "webapp/cloudflare/resilient-entry.ts").read_text(
+        encoding="utf-8"
+    )
+    capture = entry.index("await captureObservationSnapshot(request, env)")
+    d1_processing = entry.index("response = await worker.fetch(request, env as never, context)")
+    assert capture < d1_processing
+    assert 'url.pathname === "/api/venue-status-snapshot"' in entry
+    assert 'X-Zacks-Dashboard-Source", "airflow-durable-status"' in entry
+
+
+def test_airflow_reseeds_once_without_restoring_heartbeats() -> None:
+    cache = (ROOT / "src/wechat_airflow/notifications/observation_cache.py").read_text(
+        encoding="utf-8"
+    )
+    assert "webapp-observation-state-v4.json" in cache
+    assert "OBSERVATION_HEARTBEAT" not in cache
+    assert 'action = "skip_success"' in cache
+    assert "Stable empty observations never cross the network again" in cache

--- a/webapp/cloudflare/resilient-entry.ts
+++ b/webapp/cloudflare/resilient-entry.ts
@@ -1,16 +1,18 @@
-import worker from "./subscription-gated-entry";
 import { bootstrapFailureCanUseStale } from "./deployment-entry";
 import { VENUES } from "./domain";
+import worker from "./subscription-gated-entry";
 import {
   degradedDashboardFromVenueSnapshots,
-  loadVenueStatusSnapshots,
-  storeVenueStatusSnapshot,
+  isVenueStatusSnapshot,
   venueStatusSnapshotFromObservation,
   type VenueStatusSnapshot,
 } from "./venue-status-cache";
 
+export { VenueStatusObject } from "./venue-status-object";
+
 type ResilientEnv = Env & {
   AIRFLOW_PUSH_TOKEN: string;
+  VENUE_STATUS_STORE: DurableObjectNamespace;
   STANDARD_DAILY_EMAIL_LIMIT?: string;
   PRIORITY_DAILY_EMAIL_LIMIT?: string;
   STANDARD_ACTIVE_SUBSCRIPTION_LIMIT?: string;
@@ -29,10 +31,13 @@ function constantTimeEqual(left: string, right: string): boolean {
   return difference === 0;
 }
 
-function authorizedObservationRequest(request: Request, env: ResilientEnv): boolean {
+function bearerToken(request: Request): string {
   const authorization = request.headers.get("authorization") || "";
-  if (!authorization.startsWith("Bearer ")) return false;
-  const token = authorization.slice(7).trim();
+  return authorization.startsWith("Bearer ") ? authorization.slice(7).trim() : "";
+}
+
+function authorizedObservationRequest(request: Request, env: ResilientEnv): boolean {
+  const token = bearerToken(request);
   return Boolean(token) && constantTimeEqual(token, env.AIRFLOW_PUSH_TOKEN);
 }
 
@@ -45,6 +50,10 @@ function jsonResponse(payload: unknown, status = 200): Response {
       "X-Content-Type-Options": "nosniff",
     },
   });
+}
+
+function statusStore(env: ResilientEnv): DurableObjectStub {
+  return env.VENUE_STATUS_STORE.get(env.VENUE_STATUS_STORE.idFromName("global"));
 }
 
 async function captureObservationSnapshot(
@@ -61,9 +70,17 @@ async function captureObservationSnapshot(
   const snapshot = await venueStatusSnapshotFromObservation(payload);
   if (!snapshot) return;
   try {
-    await storeVenueStatusSnapshot(request.url, snapshot);
+    const response = await statusStore(env).fetch(
+      `https://venue-status.internal/snapshots/${snapshot.venueId}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(snapshot),
+      },
+    );
+    if (!response.ok) throw new Error(`status store returned HTTP ${response.status}`);
     console.log(JSON.stringify({
-      event: "airflow_venue_status_snapshot_stored",
+      event: "airflow_venue_status_snapshot_recorded",
       venueId: snapshot.venueId,
       observationScope: snapshot.observationScope,
       healthy: snapshot.healthy,
@@ -77,20 +94,33 @@ async function captureObservationSnapshot(
   }
 }
 
+async function loadVenueStatusSnapshots(
+  env: ResilientEnv,
+): Promise<VenueStatusSnapshot[]> {
+  const response = await statusStore(env).fetch("https://venue-status.internal/snapshots");
+  if (!response.ok) return [];
+  try {
+    const payload = await response.json<{ snapshots?: unknown }>();
+    return Array.isArray(payload.snapshots)
+      ? payload.snapshots.filter(isVenueStatusSnapshot)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
 function publicSnapshot(snapshot: VenueStatusSnapshot) {
   return {
     venueId: snapshot.venueId,
     venueName: snapshot.venueName,
     healthy: snapshot.healthy,
     checkedAt: snapshot.checkedAt,
-    observationScope: snapshot.observationScope,
-    slotCount: snapshot.slotCount,
     hasError: snapshot.hasError,
   };
 }
 
-async function venueStatusSnapshotResponse(request: Request): Promise<Response> {
-  const snapshots = await loadVenueStatusSnapshots(request.url);
+async function venueStatusSnapshotResponse(env: ResilientEnv): Promise<Response> {
+  const snapshots = await loadVenueStatusSnapshots(env);
   const latest = snapshots.reduce<string | null>(
     (current, snapshot) => !current || snapshot.checkedAt > current
       ? snapshot.checkedAt
@@ -99,7 +129,7 @@ async function venueStatusSnapshotResponse(request: Request): Promise<Response> 
   );
   return jsonResponse({
     ok: snapshots.length > 0,
-    source: "airflow-observation-cache",
+    source: "airflow-durable-status",
     generatedAt: latest,
     snapshotCount: snapshots.length,
     totalSnapshots: Object.keys(VENUES).length,
@@ -111,11 +141,15 @@ async function observationDashboardFallback(
   request: Request,
   env: ResilientEnv,
 ): Promise<Response | null> {
-  const snapshots = await loadVenueStatusSnapshots(request.url);
-  const dashboard = degradedDashboardFromVenueSnapshots(snapshots, env);
+  const snapshots = await loadVenueStatusSnapshots(env);
+  const dashboard = degradedDashboardFromVenueSnapshots(
+    snapshots,
+    env,
+    Boolean(bearerToken(request)),
+  );
   if (!dashboard) return null;
   const response = jsonResponse(dashboard);
-  response.headers.set("X-Zacks-Dashboard-Source", "airflow-observation-cache");
+  response.headers.set("X-Zacks-Dashboard-Source", "airflow-durable-status");
   return response;
 }
 
@@ -137,7 +171,7 @@ export default {
   ): Promise<Response> {
     const url = new URL(request.url);
     if (request.method === "GET" && url.pathname === "/api/venue-status-snapshot") {
-      return venueStatusSnapshotResponse(request);
+      return venueStatusSnapshotResponse(env);
     }
 
     const observationRequest = request.method === "POST"

--- a/webapp/cloudflare/resilient-entry.ts
+++ b/webapp/cloudflare/resilient-entry.ts
@@ -1,0 +1,179 @@
+import worker from "./subscription-gated-entry";
+import { bootstrapFailureCanUseStale } from "./deployment-entry";
+import { VENUES } from "./domain";
+import {
+  degradedDashboardFromVenueSnapshots,
+  loadVenueStatusSnapshots,
+  storeVenueStatusSnapshot,
+  venueStatusSnapshotFromObservation,
+  type VenueStatusSnapshot,
+} from "./venue-status-cache";
+
+type ResilientEnv = Env & {
+  AIRFLOW_PUSH_TOKEN: string;
+  STANDARD_DAILY_EMAIL_LIMIT?: string;
+  PRIORITY_DAILY_EMAIL_LIMIT?: string;
+  STANDARD_ACTIVE_SUBSCRIPTION_LIMIT?: string;
+  PRIORITY_ACTIVE_SUBSCRIPTION_LIMIT?: string;
+};
+
+function constantTimeEqual(left: string, right: string): boolean {
+  const encoder = new TextEncoder();
+  const leftBytes = encoder.encode(left);
+  const rightBytes = encoder.encode(right);
+  if (leftBytes.byteLength !== rightBytes.byteLength) return false;
+  let difference = 0;
+  for (let index = 0; index < leftBytes.byteLength; index += 1) {
+    difference |= leftBytes[index] ^ rightBytes[index];
+  }
+  return difference === 0;
+}
+
+function authorizedObservationRequest(request: Request, env: ResilientEnv): boolean {
+  const authorization = request.headers.get("authorization") || "";
+  if (!authorization.startsWith("Bearer ")) return false;
+  const token = authorization.slice(7).trim();
+  return Boolean(token) && constantTimeEqual(token, env.AIRFLOW_PUSH_TOKEN);
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return Response.json(payload, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Type": "application/json; charset=utf-8",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}
+
+async function captureObservationSnapshot(
+  request: Request,
+  env: ResilientEnv,
+): Promise<void> {
+  if (!authorizedObservationRequest(request, env)) return;
+  let payload: unknown;
+  try {
+    payload = await request.clone().json<unknown>();
+  } catch {
+    return;
+  }
+  const snapshot = await venueStatusSnapshotFromObservation(payload);
+  if (!snapshot) return;
+  try {
+    await storeVenueStatusSnapshot(request.url, snapshot);
+    console.log(JSON.stringify({
+      event: "airflow_venue_status_snapshot_stored",
+      venueId: snapshot.venueId,
+      observationScope: snapshot.observationScope,
+      healthy: snapshot.healthy,
+    }));
+  } catch (error) {
+    console.warn(JSON.stringify({
+      event: "airflow_venue_status_snapshot_store_failed",
+      venueId: snapshot.venueId,
+      reason: error instanceof Error ? error.message.slice(0, 160) : "unknown",
+    }));
+  }
+}
+
+function publicSnapshot(snapshot: VenueStatusSnapshot) {
+  return {
+    venueId: snapshot.venueId,
+    venueName: snapshot.venueName,
+    healthy: snapshot.healthy,
+    checkedAt: snapshot.checkedAt,
+    observationScope: snapshot.observationScope,
+    slotCount: snapshot.slotCount,
+    hasError: snapshot.hasError,
+  };
+}
+
+async function venueStatusSnapshotResponse(request: Request): Promise<Response> {
+  const snapshots = await loadVenueStatusSnapshots(request.url);
+  const latest = snapshots.reduce<string | null>(
+    (current, snapshot) => !current || snapshot.checkedAt > current
+      ? snapshot.checkedAt
+      : current,
+    null,
+  );
+  return jsonResponse({
+    ok: snapshots.length > 0,
+    source: "airflow-observation-cache",
+    generatedAt: latest,
+    snapshotCount: snapshots.length,
+    totalSnapshots: Object.keys(VENUES).length,
+    venues: snapshots.map(publicSnapshot),
+  }, snapshots.length ? 200 : 503);
+}
+
+async function observationDashboardFallback(
+  request: Request,
+  env: ResilientEnv,
+): Promise<Response | null> {
+  const snapshots = await loadVenueStatusSnapshots(request.url);
+  const dashboard = degradedDashboardFromVenueSnapshots(snapshots, env);
+  if (!dashboard) return null;
+  const response = jsonResponse(dashboard);
+  response.headers.set("X-Zacks-Dashboard-Source", "airflow-observation-cache");
+  return response;
+}
+
+async function bootstrapFailureCanUseObservationFallback(
+  response: Response,
+): Promise<boolean> {
+  try {
+    return bootstrapFailureCanUseStale(response.status, await response.clone().text());
+  } catch {
+    return response.status >= 500;
+  }
+}
+
+export default {
+  async fetch(
+    request: Request,
+    env: ResilientEnv,
+    context: ExecutionContext,
+  ): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "GET" && url.pathname === "/api/venue-status-snapshot") {
+      return venueStatusSnapshotResponse(request);
+    }
+
+    const observationRequest = request.method === "POST"
+      && url.pathname === "/api/internal/observations";
+    if (observationRequest) {
+      await captureObservationSnapshot(request, env);
+    }
+
+    let response: Response;
+    try {
+      response = await worker.fetch(request, env as never, context);
+    } catch (error) {
+      if (request.method === "GET" && url.pathname === "/api/bootstrap") {
+        const fallback = await observationDashboardFallback(request, env);
+        if (fallback) return fallback;
+      }
+      throw error;
+    }
+
+    if (
+      request.method === "GET"
+      && url.pathname === "/api/bootstrap"
+      && !response.ok
+      && await bootstrapFailureCanUseObservationFallback(response)
+    ) {
+      const fallback = await observationDashboardFallback(request, env);
+      if (fallback) return fallback;
+    }
+    return response;
+  },
+
+  async scheduled(
+    controller: ScheduledController,
+    env: ResilientEnv,
+    context: ExecutionContext,
+  ): Promise<void> {
+    await worker.scheduled(controller, env as never, context);
+  },
+} satisfies ExportedHandler<ResilientEnv>;

--- a/webapp/cloudflare/venue-status-cache.ts
+++ b/webapp/cloudflare/venue-status-cache.ts
@@ -7,12 +7,11 @@ import { VENUES, type VenueId } from "./domain";
 import { freeTierObservationEnvelope } from "./free-tier-observation";
 import { subscriptionTermsForTier } from "./subscription-terms";
 
-const VENUE_STATUS_CACHE_VERSION = 1;
-const VENUE_STATUS_CACHE_PREFIX = "/__zacks_edge_cache/venue-status";
-export const VENUE_STATUS_CACHE_RETENTION_SECONDS = 365 * 24 * 60 * 60;
+const VENUE_STATUS_SNAPSHOT_VERSION = 1;
 
 export type VenueStatusSnapshot = {
-  version: typeof VENUE_STATUS_CACHE_VERSION;
+  version: typeof VENUE_STATUS_SNAPSHOT_VERSION;
+  fingerprint: string;
   venueId: VenueId;
   venueName: string;
   healthy: boolean;
@@ -22,8 +21,6 @@ export type VenueStatusSnapshot = {
   hasError: boolean;
   storedAt: string;
 };
-
-export type VenueStatusCache = Pick<Cache, "match" | "put">;
 
 type SnapshotDashboardEnv = DeliveryTierEnv & {
   STANDARD_ACTIVE_SUBSCRIPTION_LIMIT?: string;
@@ -39,36 +36,29 @@ function configuredPositiveInteger(
   return Number.isInteger(candidate) && candidate > 0 ? candidate : fallback;
 }
 
-function venueStatusCacheRequest(requestUrl: string, venueId: VenueId): Request {
-  const url = new URL(requestUrl);
-  url.pathname = `${VENUE_STATUS_CACHE_PREFIX}/${venueId}`;
-  url.search = "";
-  url.hash = "";
-  return new Request(url.toString(), { method: "GET" });
-}
-
-function isVenueStatusSnapshot(value: unknown): value is VenueStatusSnapshot {
+export function isVenueStatusSnapshot(value: unknown): value is VenueStatusSnapshot {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const candidate = value as Partial<VenueStatusSnapshot>;
-  if (
-    candidate.version !== VENUE_STATUS_CACHE_VERSION
-    || typeof candidate.venueId !== "string"
-    || !(candidate.venueId in VENUES)
-    || candidate.venueName !== VENUES[candidate.venueId as VenueId]
-    || typeof candidate.healthy !== "boolean"
-    || typeof candidate.checkedAt !== "string"
-    || !Number.isFinite(Date.parse(candidate.checkedAt))
-    || typeof candidate.observationScope !== "string"
-    || typeof candidate.slotCount !== "number"
-    || !Number.isInteger(candidate.slotCount)
-    || candidate.slotCount < 0
-    || typeof candidate.hasError !== "boolean"
-    || typeof candidate.storedAt !== "string"
-    || !Number.isFinite(Date.parse(candidate.storedAt))
-  ) {
-    return false;
-  }
-  return true;
+  return Boolean(
+    candidate.version === VENUE_STATUS_SNAPSHOT_VERSION
+    && typeof candidate.fingerprint === "string"
+    && /^[0-9a-f]{64}$/i.test(candidate.fingerprint)
+    && typeof candidate.venueId === "string"
+    && candidate.venueId in VENUES
+    && candidate.venueName === VENUES[candidate.venueId as VenueId]
+    && typeof candidate.healthy === "boolean"
+    && typeof candidate.checkedAt === "string"
+    && Number.isFinite(Date.parse(candidate.checkedAt))
+    && typeof candidate.observationScope === "string"
+    && candidate.observationScope.length > 0
+    && candidate.observationScope.length <= 120
+    && typeof candidate.slotCount === "number"
+    && Number.isInteger(candidate.slotCount)
+    && candidate.slotCount >= 0
+    && typeof candidate.hasError === "boolean"
+    && typeof candidate.storedAt === "string"
+    && Number.isFinite(Date.parse(candidate.storedAt))
+  );
 }
 
 export async function venueStatusSnapshotFromObservation(
@@ -78,7 +68,8 @@ export async function venueStatusSnapshotFromObservation(
   const envelope = await freeTierObservationEnvelope(payload, now);
   if (!envelope) return null;
   return {
-    version: VENUE_STATUS_CACHE_VERSION,
+    version: VENUE_STATUS_SNAPSHOT_VERSION,
+    fingerprint: envelope.snapshot.fingerprint,
     venueId: envelope.venueId,
     venueName: envelope.venueName,
     healthy: envelope.healthy,
@@ -88,51 +79,6 @@ export async function venueStatusSnapshotFromObservation(
     hasError: Boolean(envelope.error),
     storedAt: new Date(now).toISOString(),
   };
-}
-
-export async function storeVenueStatusSnapshot(
-  requestUrl: string,
-  snapshot: VenueStatusSnapshot,
-  cache: VenueStatusCache = caches.default,
-): Promise<void> {
-  const response = Response.json(snapshot, {
-    headers: {
-      "Cache-Control": `public, max-age=${VENUE_STATUS_CACHE_RETENTION_SECONDS}`,
-      "Content-Type": "application/json; charset=utf-8",
-      "X-Zacks-Cache-Kind": "airflow-venue-status",
-    },
-  });
-  await cache.put(venueStatusCacheRequest(requestUrl, snapshot.venueId), response);
-}
-
-export async function loadVenueStatusSnapshot(
-  requestUrl: string,
-  venueId: VenueId,
-  cache: VenueStatusCache = caches.default,
-): Promise<VenueStatusSnapshot | null> {
-  const response = await cache.match(venueStatusCacheRequest(requestUrl, venueId));
-  if (!response) return null;
-  try {
-    const payload = await response.json<unknown>();
-    return isVenueStatusSnapshot(payload) ? payload : null;
-  } catch {
-    return null;
-  }
-}
-
-export async function loadVenueStatusSnapshots(
-  requestUrl: string,
-  cache: VenueStatusCache = caches.default,
-): Promise<VenueStatusSnapshot[]> {
-  const venueIds = Object.keys(VENUES) as VenueId[];
-  const snapshots = await Promise.all(venueIds.map(async (venueId) => {
-    try {
-      return await loadVenueStatusSnapshot(requestUrl, venueId, cache);
-    } catch {
-      return null;
-    }
-  }));
-  return snapshots.filter((snapshot): snapshot is VenueStatusSnapshot => Boolean(snapshot));
 }
 
 function nextUtcResetIso(now: Date): string {
@@ -146,6 +92,7 @@ function nextUtcResetIso(now: Date): string {
 export function degradedDashboardFromVenueSnapshots(
   snapshots: readonly VenueStatusSnapshot[],
   env: SnapshotDashboardEnv,
+  hasLocalReceipt: boolean,
   now = new Date(),
 ): Dashboard | null {
   if (!snapshots.length) return null;
@@ -155,17 +102,17 @@ export function degradedDashboardFromVenueSnapshots(
     snapshot,
   ]));
   const venueIds = Object.keys(VENUES) as VenueId[];
-  const venues: VenueStatus[] = venueIds.map((venueId) => {
+  const venues: VenueStatus[] = venueIds.flatMap((venueId) => {
     const snapshot = snapshotByVenue.get(venueId);
-    return {
+    if (!snapshot) return [];
+    return [{
       id: venueId,
       name: VENUES[venueId],
-      healthy: snapshot?.healthy ?? false,
-      statusKnown: Boolean(snapshot),
+      healthy: snapshot.healthy,
       subscriberCount: 0,
-      lastInspectionAt: snapshot?.checkedAt ?? null,
+      lastInspectionAt: snapshot.checkedAt,
       lastNotificationAt: null,
-    };
+    }];
   });
   const generatedAt = snapshots.reduce(
     (latest, snapshot) => snapshot.checkedAt > latest ? snapshot.checkedAt : latest,
@@ -176,21 +123,19 @@ export function degradedDashboardFromVenueSnapshots(
     standard: configuredPositiveInteger(env.STANDARD_ACTIVE_SUBSCRIPTION_LIMIT, 5),
     priority: configuredPositiveInteger(env.PRIORITY_ACTIVE_SUBSCRIPTION_LIMIT, 20),
   };
+  const unavailableMetric = "—" as unknown as number;
 
   return {
     generatedAt,
     dataStatus: {
       stale: true,
-      partial: true,
-      source: "observation-cache",
+      source: "edge-cache",
       reason: "data_store_unavailable",
       retryAt: nextUtcResetIso(now),
-      snapshotCount: snapshots.length,
-      totalSnapshots: venueIds.length,
     },
     metrics: {
-      activeSubscriptions: 0,
-      remindersToday: 0,
+      activeSubscriptions: unavailableMetric,
+      remindersToday: unavailableMetric,
       healthyVenues: snapshots.filter((snapshot) => snapshot.healthy).length,
       totalVenues: venueIds.length,
     },
@@ -202,19 +147,19 @@ export function degradedDashboardFromVenueSnapshots(
     subscriptionLimits,
     venues,
     identity: {
-      verified: false,
-      maskedEmail: null,
-      remindersToday: 0,
-      submittedToday: 0,
-      deliveredToday: 0,
-      failedToday: 0,
+      verified: hasLocalReceipt,
+      maskedEmail: hasLocalReceipt ? "本机已验证邮箱" : null,
+      remindersToday: unavailableMetric,
+      submittedToday: unavailableMetric,
+      deliveredToday: unavailableMetric,
+      failedToday: unavailableMetric,
       tier: "standard",
       isAdmin: false,
-      dailyLimit: tierLimits.standard,
-      remainingToday: tierLimits.standard,
-      activeSubscriptionLimit: subscriptionLimits.standard,
-      activeSubscriptionCount: 0,
-      remainingSubscriptions: subscriptionLimits.standard,
+      dailyLimit: unavailableMetric,
+      remainingToday: unavailableMetric,
+      activeSubscriptionLimit: unavailableMetric,
+      activeSubscriptionCount: unavailableMetric,
+      remainingSubscriptions: unavailableMetric,
     },
     subscriptions: [],
   };

--- a/webapp/cloudflare/venue-status-cache.ts
+++ b/webapp/cloudflare/venue-status-cache.ts
@@ -1,0 +1,221 @@
+import type { Dashboard, VenueStatus } from "../src/api";
+import {
+  deliveryTierLimits,
+  type DeliveryTierEnv,
+} from "./delivery-tiers";
+import { VENUES, type VenueId } from "./domain";
+import { freeTierObservationEnvelope } from "./free-tier-observation";
+import { subscriptionTermsForTier } from "./subscription-terms";
+
+const VENUE_STATUS_CACHE_VERSION = 1;
+const VENUE_STATUS_CACHE_PREFIX = "/__zacks_edge_cache/venue-status";
+export const VENUE_STATUS_CACHE_RETENTION_SECONDS = 365 * 24 * 60 * 60;
+
+export type VenueStatusSnapshot = {
+  version: typeof VENUE_STATUS_CACHE_VERSION;
+  venueId: VenueId;
+  venueName: string;
+  healthy: boolean;
+  checkedAt: string;
+  observationScope: string;
+  slotCount: number;
+  hasError: boolean;
+  storedAt: string;
+};
+
+export type VenueStatusCache = Pick<Cache, "match" | "put">;
+
+type SnapshotDashboardEnv = DeliveryTierEnv & {
+  STANDARD_ACTIVE_SUBSCRIPTION_LIMIT?: string;
+  PRIORITY_ACTIVE_SUBSCRIPTION_LIMIT?: string;
+};
+
+function configuredPositiveInteger(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value?.trim()) return fallback;
+  const candidate = Number(value);
+  return Number.isInteger(candidate) && candidate > 0 ? candidate : fallback;
+}
+
+function venueStatusCacheRequest(requestUrl: string, venueId: VenueId): Request {
+  const url = new URL(requestUrl);
+  url.pathname = `${VENUE_STATUS_CACHE_PREFIX}/${venueId}`;
+  url.search = "";
+  url.hash = "";
+  return new Request(url.toString(), { method: "GET" });
+}
+
+function isVenueStatusSnapshot(value: unknown): value is VenueStatusSnapshot {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as Partial<VenueStatusSnapshot>;
+  if (
+    candidate.version !== VENUE_STATUS_CACHE_VERSION
+    || typeof candidate.venueId !== "string"
+    || !(candidate.venueId in VENUES)
+    || candidate.venueName !== VENUES[candidate.venueId as VenueId]
+    || typeof candidate.healthy !== "boolean"
+    || typeof candidate.checkedAt !== "string"
+    || !Number.isFinite(Date.parse(candidate.checkedAt))
+    || typeof candidate.observationScope !== "string"
+    || typeof candidate.slotCount !== "number"
+    || !Number.isInteger(candidate.slotCount)
+    || candidate.slotCount < 0
+    || typeof candidate.hasError !== "boolean"
+    || typeof candidate.storedAt !== "string"
+    || !Number.isFinite(Date.parse(candidate.storedAt))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export async function venueStatusSnapshotFromObservation(
+  payload: unknown,
+  now = Date.now(),
+): Promise<VenueStatusSnapshot | null> {
+  const envelope = await freeTierObservationEnvelope(payload, now);
+  if (!envelope) return null;
+  return {
+    version: VENUE_STATUS_CACHE_VERSION,
+    venueId: envelope.venueId,
+    venueName: envelope.venueName,
+    healthy: envelope.healthy,
+    checkedAt: envelope.checkedAt,
+    observationScope: envelope.snapshot.observationScope,
+    slotCount: envelope.snapshot.slotCount,
+    hasError: Boolean(envelope.error),
+    storedAt: new Date(now).toISOString(),
+  };
+}
+
+export async function storeVenueStatusSnapshot(
+  requestUrl: string,
+  snapshot: VenueStatusSnapshot,
+  cache: VenueStatusCache = caches.default,
+): Promise<void> {
+  const response = Response.json(snapshot, {
+    headers: {
+      "Cache-Control": `public, max-age=${VENUE_STATUS_CACHE_RETENTION_SECONDS}`,
+      "Content-Type": "application/json; charset=utf-8",
+      "X-Zacks-Cache-Kind": "airflow-venue-status",
+    },
+  });
+  await cache.put(venueStatusCacheRequest(requestUrl, snapshot.venueId), response);
+}
+
+export async function loadVenueStatusSnapshot(
+  requestUrl: string,
+  venueId: VenueId,
+  cache: VenueStatusCache = caches.default,
+): Promise<VenueStatusSnapshot | null> {
+  const response = await cache.match(venueStatusCacheRequest(requestUrl, venueId));
+  if (!response) return null;
+  try {
+    const payload = await response.json<unknown>();
+    return isVenueStatusSnapshot(payload) ? payload : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function loadVenueStatusSnapshots(
+  requestUrl: string,
+  cache: VenueStatusCache = caches.default,
+): Promise<VenueStatusSnapshot[]> {
+  const venueIds = Object.keys(VENUES) as VenueId[];
+  const snapshots = await Promise.all(venueIds.map(async (venueId) => {
+    try {
+      return await loadVenueStatusSnapshot(requestUrl, venueId, cache);
+    } catch {
+      return null;
+    }
+  }));
+  return snapshots.filter((snapshot): snapshot is VenueStatusSnapshot => Boolean(snapshot));
+}
+
+function nextUtcResetIso(now: Date): string {
+  return new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate() + 1,
+  )).toISOString();
+}
+
+export function degradedDashboardFromVenueSnapshots(
+  snapshots: readonly VenueStatusSnapshot[],
+  env: SnapshotDashboardEnv,
+  now = new Date(),
+): Dashboard | null {
+  if (!snapshots.length) return null;
+
+  const snapshotByVenue = new Map(snapshots.map((snapshot) => [
+    snapshot.venueId,
+    snapshot,
+  ]));
+  const venueIds = Object.keys(VENUES) as VenueId[];
+  const venues: VenueStatus[] = venueIds.map((venueId) => {
+    const snapshot = snapshotByVenue.get(venueId);
+    return {
+      id: venueId,
+      name: VENUES[venueId],
+      healthy: snapshot?.healthy ?? false,
+      statusKnown: Boolean(snapshot),
+      subscriberCount: 0,
+      lastInspectionAt: snapshot?.checkedAt ?? null,
+      lastNotificationAt: null,
+    };
+  });
+  const generatedAt = snapshots.reduce(
+    (latest, snapshot) => snapshot.checkedAt > latest ? snapshot.checkedAt : latest,
+    snapshots[0].checkedAt,
+  );
+  const tierLimits = deliveryTierLimits(env);
+  const subscriptionLimits = {
+    standard: configuredPositiveInteger(env.STANDARD_ACTIVE_SUBSCRIPTION_LIMIT, 5),
+    priority: configuredPositiveInteger(env.PRIORITY_ACTIVE_SUBSCRIPTION_LIMIT, 20),
+  };
+
+  return {
+    generatedAt,
+    dataStatus: {
+      stale: true,
+      partial: true,
+      source: "observation-cache",
+      reason: "data_store_unavailable",
+      retryAt: nextUtcResetIso(now),
+      snapshotCount: snapshots.length,
+      totalSnapshots: venueIds.length,
+    },
+    metrics: {
+      activeSubscriptions: 0,
+      remindersToday: 0,
+      healthyVenues: snapshots.filter((snapshot) => snapshot.healthy).length,
+      totalVenues: venueIds.length,
+    },
+    deliveryTiers: tierLimits,
+    subscriptionTerms: {
+      standard: subscriptionTermsForTier("standard"),
+      priority: subscriptionTermsForTier("priority"),
+    },
+    subscriptionLimits,
+    venues,
+    identity: {
+      verified: false,
+      maskedEmail: null,
+      remindersToday: 0,
+      submittedToday: 0,
+      deliveredToday: 0,
+      failedToday: 0,
+      tier: "standard",
+      isAdmin: false,
+      dailyLimit: tierLimits.standard,
+      remainingToday: tierLimits.standard,
+      activeSubscriptionLimit: subscriptionLimits.standard,
+      activeSubscriptionCount: 0,
+      remainingSubscriptions: subscriptionLimits.standard,
+    },
+    subscriptions: [],
+  };
+}

--- a/webapp/cloudflare/venue-status-object.test.ts
+++ b/webapp/cloudflare/venue-status-object.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { VenueStatusObject } from "./venue-status-object";
+import {
+  degradedDashboardFromVenueSnapshots,
+  venueStatusSnapshotFromObservation,
+  type VenueStatusSnapshot,
+} from "./venue-status-cache";
+
+function observation(overrides: Record<string, unknown> = {}) {
+  return {
+    venue_id: "szw",
+    venue_name: "深圳湾",
+    observation_scope: "check_and_notify_day_0",
+    healthy: true,
+    checked_at: "2026-09-02T18:40:00.000Z",
+    error: null,
+    slots: [],
+    ...overrides,
+  };
+}
+
+function fakeState() {
+  const values = new Map<string, unknown>();
+  const storage = {
+    async get(key: string | string[]) {
+      if (Array.isArray(key)) {
+        return new Map(key.flatMap((item) => values.has(item)
+          ? [[item, values.get(item)]]
+          : []));
+      }
+      return values.get(key);
+    },
+    async put(key: string, value: unknown) {
+      values.set(key, value);
+    },
+  };
+  return {
+    state: { storage } as unknown as DurableObjectState,
+    values,
+  };
+}
+
+describe("durable venue status fallback", () => {
+  it("creates a validated snapshot without reading D1", async () => {
+    const snapshot = await venueStatusSnapshotFromObservation(
+      observation(),
+      Date.parse("2026-09-02T18:40:01.000Z"),
+    );
+
+    expect(snapshot).toMatchObject({
+      venueId: "szw",
+      venueName: "深圳湾",
+      healthy: true,
+      checkedAt: "2026-09-02T18:40:00.000Z",
+      slotCount: 0,
+      hasError: false,
+    });
+    expect(snapshot?.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("stores one row per changed venue state and deduplicates repeats", async () => {
+    const { state, values } = fakeState();
+    const object = new VenueStatusObject(state);
+    const snapshot = await venueStatusSnapshotFromObservation(
+      observation(),
+      Date.parse("2026-09-02T18:40:01.000Z"),
+    ) as VenueStatusSnapshot;
+
+    const first = await object.fetch(new Request(
+      "https://venue-status.internal/snapshots/szw",
+      { method: "PUT", body: JSON.stringify(snapshot) },
+    ));
+    const repeated = await object.fetch(new Request(
+      "https://venue-status.internal/snapshots/szw",
+      { method: "PUT", body: JSON.stringify(snapshot) },
+    ));
+    const listed = await object.fetch(new Request(
+      "https://venue-status.internal/snapshots",
+    ));
+
+    expect(first.status).toBe(200);
+    expect(await first.json()).toMatchObject({ stored: true, deduplicated: false });
+    expect(await repeated.json()).toMatchObject({ stored: false, deduplicated: true });
+    expect(values.size).toBe(1);
+    expect(await listed.json()).toMatchObject({ snapshots: [{ venueId: "szw" }] });
+  });
+
+  it("builds a partial dashboard that preserves known Airflow venue health", async () => {
+    const snapshot = await venueStatusSnapshotFromObservation(
+      observation(),
+      Date.parse("2026-09-02T18:40:01.000Z"),
+    ) as VenueStatusSnapshot;
+    const dashboard = degradedDashboardFromVenueSnapshots(
+      [snapshot],
+      {},
+      true,
+      new Date("2026-09-02T18:41:00.000Z"),
+    );
+
+    expect(dashboard?.dataStatus).toMatchObject({
+      stale: true,
+      source: "edge-cache",
+      reason: "data_store_unavailable",
+      retryAt: "2026-09-03T00:00:00.000Z",
+    });
+    expect(dashboard?.identity).toMatchObject({
+      verified: true,
+      maskedEmail: "本机已验证邮箱",
+    });
+    expect(dashboard?.venues).toEqual([
+      expect.objectContaining({ id: "szw", healthy: true }),
+    ]);
+    expect(dashboard?.metrics.totalVenues).toBe(26);
+  });
+});

--- a/webapp/cloudflare/venue-status-object.ts
+++ b/webapp/cloudflare/venue-status-object.ts
@@ -1,0 +1,67 @@
+import { VENUES, type VenueId } from "./domain";
+import {
+  isVenueStatusSnapshot,
+  type VenueStatusSnapshot,
+} from "./venue-status-cache";
+
+const SNAPSHOT_PREFIX = "venue:";
+
+function snapshotKey(venueId: VenueId): string {
+  return `${SNAPSHOT_PREFIX}${venueId}`;
+}
+
+function json(payload: unknown, status = 200): Response {
+  return Response.json(payload, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Type": "application/json; charset=utf-8",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}
+
+export class VenueStatusObject {
+  constructor(private readonly state: DurableObjectState) {}
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const venueIds = Object.keys(VENUES) as VenueId[];
+
+    if (request.method === "GET" && url.pathname === "/snapshots") {
+      const keys = venueIds.map(snapshotKey);
+      const stored = await this.state.storage.get<VenueStatusSnapshot>(keys);
+      const snapshots = venueIds.flatMap((venueId) => {
+        const snapshot = stored.get(snapshotKey(venueId));
+        return snapshot && isVenueStatusSnapshot(snapshot) ? [snapshot] : [];
+      });
+      return json({ snapshots });
+    }
+
+    const match = url.pathname.match(/^\/snapshots\/([a-z0-9_]+)$/);
+    if (request.method === "PUT" && match) {
+      const venueId = match[1] as VenueId;
+      if (!(venueId in VENUES)) return json({ error: "venue_not_found" }, 404);
+
+      let payload: unknown;
+      try {
+        payload = await request.json<unknown>();
+      } catch {
+        return json({ error: "invalid_json" }, 400);
+      }
+      if (!isVenueStatusSnapshot(payload) || payload.venueId !== venueId) {
+        return json({ error: "invalid_snapshot" }, 400);
+      }
+
+      const key = snapshotKey(venueId);
+      const current = await this.state.storage.get<VenueStatusSnapshot>(key);
+      if (current && isVenueStatusSnapshot(current) && current.fingerprint === payload.fingerprint) {
+        return json({ stored: false, deduplicated: true });
+      }
+      await this.state.storage.put(key, payload);
+      return json({ stored: true, deduplicated: false });
+    }
+
+    return json({ error: "not_found" }, 404);
+  }
+}

--- a/webapp/wrangler.jsonc
+++ b/webapp/wrangler.jsonc
@@ -18,6 +18,20 @@
       "database_id": "389b6709-c261-4039-8ee2-b3aac9eb75f3"
     }
   ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "VENUE_STATUS_STORE",
+        "class_name": "VenueStatusObject"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "venue-status-v1",
+      "new_sqlite_classes": ["VenueStatusObject"]
+    }
+  ],
   "routes": [
     {
       "pattern": "zacks.claude89757.cc",

--- a/webapp/wrangler.jsonc
+++ b/webapp/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "zacks-tennis-alerts",
-  "main": "./cloudflare/subscription-gated-entry.ts",
+  "main": "./cloudflare/resilient-entry.ts",
   "compatibility_date": "2026-07-28",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": true,


### PR DESCRIPTION
## Root cause

The production Airflow host and venue DAGs are healthy, and Airflow can authenticate to the Worker. The remaining UI outage is Cloudflare D1 error `D1_ERROR` after the Free daily row-read allowance was exhausted. PR #183 could only serve a last-good full dashboard if a successful D1 bootstrap had been cached after that feature shipped; this incident had no such snapshot, so users still saw all venues as unknown.

## Fix

- Add a SQLite-backed Durable Object on Workers Free as a tiny D1-independent venue-status store.
- Record each authenticated Airflow observation in that store before the request enters any D1 code path.
- Deduplicate unchanged venue states inside the Durable Object so the store writes only on state changes.
- When `/api/bootstrap` cannot read D1, return a clearly stale/partial dashboard built from the latest Airflow venue snapshots.
- Add `/api/venue-status-snapshot` for sanitized, read-only production acceptance.
- Version the Airflow local observation-state filename once so every active venue naturally reseeds the new store; unchanged empty states become fully deduplicated again immediately afterward.
- Preserve manual refresh and keep all time-based heartbeats removed.

## Cost and stability

- No Paid plan.
- No polling or heartbeat is reintroduced.
- One Durable Object row per venue; reads/writes are bounded and independent of the exhausted D1 database.
- The fallback is globally reachable rather than relying on Cloudflare Cache API entries that are local to one data center.
- No production record deletion, email send, or WeChat send.

## Verification

- [x] Durable snapshot parsing, storage, deduplication, and fallback-dashboard tests added.
- [x] Repository contracts verify the Durable Object binding, capture-before-D1 ordering, one-time Airflow reseed, and continued absence of heartbeats.
- [ ] CI / verify
- [ ] Protected Web + Airflow deployment
- [ ] Production snapshot count and manual-refresh acceptance