### PR TITLE
fix(web): remove duplicate refresh nudges

### DIFF
--- a/tests/manual_refresh_no_heartbeat_contract_test.py
+++ b/tests/manual_refresh_no_heartbeat_contract_test.py
@@ -37,8 +37,7 @@ def test_dashboard_refresh_is_user_driven_and_health_is_last_known() -> None:
 
     assert "window.setInterval(() => void refresh()" not in prototype
     assert "onClick={() => void refresh(true)}" in prototype
-    assert "页面数据由用户手动刷新" in prototype
-    assert "点击顶部按钮获取最新数据" in prototype
+    assert 'aria-label="获取最新状态"' in prototype
     assert "后台巡检与页面刷新分开" in prototype
     assert 'const requestPath = options.force ? "/api/bootstrap?refresh=1"' in api
     assert "INSPECTION_FRESHNESS_MS" not in worker

--- a/tests/webapp_subscription_weekdays_wiring_test.py
+++ b/tests/webapp_subscription_weekdays_wiring_test.py
@@ -19,8 +19,7 @@ def test_public_venue_popularity_uses_unique_followers_and_stable_order():
 
     assert "COUNT(DISTINCT s.email)" in worker
     assert "ORDER BY subscriber_count DESC" in worker
-    assert "点按卡片快速创建提醒 · 页面数据由用户手动刷新" in ui
-    assert "点击顶部按钮获取最新数据" in ui
+    assert "点按卡片快速创建提醒" in ui
     assert "right.subscriberCount - left.subscriberCount" in ui
 
 

--- a/tests/webapp_venue_refresh_nudges_test.py
+++ b/tests/webapp_venue_refresh_nudges_test.py
@@ -4,11 +4,11 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_venue_section_avoids_duplicate_refresh_nudges() -> None:
-    main = (ROOT / "webapp/src/main.tsx").read_text(encoding="utf-8")
+    index = (ROOT / "webapp/index.html").read_text(encoding="utf-8")
     prototype = (ROOT / "webapp/src/Prototype.tsx").read_text(encoding="utf-8")
     styles = (ROOT / "webapp/src/venue-section-refresh.css").read_text(encoding="utf-8")
 
-    assert 'import "./venue-section-refresh.css";' in main
+    assert '<link rel="stylesheet" href="/src/venue-section-refresh.css" />' in index
     assert ".venue-section .section-heading > div > p" in styles
     assert ".venue-section .section-heading > div::after" in styles
     assert 'content: "点按卡片快速创建提醒";' in styles

--- a/tests/webapp_venue_refresh_nudges_test.py
+++ b/tests/webapp_venue_refresh_nudges_test.py
@@ -6,9 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 def test_venue_section_avoids_duplicate_refresh_nudges() -> None:
     main = (ROOT / "webapp/src/main.tsx").read_text(encoding="utf-8")
     prototype = (ROOT / "webapp/src/Prototype.tsx").read_text(encoding="utf-8")
-    styles = (ROOT / "webapp/src/venue-section-refresh.css").read_text(
-        encoding="utf-8"
-    )
+    styles = (ROOT / "webapp/src/venue-section-refresh.css").read_text(encoding="utf-8")
 
     assert 'import "./venue-section-refresh.css";' in main
     assert ".venue-section .section-heading > div > p" in styles

--- a/tests/webapp_venue_refresh_nudges_test.py
+++ b/tests/webapp_venue_refresh_nudges_test.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_venue_section_avoids_duplicate_refresh_nudges() -> None:
+    main = (ROOT / "webapp/src/main.tsx").read_text(encoding="utf-8")
+    prototype = (ROOT / "webapp/src/Prototype.tsx").read_text(encoding="utf-8")
+    styles = (ROOT / "webapp/src/venue-section-refresh.css").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'import "./venue-section-refresh.css";' in main
+    assert ".venue-section .section-heading > div > p" in styles
+    assert ".venue-section .section-heading > div::after" in styles
+    assert 'content: "点按卡片快速创建提醒";' in styles
+    assert ".venue-section .section-heading > span" in styles
+    assert styles.count("display: none;") == 2
+    assert 'aria-label="获取最新状态"' in prototype
+    assert "onClick={() => void refresh(true)}" in prototype

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="/src/desktop.css" media="(min-width: 900px)" />
     <link rel="stylesheet" href="/src/desktop-a11y.css" media="(min-width: 900px)" />
     <link rel="stylesheet" href="/src/brand-logo.css" />
+    <link rel="stylesheet" href="/src/venue-section-refresh.css" />
     <title>Zacks 网球提醒</title>
   </head>
   <body>

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -4,6 +4,7 @@ import "@fontsource/roboto/latin-500.css";
 import App from "./App";
 import "./styles.css";
 import "./prototype.css";
+import "./venue-section-refresh.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -4,7 +4,6 @@ import "@fontsource/roboto/latin-500.css";
 import App from "./App";
 import "./styles.css";
 import "./prototype.css";
-import "./venue-section-refresh.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/webapp/src/venue-section-refresh.css
+++ b/webapp/src/venue-section-refresh.css
@@ -1,0 +1,27 @@
+/*
+ * Keep the top status bar as the single refresh affordance. The venue section
+ * should focus on quick subscription creation without repeating refresh cues.
+ */
+.venue-section .section-heading > div > p {
+  display: none;
+}
+
+.venue-section .section-heading > div::after {
+  display: block;
+  margin: 3px 0 0;
+  color: var(--muted);
+  content: "点按卡片快速创建提醒";
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.venue-section .section-heading > span {
+  display: none;
+}
+
+@media (min-width: 900px) {
+  html body .venue-section .section-heading > div::after {
+    margin-top: 5px;
+    font-size: 12px;
+  }
+}


### PR DESCRIPTION
## Summary
- remove the repeated manual-refresh prompts from the venue status section on mobile and desktop
- retain the useful “点按卡片快速创建提醒” guidance
- keep the top status-bar refresh control and all manual-refresh behavior unchanged
- update contract coverage so refresh behavior is protected without requiring duplicate prompt copy

## Risk
Presentation-only Web change. No Airflow, Cloudflare Worker, subscription, email, or WeChat behavior is changed.

## Verification
- added a focused regression contract for the venue-section presentation
- full repository CI should run on this pull request