### PR TITLE
fix: make Host Core cutover survive long imports

### DIFF
--- a/.github/workflows/production-host-core.yml
+++ b/.github/workflows/production-host-core.yml
@@ -67,7 +67,7 @@ jobs:
     if: needs.resolve.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     environment: production
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       TARGET_COMMIT: ${{ needs.resolve.outputs.target_commit }}
       OPERATION: ${{ needs.resolve.outputs.operation }}
@@ -133,7 +133,14 @@ jobs:
       - name: Prepare exact remote commit
         run: |
           set -euo pipefail
-          ssh -p "$AIRFLOW_SSH_PORT" "$AIRFLOW_SSH_USER@$AIRFLOW_SSH_HOST" \
+          ssh \
+            -o BatchMode=yes \
+            -o ConnectTimeout=20 \
+            -o ServerAliveInterval=15 \
+            -o ServerAliveCountMax=120 \
+            -o TCPKeepAlive=yes \
+            -p "$AIRFLOW_SSH_PORT" \
+            "$AIRFLOW_SSH_USER@$AIRFLOW_SSH_HOST" \
             "set -euo pipefail; cd '$AIRFLOW_REPOSITORY_PATH'; \
              git fetch --prune origin main; \
              test -z \"\$(git status --porcelain --untracked-files=no)\"; \
@@ -145,6 +152,23 @@ jobs:
         run: |
           set -euo pipefail
 
+          SSH_OPTIONS=(
+            -o BatchMode=yes
+            -o ConnectTimeout=20
+            -o ServerAliveInterval=15
+            -o ServerAliveCountMax=120
+            -o TCPKeepAlive=yes
+            -p "$AIRFLOW_SSH_PORT"
+          )
+          SCP_OPTIONS=(
+            -o BatchMode=yes
+            -o ConnectTimeout=20
+            -o ServerAliveInterval=15
+            -o ServerAliveCountMax=120
+            -o TCPKeepAlive=yes
+            -P "$AIRFLOW_SSH_PORT"
+          )
+
           remote() {
             local quoted=()
             local argument escaped
@@ -152,9 +176,11 @@ jobs:
               printf -v escaped '%q' "$argument"
               quoted+=("$escaped")
             done
-            ssh -p "$AIRFLOW_SSH_PORT" "$AIRFLOW_SSH_USER@$AIRFLOW_SSH_HOST" \
+            ssh "${SSH_OPTIONS[@]}" \
+              "$AIRFLOW_SSH_USER@$AIRFLOW_SSH_HOST" \
               "set -euo pipefail; cd '$AIRFLOW_REPOSITORY_PATH'; \
-               DEPLOYMENT_COMMIT='$TARGET_COMMIT' python3 scripts/host_core_production.py \
+               DEPLOYMENT_COMMIT='$TARGET_COMMIT' \
+               python3 scripts/host_core_command_with_heartbeat.py \
                ${quoted[*]} --target-commit '$TARGET_COMMIT'"
           }
 
@@ -209,11 +235,13 @@ jobs:
             snapshot_sha="$(sha256sum "$gzip_path" | cut -d' ' -f1)"
             local remote_dir="$AIRFLOW_REPOSITORY_PATH/.local/host-core-migration"
             local remote_path="$remote_dir/d1-${pass_name}-${snapshot_sha}.sql.gz"
-            ssh -p "$AIRFLOW_SSH_PORT" "$AIRFLOW_SSH_USER@$AIRFLOW_SSH_HOST" \
+            ssh "${SSH_OPTIONS[@]}" \
+              "$AIRFLOW_SSH_USER@$AIRFLOW_SSH_HOST" \
               "install -d -m 0700 '$remote_dir'"
-            scp -P "$AIRFLOW_SSH_PORT" "$gzip_path" \
+            scp "${SCP_OPTIONS[@]}" "$gzip_path" \
               "$AIRFLOW_SSH_USER@$AIRFLOW_SSH_HOST:$remote_path"
-            ssh -p "$AIRFLOW_SSH_PORT" "$AIRFLOW_SSH_USER@$AIRFLOW_SSH_HOST" \
+            ssh "${SSH_OPTIONS[@]}" \
+              "$AIRFLOW_SSH_USER@$AIRFLOW_SSH_HOST" \
               "chmod 0600 '$remote_path'; test -s '$remote_path'; \
                test \"\$(sha256sum '$remote_path' | cut -d' ' -f1)\" = '$snapshot_sha'"
             printf '%s|%s\n' "$remote_path" "$snapshot_sha"
@@ -324,5 +352,6 @@ jobs:
             echo "- Target commit: \`$TARGET_COMMIT\`"
             echo "- Result: \`${{ job.status }}\`"
             echo "- D1 migration source: control-plane SQL export"
+            echo "- Long operations: SSH keepalive plus command heartbeat"
             echo "- Real test notifications: none"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/host_core_command_with_heartbeat.py
+++ b/scripts/host_core_command_with_heartbeat.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Run one Host Core production command with periodic progress heartbeats.
+
+The production host still uses Python 3.6, so this wrapper intentionally avoids
+newer syntax.  It keeps the SSH session active while the child command captures
+a long-running D1 SQL import, then forwards the child's exact output and exit
+status.
+"""
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOST_CORE_SCRIPT = ROOT / "scripts" / "host_core_production.py"
+
+
+def run_with_heartbeat(command, label, interval_seconds=20):
+    if interval_seconds <= 0:
+        raise ValueError("heartbeat interval must be positive")
+
+    started_at = time.monotonic()
+    process = subprocess.Popen(
+        command,
+        cwd=str(ROOT),
+        universal_newlines=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        while True:
+            try:
+                stdout, stderr = process.communicate(timeout=interval_seconds)
+                break
+            except subprocess.TimeoutExpired:
+                print(
+                    json.dumps(
+                        {
+                            "elapsedSeconds": int(time.monotonic() - started_at),
+                            "event": "host_core_command_heartbeat",
+                            "label": label,
+                        },
+                        sort_keys=True,
+                    ),
+                    file=sys.stderr,
+                )
+                sys.stderr.flush()
+    except BaseException:
+        process.kill()
+        stdout, stderr = process.communicate()
+        if stdout:
+            sys.stdout.write(stdout)
+            sys.stdout.flush()
+        if stderr:
+            sys.stderr.write(stderr)
+            sys.stderr.flush()
+        raise
+
+    if stdout:
+        sys.stdout.write(stdout)
+        sys.stdout.flush()
+    if stderr:
+        sys.stderr.write(stderr)
+        sys.stderr.flush()
+    return process.returncode
+
+
+def main(arguments=None):
+    values = list(sys.argv[1:] if arguments is None else arguments)
+    if not values:
+        print("host-core command is required", file=sys.stderr)
+        return 2
+    command = [sys.executable, str(HOST_CORE_SCRIPT)] + values
+    return run_with_heartbeat(command, "Host Core {}".format(values[0]))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/host_core_command_with_heartbeat.py
+++ b/scripts/host_core_command_with_heartbeat.py
@@ -73,7 +73,7 @@ def main(arguments=None):
         print("host-core command is required", file=sys.stderr)
         return 2
     command = [sys.executable, str(HOST_CORE_SCRIPT)] + values
-    return run_with_heartbeat(command, "Host Core {}".format(values[0]))
+    return run_with_heartbeat(command, f"Host Core {values[0]}")
 
 
 if __name__ == "__main__":

--- a/tests/host_core_architecture_contract_test.py
+++ b/tests/host_core_architecture_contract_test.py
@@ -89,6 +89,7 @@ def test_repository_invariants_no_longer_assign_delivery_to_d1() -> None:
 
 def test_cutover_uses_quota_independent_sql_export_and_one_delivery_owner() -> None:
     workflow = read(".github/workflows/production-host-core.yml")
+    wrapper = read("scripts/host_core_command_with_heartbeat.py")
     runbook = read("docs/runbooks/host-core-cutover.md")
 
     assert "workflow_call:" in workflow
@@ -107,10 +108,18 @@ def test_cutover_uses_quota_independent_sql_export_and_one_delivery_owner() -> N
     assert workflow.index("deploy_edge false true true") < workflow.index(
         "remote migrate-sql --pass-name final"
     )
-    assert workflow.index("remote prepare-cutover") < workflow.index("deploy_edge true false false")
-    assert workflow.index("deploy_edge true false false") < workflow.index("remote cutover")
+    assert workflow.index("remote prepare-cutover") < workflow.index(
+        "deploy_edge true false false"
+    )
+    assert workflow.index("deploy_edge true false false") < workflow.index(
+        "remote cutover"
+    )
     assert ".wrangler-host-core-runtime.json" in workflow
-    assert "python3 scripts/host_core_production.py" in workflow
+    assert "python3 scripts/host_core_command_with_heartbeat.py" in workflow
+    assert "ServerAliveInterval=15" in workflow
+    assert "ServerAliveCountMax=120" in workflow
+    assert "host_core_command_heartbeat" in wrapper
+    assert "subprocess.TimeoutExpired" in wrapper
     assert "--var " not in workflow
     assert "remote rollback" in workflow
     assert "Real test notifications: none" in workflow

--- a/tests/host_core_architecture_contract_test.py
+++ b/tests/host_core_architecture_contract_test.py
@@ -108,12 +108,8 @@ def test_cutover_uses_quota_independent_sql_export_and_one_delivery_owner() -> N
     assert workflow.index("deploy_edge false true true") < workflow.index(
         "remote migrate-sql --pass-name final"
     )
-    assert workflow.index("remote prepare-cutover") < workflow.index(
-        "deploy_edge true false false"
-    )
-    assert workflow.index("deploy_edge true false false") < workflow.index(
-        "remote cutover"
-    )
+    assert workflow.index("remote prepare-cutover") < workflow.index("deploy_edge true false false")
+    assert workflow.index("deploy_edge true false false") < workflow.index("remote cutover")
     assert ".wrangler-host-core-runtime.json" in workflow
     assert "python3 scripts/host_core_command_with_heartbeat.py" in workflow
     assert "ServerAliveInterval=15" in workflow

--- a/tests/host_core_command_heartbeat_test.py
+++ b/tests/host_core_command_heartbeat_test.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "host_core_command_with_heartbeat.py"
+
+
+def load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("host_core_command_with_heartbeat", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TimeoutThenSuccess:
+    returncode = 0
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.killed = False
+
+    def communicate(self, timeout: int | None = None) -> tuple[str, str]:
+        self.calls += 1
+        if self.calls == 1:
+            raise subprocess.TimeoutExpired(["fake"], timeout)
+        return "child-out\n", "child-err\n"
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+class ImmediateFailure:
+    returncode = 7
+
+    def communicate(self, timeout: int | None = None) -> tuple[str, str]:
+        del timeout
+        return "", "failure-detail\n"
+
+    def kill(self) -> None:
+        raise AssertionError("completed child must not be killed")
+
+
+def test_timeout_emits_heartbeat_and_forwards_output(
+    monkeypatch: Any, capsys: Any
+) -> None:
+    module = load_module()
+    process = TimeoutThenSuccess()
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *args, **kwargs: process)
+
+    result = module.run_with_heartbeat(["fake"], "migration", interval_seconds=1)
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert process.calls == 2
+    assert process.killed is False
+    assert "host_core_command_heartbeat" in captured.err
+    assert '"label": "migration"' in captured.err
+    assert "child-out" in captured.out
+    assert "child-err" in captured.err
+
+
+def test_child_exit_status_is_preserved(monkeypatch: Any, capsys: Any) -> None:
+    module = load_module()
+    monkeypatch.setattr(
+        module.subprocess,
+        "Popen",
+        lambda *args, **kwargs: ImmediateFailure(),
+    )
+
+    result = module.run_with_heartbeat(["fake"], "failure", interval_seconds=1)
+
+    captured = capsys.readouterr()
+    assert result == 7
+    assert "failure-detail" in captured.err
+
+
+def test_main_forwards_arguments_to_production_script(monkeypatch: Any) -> None:
+    module = load_module()
+    observed: dict[str, object] = {}
+
+    def fake_run(command: list[str], label: str, interval_seconds: int = 20) -> int:
+        observed.update(
+            {"command": command, "label": label, "interval": interval_seconds}
+        )
+        return 0
+
+    monkeypatch.setattr(module, "run_with_heartbeat", fake_run)
+
+    assert module.main(["migrate-sql", "--target-commit", "a" * 40]) == 0
+    assert observed["command"] == [
+        module.sys.executable,
+        str(module.HOST_CORE_SCRIPT),
+        "migrate-sql",
+        "--target-commit",
+        "a" * 40,
+    ]
+    assert observed["label"] == "Host Core migrate-sql"
+    assert observed["interval"] == 20

--- a/tests/host_core_command_heartbeat_test.py
+++ b/tests/host_core_command_heartbeat_test.py
@@ -47,9 +47,7 @@ class ImmediateFailure:
         raise AssertionError("completed child must not be killed")
 
 
-def test_timeout_emits_heartbeat_and_forwards_output(
-    monkeypatch: Any, capsys: Any
-) -> None:
+def test_timeout_emits_heartbeat_and_forwards_output(monkeypatch: Any, capsys: Any) -> None:
     module = load_module()
     process = TimeoutThenSuccess()
     monkeypatch.setattr(module.subprocess, "Popen", lambda *args, **kwargs: process)
@@ -86,9 +84,7 @@ def test_main_forwards_arguments_to_production_script(monkeypatch: Any) -> None:
     observed: dict[str, object] = {}
 
     def fake_run(command: list[str], label: str, interval_seconds: int = 20) -> int:
-        observed.update(
-            {"command": command, "label": label, "interval": interval_seconds}
-        )
+        observed.update({"command": command, "label": label, "interval": interval_seconds})
         return 0
 
     monkeypatch.setattr(module, "run_with_heartbeat", fake_run)

--- a/tests/host_core_release_hardening_test.py
+++ b/tests/host_core_release_hardening_test.py
@@ -23,6 +23,7 @@ def test_manual_ci_uses_first_parent_and_validates_sender_without_deploying() ->
 def test_host_entry_scripts_remain_runnable_on_the_production_python_36_host() -> None:
     for path in (
         "scripts/host_core_production.py",
+        "scripts/host_core_command_with_heartbeat.py",
         "scripts/configure_zacks_tunnel.py",
     ):
         source = read(path)
@@ -33,9 +34,16 @@ def test_host_entry_scripts_remain_runnable_on_the_production_python_36_host() -
         assert "missing_ok=" not in source
 
 
-def test_all_production_host_core_callers_use_python3() -> None:
+def test_all_production_host_core_callers_use_explicit_python3() -> None:
+    host_workflow = read(".github/workflows/production-host-core.yml")
+    wrapper = read("scripts/host_core_command_with_heartbeat.py")
+
+    assert "python scripts/host_core_production.py" not in host_workflow
+    assert "python3 scripts/host_core_command_with_heartbeat.py" in host_workflow
+    assert 'HOST_CORE_SCRIPT = ROOT / "scripts" / "host_core_production.py"' in wrapper
+    assert "command = [sys.executable, str(HOST_CORE_SCRIPT)] + values" in wrapper
+
     for path in (
-        ".github/workflows/production-host-core.yml",
         ".github/workflows/production-host-core-v070.yml",
         ".github/workflows/production-ship.yml",
     ):


### PR DESCRIPTION
## Production failure

The Host Core cutover currently reaches the D1 control-plane export and starts the PostgreSQL import, but the long, silent remote import exceeds the effective SSH idle window. The runner receives `client_loop: send disconnect: Broken pipe`, the guarded workflow fails, and recovery returns notification ownership to the legacy Cloudflare/D1 path. As a result, subscription creation, subscriber email delivery, and upstream WeChat delivery remain coupled to the exhausted D1 quota.

## Fix

- Add a Python 3.6-compatible command wrapper that runs `host_core_production.py`, emits a structured heartbeat every 20 seconds while a child operation is still running, forwards the exact stdout/stderr, and preserves the child exit status.
- Enable SSH and SCP keepalives throughout the protected production Host Core workflow.
- Route every remote Host Core operation through the heartbeat wrapper, including both long D1 SQL import passes.
- Extend the guarded workflow timeout to 120 minutes.
- Add unit and architecture-contract coverage for heartbeat behavior, exit-status preservation, and transport settings.

## Safety

- D1 remains read-only migration evidence; no production D1 data is deleted.
- Before cutover, Cloudflare remains the single notification owner.
- The notification worker is stopped during public API activation.
- Failed pre-activation operations return to the legacy route; post-activation failures pause host delivery rather than enabling two senders.
- No synthetic email or WeChat message is sent by this PR or its CI.

## Production acceptance after merge

The repair is not complete merely when this PR merges. The protected production cutover must then prove all of the following:

1. `ZACKS_DELIVERY_OWNER=airflow_host`, host observation and host WeChat gate are active, and `cutover_at` is non-null.
2. Cloudflare is the stateless edge and `/api/subscriptions` writes to PostgreSQL without D1/quota errors.
3. A temporary public subscription is created, verified in PostgreSQL, and removed safely.
4. One authorized acceptance email is submitted through the local Outbox/Tencent SES path.
5. One authorized WeChat acceptance message succeeds through Airflow → Sender → Appium/Android.
6. All 26 venue watchers continue naturally, and recent delivery queues have no unresolved failures.

Only that end-to-end production acceptance will be reported as success.