### PR TITLE
fix: support the production host PyYAML during cutover

### DIFF
--- a/scripts/configure_zacks_tunnel.py
+++ b/scripts/configure_zacks_tunnel.py
@@ -74,7 +74,11 @@ def _remove(path):
 
 def _dump(path, document, mode):
     with path.open("w", encoding="utf-8") as handle:
-        yaml.safe_dump(document, handle, sort_keys=False, allow_unicode=True)
+        # The production host carries an older PyYAML whose safe_dump forwards
+        # unknown keyword arguments to dump_all and rejects sort_keys. Mapping
+        # order is not part of the cloudflared configuration contract; the
+        # generated candidate is validated by cloudflared before replacement.
+        yaml.safe_dump(document, handle, allow_unicode=True)
         handle.flush()
         os.fsync(handle.fileno())
     os.chmod(str(path), mode)

--- a/tests/configure_zacks_tunnel_test.py
+++ b/tests/configure_zacks_tunnel_test.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from scripts.configure_zacks_tunnel import PATH_PATTERN, with_zacks_rule
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from scripts.configure_zacks_tunnel import PATH_PATTERN, _dump, with_zacks_rule
 
 
 def test_inserts_host_core_path_before_general_airflow_rule() -> None:
@@ -59,3 +64,23 @@ def test_exact_existing_rule_requires_no_change() -> None:
     )
     assert changed is False
     assert updated["ingress"][0] == rule
+
+
+def test_dump_uses_only_keywords_supported_by_the_production_pyyaml(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "config.yml"
+    document = {"ingress": [{"service": "http_status:404"}]}
+    calls: list[dict[str, object]] = []
+
+    def legacy_safe_dump(data: object, stream: object, **kwargs: object) -> None:
+        calls.append(kwargs)
+        assert "sort_keys" not in kwargs
+        yaml.dump(data, stream, allow_unicode=bool(kwargs.get("allow_unicode")))
+
+    with patch("scripts.configure_zacks_tunnel.yaml.safe_dump", side_effect=legacy_safe_dump):
+        _dump(output, document, 0o600)
+
+    assert calls == [{"allow_unicode": True}]
+    assert yaml.safe_load(output.read_text(encoding="utf-8")) == document
+    assert output.stat().st_mode & 0o777 == 0o600


### PR DESCRIPTION
## Root cause

The repaired 0.7.0 cutover reached the production host preflight, but the host has an older PyYAML. Its `safe_dump` rejects the newer `sort_keys` keyword, so the tunnel candidate could not be serialized. The failure happened before any edge mutation, service start, data import, or ownership switch.

## Fix

- Remove the nonessential `sort_keys` argument from the cloudflared candidate serializer.
- Keep atomic write, fsync, mode preservation, cloudflared validation, backup, and restart rollback behavior unchanged.
- Add a regression test with a legacy-PyYAML-compatible mock that fails if `sort_keys` is passed.

After exact-SHA CI and merge, the protected 0.7.0 ship transaction will be retried with the new main SHA. No synthetic email or WeChat notification is used for acceptance.