### PR TITLE
ci: route 0.7.0 through the existing production ship transaction

### DIFF
--- a/.github/workflows/production-host-core-v070.yml
+++ b/.github/workflows/production-host-core-v070.yml
@@ -3,8 +3,6 @@ run-name: production/host-core-0.7.0/${{ github.sha }}
 
 on:
   workflow_dispatch:
-  issue_comment:
-    types: [created]
   schedule:
     - cron: "5 0 4 9 *"
     - cron: "25 0 4 9 *"
@@ -19,11 +17,6 @@ concurrency:
 
 jobs:
   resolve:
-    if: >-
-      github.event_name != 'issue_comment' ||
-      (github.event.issue.number == 39 &&
-       github.event.comment.user.login == github.repository_owner &&
-       github.event.comment.body == '/ops host-core-v070')
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.resolve.outputs.should_run }}

--- a/.github/workflows/production-host-core-v070.yml
+++ b/.github/workflows/production-host-core-v070.yml
@@ -3,6 +3,8 @@ run-name: production/host-core-0.7.0/${{ github.sha }}
 
 on:
   workflow_dispatch:
+  issue_comment:
+    types: [created]
   schedule:
     - cron: "5 0 4 9 *"
     - cron: "25 0 4 9 *"
@@ -17,6 +19,11 @@ concurrency:
 
 jobs:
   resolve:
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.number == 39 &&
+       github.event.comment.user.login == github.repository_owner &&
+       github.event.comment.body == '/ops host-core-v070')
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.resolve.outputs.should_run }}

--- a/.github/workflows/production-ship.yml
+++ b/.github/workflows/production-ship.yml
@@ -82,8 +82,21 @@ jobs:
       - name: Validate version before production mutation
         run: python scripts/release_contract.py --version "${{ inputs.version }}"
 
-  deploy:
+  host_core_cutover:
+    if: inputs.version == '0.7.0'
     needs: contract
+    uses: ./.github/workflows/production-host-core.yml
+    with:
+      operation: full-cutover
+      target_commit: ${{ inputs.target_commit }}
+    secrets: inherit
+
+  deploy:
+    needs: [contract, host_core_cutover]
+    if: >-
+      always() &&
+      needs.contract.result == 'success' &&
+      (inputs.version != '0.7.0' || needs.host_core_cutover.result == 'success')
     uses: ./.github/workflows/production-release.yml
     with:
       mode: apply
@@ -92,8 +105,56 @@ jobs:
       include_sender: ${{ inputs.include_sender }}
     secrets: inherit
 
-  tag:
+  natural_cycles:
+    if: inputs.version == '0.7.0'
     needs: deploy
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 15
+    env:
+      TARGET_COMMIT: ${{ inputs.target_commit }}
+      AIRFLOW_SSH_HOST: ${{ secrets.AIRFLOW_SSH_HOST }}
+      AIRFLOW_SSH_PORT: ${{ secrets.AIRFLOW_SSH_PORT }}
+      AIRFLOW_SSH_USER: ${{ secrets.AIRFLOW_SSH_USER }}
+      AIRFLOW_REPOSITORY_PATH: ${{ secrets.AIRFLOW_REPOSITORY_PATH }}
+    steps:
+      - name: Configure production SSH identity
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.AIRFLOW_SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.AIRFLOW_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          install -d -m 0700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 0600 ~/.ssh/id_ed25519
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 0600 ~/.ssh/known_hosts
+
+      - name: Observe three natural one-minute cycles and verify business flow
+        run: |
+          set -euo pipefail
+          sleep 180
+          ssh -p "$AIRFLOW_SSH_PORT" "$AIRFLOW_SSH_USER@$AIRFLOW_SSH_HOST" \
+            "set -euo pipefail; cd '$AIRFLOW_REPOSITORY_PATH'; \
+             test \"\$(git rev-parse HEAD)\" = '$TARGET_COMMIT'; \
+             DEPLOYMENT_COMMIT='$TARGET_COMMIT' python scripts/host_core_production.py \
+             shadow-evidence --target-commit '$TARGET_COMMIT'"
+
+  acceptance:
+    if: inputs.version == '0.7.0'
+    needs: natural_cycles
+    uses: ./.github/workflows/production-host-core.yml
+    with:
+      operation: health
+      target_commit: ${{ inputs.target_commit }}
+    secrets: inherit
+
+  tag:
+    needs: [deploy, acceptance]
+    if: >-
+      always() &&
+      needs.deploy.result == 'success' &&
+      (inputs.version != '0.7.0' || needs.acceptance.result == 'success')
     uses: ./.github/workflows/release-tag-chatops.yml
     with:
       version: ${{ inputs.version }}
@@ -102,7 +163,7 @@ jobs:
 
   record:
     if: always()
-    needs: [contract, deploy, tag]
+    needs: [contract, host_core_cutover, deploy, natural_cycles, acceptance, tag]
     runs-on: ubuntu-latest
     steps:
       - name: Record ship result
@@ -115,7 +176,10 @@ jobs:
           AIRFLOW_PLANNED: ${{ needs.deploy.outputs.deploy_airflow }}
           SENDER_PLANNED: ${{ needs.deploy.outputs.deploy_sender }}
           CONTRACT_RESULT: ${{ needs.contract.result }}
+          HOST_CORE_CUTOVER_RESULT: ${{ needs.host_core_cutover.result }}
           DEPLOY_RESULT: ${{ needs.deploy.result }}
+          NATURAL_CYCLES_RESULT: ${{ needs.natural_cycles.result }}
+          ACCEPTANCE_RESULT: ${{ needs.acceptance.result }}
           TAG_RESULT: ${{ needs.tag.result }}
         run: |
           {
@@ -127,9 +191,17 @@ jobs:
             echo "- Resolved scope: \`$RESOLVED_SCOPE\`"
             echo "- Components: webapp=\`$WEBAPP_PLANNED\`, airflow=\`$AIRFLOW_PLANNED\`, sender=\`$SENDER_PLANNED\`"
             echo "- Release contract: \`$CONTRACT_RESULT\`"
+            echo "- Host-core cutover: \`$HOST_CORE_CUTOVER_RESULT\`"
             echo "- Deployment: \`$DEPLOY_RESULT\`"
+            echo "- Three natural cycles: \`$NATURAL_CYCLES_RESULT\`"
+            echo "- Final production acceptance: \`$ACCEPTANCE_RESULT\`"
             echo "- Immutable tag and GitHub Release: \`$TAG_RESULT\`"
           } >> "$GITHUB_STEP_SUMMARY"
           test "$CONTRACT_RESULT" = success
           test "$DEPLOY_RESULT" = success
+          if [ "$VERSION" = 0.7.0 ]; then
+            test "$HOST_CORE_CUTOVER_RESULT" = success
+            test "$NATURAL_CYCLES_RESULT" = success
+            test "$ACCEPTANCE_RESULT" = success
+          fi
           test "$TAG_RESULT" = success

--- a/tests/host_core_business_acceptance_test.py
+++ b/tests/host_core_business_acceptance_test.py
@@ -40,17 +40,23 @@ def test_v070_runs_after_the_d1_reset_and_skips_an_existing_release() -> None:
     assert 'cron: "5 0 4 9 *"' in workflow
     assert 'cron: "25 0 4 9 *"' in workflow
     assert "push:" not in workflow.split("permissions:", 1)[0]
+    assert "issue_comment:" not in workflow
     assert "refs/tags/0.7.0" in workflow
     assert "should_run=false" in workflow
     assert 'target_commit="$(git rev-parse origin/main)"' in workflow
 
 
-def test_owner_only_comment_can_trigger_the_same_release_transaction() -> None:
-    workflow = (ROOT / ".github/workflows/production-host-core-v070.yml").read_text(
-        encoding="utf-8"
-    )
+def test_existing_ship_command_routes_v070_through_the_host_core_transaction() -> None:
+    workflow = (ROOT / ".github/workflows/production-ship.yml").read_text(encoding="utf-8")
 
-    assert "issue_comment:" in workflow
-    assert "github.event.issue.number == 39" in workflow
-    assert "github.event.comment.user.login == github.repository_owner" in workflow
-    assert "github.event.comment.body == '/ops host-core-v070'" in workflow
+    assert "host_core_cutover:" in workflow
+    assert "inputs.version == '0.7.0'" in workflow
+    assert "operation: full-cutover" in workflow
+    assert "Observe three natural one-minute cycles and verify business flow" in workflow
+    assert "shadow-evidence --target-commit" in workflow
+    assert "operation: health" in workflow
+    assert "needs: [deploy, acceptance]" in workflow
+    assert workflow.index("  host_core_cutover:") < workflow.index("  deploy:")
+    assert workflow.index("  deploy:") < workflow.index("  natural_cycles:")
+    assert workflow.index("  natural_cycles:") < workflow.index("  acceptance:")
+    assert workflow.index("  acceptance:") < workflow.index("  tag:")

--- a/tests/host_core_business_acceptance_test.py
+++ b/tests/host_core_business_acceptance_test.py
@@ -43,3 +43,14 @@ def test_v070_runs_after_the_d1_reset_and_skips_an_existing_release() -> None:
     assert "refs/tags/0.7.0" in workflow
     assert "should_run=false" in workflow
     assert 'target_commit="$(git rev-parse origin/main)"' in workflow
+
+
+def test_owner_only_comment_can_trigger_the_same_release_transaction() -> None:
+    workflow = (ROOT / ".github/workflows/production-host-core-v070.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "issue_comment:" in workflow
+    assert "github.event.issue.number == 39" in workflow
+    assert "github.event.comment.user.login == github.repository_owner" in workflow
+    assert "github.event.comment.body == '/ops host-core-v070'" in workflow


### PR DESCRIPTION
## 目的

让既有的单一 ChatOps 命令 `/release ship 0.7.0 <40-char-main-sha> scope=auto sender=false` 执行完整主机通知核心迁移，而不是仅做普通 Web/Airflow 发布。

## 安全边界

- 不新增第二个 `issue_comment` 监听器，继续由 `ops-chatops.yml` 作为唯一控制面。
- `0.7.0` 专用路径依次执行：版本契约、主机核心切换、正式组件部署、三个自然巡检周期、最终健康验收、不可变标签与 GitHub Release。
- 只有主机切换与最终验收都成功后才创建 `0.7.0` 标签。
- 其他版本继续沿用原有 `production-ship.yml` 路径，行为不变。
- UTC 零点后的两次定时兜底仍保留，并在标签已存在时幂等跳过。