### PR TITLE
fix: safely prepare the host-core production checkout

### DIFF
--- a/.github/workflows/production-host-core.yml
+++ b/.github/workflows/production-host-core.yml
@@ -146,13 +146,22 @@ jobs:
           printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
           chmod 0600 ~/.ssh/known_hosts
 
+      - name: Back up and clear bounded tracked worktree drift
+        run: |
+          set -euo pipefail
+          PYTHONPATH=scripts python scripts/repair_airflow_worktree.py \
+            --target-commit "$TARGET_COMMIT" \
+            --expected-dirty-count 1 \
+            --if-needed \
+            --format json
+
       - name: Prepare exact remote commit
         run: |
           set -euo pipefail
           ssh -p "$AIRFLOW_SSH_PORT" "$AIRFLOW_SSH_USER@$AIRFLOW_SSH_HOST" \
             "set -euo pipefail; cd '$AIRFLOW_REPOSITORY_PATH'; \
              git fetch --prune origin main; \
-             test -z \"\$(git status --porcelain)\"; \
+             test -z \"\$(git status --porcelain --untracked-files=no)\"; \
              git checkout --detach '$TARGET_COMMIT'; \
              test \"\$(git rev-parse HEAD)\" = '$TARGET_COMMIT'"
 

--- a/tests/host_core_worktree_preparation_test.py
+++ b/tests/host_core_worktree_preparation_test.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_host_core_backs_up_bounded_tracked_drift_before_checkout() -> None:
+    workflow = (ROOT / ".github/workflows/production-host-core.yml").read_text(
+        encoding="utf-8"
+    )
+    prepare = workflow.split(
+        "      - name: Back up and clear bounded tracked worktree drift", 1
+    )[1].split("      - name: Operate host core", 1)[0]
+
+    assert "scripts/repair_airflow_worktree.py" in prepare
+    assert '--expected-dirty-count 1' in prepare
+    assert "--if-needed" in prepare
+    assert prepare.index("repair_airflow_worktree.py") < prepare.index(
+        "git checkout --detach"
+    )
+
+
+def test_host_core_preserves_untracked_runtime_files() -> None:
+    workflow = (ROOT / ".github/workflows/production-host-core.yml").read_text(
+        encoding="utf-8"
+    )
+    prepare = workflow.split("      - name: Prepare exact remote commit", 1)[1].split(
+        "      - name: Operate host core", 1
+    )[0]
+
+    assert "git status --porcelain --untracked-files=no" in prepare
+    assert 'git status --porcelain)\\"' not in prepare

--- a/tests/host_core_worktree_preparation_test.py
+++ b/tests/host_core_worktree_preparation_test.py
@@ -6,25 +6,19 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_host_core_backs_up_bounded_tracked_drift_before_checkout() -> None:
-    workflow = (ROOT / ".github/workflows/production-host-core.yml").read_text(
-        encoding="utf-8"
-    )
-    prepare = workflow.split(
-        "      - name: Back up and clear bounded tracked worktree drift", 1
-    )[1].split("      - name: Operate host core", 1)[0]
+    workflow = (ROOT / ".github/workflows/production-host-core.yml").read_text(encoding="utf-8")
+    prepare = workflow.split("      - name: Back up and clear bounded tracked worktree drift", 1)[
+        1
+    ].split("      - name: Operate host core", 1)[0]
 
     assert "scripts/repair_airflow_worktree.py" in prepare
-    assert '--expected-dirty-count 1' in prepare
+    assert "--expected-dirty-count 1" in prepare
     assert "--if-needed" in prepare
-    assert prepare.index("repair_airflow_worktree.py") < prepare.index(
-        "git checkout --detach"
-    )
+    assert prepare.index("repair_airflow_worktree.py") < prepare.index("git checkout --detach")
 
 
 def test_host_core_preserves_untracked_runtime_files() -> None:
-    workflow = (ROOT / ".github/workflows/production-host-core.yml").read_text(
-        encoding="utf-8"
-    )
+    workflow = (ROOT / ".github/workflows/production-host-core.yml").read_text(encoding="utf-8")
     prepare = workflow.split("      - name: Prepare exact remote commit", 1)[1].split(
         "      - name: Operate host core", 1
     )[0]


### PR DESCRIPTION
## 问题

0.7.0 首次生产事务在任何迁移或所有权切换之前，被远端仓库的脏工作区安全闸门拦截。现有主机核心流程使用 `git status --porcelain`，把未跟踪的运行时文件也当作代码漂移；同时没有调用仓库已经验证过的单文件漂移备份修复器。

## 修复

- 在精确提交 checkout 前调用 `scripts/repair_airflow_worktree.py`。
- 仅允许“工作区干净”或“恰好一个已跟踪漂移”；后者先生成二进制补丁和元数据并验证可恢复，再清理。
- 后续只检查已跟踪文件：`git status --porcelain --untracked-files=no`。
- 未跟踪运行时文件、数据库、容器和服务保持不动。
- 增加工作流合约测试，保证修复先于 checkout，且未来不会重新阻塞未跟踪运行时文件。

## 安全性

若已跟踪漂移超过一个，流程继续 fail-closed，不执行迁移、切换或发送所有权变更。