### PR TITLE
fix(host-core): stop startup DDL deadlocks and safely resume verified cutover

### DIFF
--- a/docs/incidents/2026-09-05-host-core-cutover.md
+++ b/docs/incidents/2026-09-05-host-core-cutover.md
@@ -1,0 +1,53 @@
+# Host Core cutover recovery — 2026-09-05
+
+## Verified incident baseline
+
+PR #208 / commit `1726aefc0ccf10262b676149542c7e21034a6fd1` repaired
+Python 3.6 subprocess input handling and passed exact-commit CI.
+Production ship `33961782432` then completed encrypted secret transfer,
+15-table SQL import/reconciliation (including 104 subscriptions), and deployed
+the stateless edge without a D1 binding. At 11:16:27 UTC, enabling delivery
+failed with PostgreSQL `DeadlockDetected` while `ensure_schema` ran
+`CREATE INDEX IF NOT EXISTS observed_slots_venue_date_idx`. Failure recovery
+paused host delivery. Airflow, Sender, natural delivery acceptance and release
+tagging had not run. A deployed edge is not proof of working notifications.
+
+## Root cause and repair
+
+The process-local schema-ready boolean was false in every new CLI process.
+Even when the database was current, every operator command re-ran all schema
+DDL and seed writes against concurrent venue observations. Idempotent SQL does
+not mean lock-free SQL. Initialization now uses a durable fingerprint of base
+DDL, extensions and venue seeds, serialized under the existing advisory lock.
+A current database takes a read-only ledger path. The cache is engine-specific
+and becomes ready only after commit. Only rolled-back deadlocks/lock timeouts
+are retried, with bounded timeouts; other errors still fail closed.
+
+The interrupted first cutover had reconciled migration data and exposed the
+host API, but had not set `activated_at`. Retrying based only on that flag
+could re-import stale D1 data over host-side subscription changes. The protected
+release now resumes from the complete 15-table identity checkpoint, without
+secret transfer, D1 import, or a maintenance edge. A pure edge without a valid
+checkpoint is refused rather than overwritten. D1 is preserved, never deleted.
+
+## Verification and release policy
+
+Regressions cover an active PostgreSQL writer during cold-process startup,
+ledger durability, engine-specific caching, rollback and bounded lock retries,
+and executing the release shell with network-free stubs to prove that resume
+cannot re-import or expose the maintenance edge. Exact-commit CI remains the
+authoritative gate. Use the existing protected `0.7.0` ship transaction with
+`scope=all sender=true`; all existing production acceptance requirements remain.
+Do not mark the release complete before natural SES-delivered and WeChat-sent
+records, the rollback-only subscription API probe, 26 venue DAGs with three
+natural successes, and exact host/edge/Sender identities pass.
+
+## Remaining Cloudflare boundary
+
+Venue observations, matching, durable queues and existing email/WeChat delivery
+run on the host and do not use D1 or Worker Cron. The browser `/api/*` entry
+still invokes the Cloudflare Worker and its origin still uses Cloudflare
+Tunnel. Stateless does not mean unlimited: Worker request/CPU quotas can still
+affect new browser operations. A future quota-independent public API ingress
+would need its own authenticated/rate-limited host route; do not silently
+remove origin authentication or change paid plans in this incident repair.

--- a/scripts/host_core_release.sh
+++ b/scripts/host_core_release.sh
@@ -15,6 +15,13 @@ remote() {
     "set -euo pipefail; cd '$AIRFLOW_REPOSITORY_PATH'; DEPLOYMENT_COMMIT='$TARGET_COMMIT' \
      python3 scripts/host_core_command_with_heartbeat.py ${quoted[*]} --target-commit '$TARGET_COMMIT'"
 }
+checkpoint() {
+  ssh "${SSH_OPTIONS[@]}" "$AIRFLOW_SSH_USER@$AIRFLOW_SSH_HOST" \
+    "set -euo pipefail; cd '$AIRFLOW_REPOSITORY_PATH'; \
+     DEPLOYMENT_COMMIT='$TARGET_COMMIT' AIRFLOW_IMAGE_NAME='wechat-on-airflow:host-$TARGET_COMMIT' \
+     docker compose exec -T zacks-api python -m wechat_airflow.host_core.release_checkpoint \
+       --expected-commit '$TARGET_COMMIT'"
+}
 deploy_edge() {
   local kind="$1"
   node - "$kind" <<'JS'
@@ -67,14 +74,25 @@ case "$OPERATION" in
   full-cutover)
     changed=true
     remote prepare-runtime | tee /tmp/host-core-prepare.log
-    previously_activated="$(tail -n 1 /tmp/host-core-prepare.log | jq -r 'if (.previouslyActivated | type) == "boolean" then .previouslyActivated else error("missing activation state") end')"
-    if [[ "$previously_activated" == false ]]; then
+    checkpoint | tee /tmp/host-core-checkpoint.json
+    migration_complete="$(jq -er 'if (.migrationComplete | type) == "boolean" then (.migrationComplete | tostring) else error("missing migration checkpoint") end' /tmp/host-core-checkpoint.json)"
+    if [[ "$migration_complete" == false ]]; then
+      # Refuse to overwrite host-side writes when a previous attempt already
+      # exposed the pure edge but has lost its migration evidence.
+      edge="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 \
+        https://zacks.claude89757.cc/api/edge-healthz)"
+      if [[ "$(printf '%s' "$edge" | jq -r '.cutover // false')" == true ]]; then
+        echo 'Pure edge already active without a verified checkpoint; refusing D1 re-import' >&2
+        exit 1
+      fi
       # Freeze the old owner before exporting. This is an explicit maintenance
       # interval, not a compatibility backend or a second delivery owner.
       deploy_edge maintenance
       sleep 300
       remote sync-secrets
       export_snapshot
+    else
+      echo '{"event":"resume_verified_migration","d1Reimport":false,"secretRotation":false}'
     fi
     remote prepare-routing
     deploy_edge production

--- a/src/wechat_airflow/host_core/database.py
+++ b/src/wechat_airflow/host_core/database.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import threading
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
+from weakref import WeakSet
 
 from sqlalchemy import Engine, create_engine, text
 from sqlalchemy.engine import Connection
+from sqlalchemy.exc import DBAPIError
 
 from .domain import VENUES, utc_now
 from .schema import SCHEMA_STATEMENTS, SCHEMA_VERSION
@@ -15,8 +20,22 @@ from .schema_extensions import SCHEMA_EXTENSION_STATEMENTS
 
 _ENGINE: Engine | None = None
 _ENGINE_LOCK = threading.Lock()
-_SCHEMA_READY = False
+_SCHEMA_ENGINES: WeakSet[Engine] = WeakSet()
 _SCHEMA_LOCK = threading.Lock()
+# Include extensions and catalog seeds: the old semantic version alone did not
+# change when extension DDL changed. Persist this only with a successful commit.
+SCHEMA_REVISION = (
+    SCHEMA_VERSION
+    + ":"
+    + hashlib.sha256(
+        json.dumps(
+            [SCHEMA_STATEMENTS, SCHEMA_EXTENSION_STATEMENTS, sorted(VENUES.items())],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+)
+SCHEMA_ATTEMPTS = 5
 
 
 def _database_url() -> str:
@@ -48,62 +67,80 @@ def get_engine() -> Engine:
     return _ENGINE
 
 
+def _schema_current(connection: Connection) -> bool:
+    if connection.execute(text("SELECT to_regclass('zacks.schema_versions')")).scalar_one() is None:
+        return False
+    return bool(
+        connection.execute(
+            text("SELECT EXISTS (SELECT 1 FROM zacks.schema_versions WHERE version=:version)"),
+            {"version": SCHEMA_REVISION},
+        ).scalar_one()
+    )
+
+
+def _apply_schema(connection: Connection) -> None:
+    for statement in (*SCHEMA_STATEMENTS, *SCHEMA_EXTENSION_STATEMENTS):
+        connection.execute(text(statement))
+    now = utc_now()
+    for venue_id, venue_name in sorted(VENUES.items()):
+        connection.execute(
+            text(
+                """
+                INSERT INTO zacks.venue_status(venue_id, venue_name, healthy, updated_at)
+                VALUES (:venue_id, :venue_name, false, :updated_at)
+                ON CONFLICT (venue_id) DO UPDATE SET venue_name = EXCLUDED.venue_name
+                """
+            ),
+            {"venue_id": venue_id, "venue_name": venue_name, "updated_at": now},
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO zacks.subscription_generations(venue_id, generation, updated_at)
+                VALUES (:venue_id, 0, :updated_at)
+                ON CONFLICT (venue_id) DO NOTHING
+                """
+            ),
+            {"venue_id": venue_id, "updated_at": now},
+        )
+    connection.execute(
+        text(
+            "INSERT INTO zacks.schema_versions(version, applied_at) VALUES (:version, now()) "
+            "ON CONFLICT (version) DO NOTHING"
+        ),
+        [{"version": SCHEMA_VERSION}, {"version": SCHEMA_REVISION}],
+    )
+
+
+def _ensure_schema_once(target: Engine, *, force: bool) -> None:
+    with target.begin() as connection:
+        # One cold process must never hold application tables indefinitely while
+        # other processes serve observations. Retry only rolled-back lock errors.
+        connection.execute(text("SET LOCAL lock_timeout = '5s'"))
+        connection.execute(text("SET LOCAL statement_timeout = '60s'"))
+        connection.execute(text("SELECT pg_advisory_xact_lock(hashtext('zacks-host-schema-v1'))"))
+        if force or not _schema_current(connection):
+            _apply_schema(connection)
+
+
 def ensure_schema(engine: Engine | None = None, *, force: bool = False) -> None:
-    global _SCHEMA_READY
-    if _SCHEMA_READY and not force:
-        return
     target = engine or get_engine()
     with _SCHEMA_LOCK:
-        if _SCHEMA_READY and not force:
+        if target in _SCHEMA_ENGINES and not force:
             return
-        with target.begin() as connection:
-            connection.execute(
-                text("SELECT pg_advisory_xact_lock(hashtext('zacks-host-schema-v1'))")
-            )
-            for statement in (*SCHEMA_STATEMENTS, *SCHEMA_EXTENSION_STATEMENTS):
-                connection.execute(text(statement))
-            connection.execute(
-                text(
-                    """
-                    INSERT INTO zacks.schema_versions(version, applied_at)
-                    VALUES (:version, now())
-                    ON CONFLICT (version) DO NOTHING
-                    """
-                ),
-                {"version": SCHEMA_VERSION},
-            )
-            now = utc_now()
-            for venue_id, venue_name in VENUES.items():
-                connection.execute(
-                    text(
-                        """
-                        INSERT INTO zacks.venue_status(
-                            venue_id, venue_name, healthy, updated_at
-                        )
-                        VALUES (:venue_id, :venue_name, false, :updated_at)
-                        ON CONFLICT (venue_id) DO UPDATE SET
-                            venue_name = EXCLUDED.venue_name
-                        """
-                    ),
-                    {
-                        "venue_id": venue_id,
-                        "venue_name": venue_name,
-                        "updated_at": now,
-                    },
-                )
-                connection.execute(
-                    text(
-                        """
-                        INSERT INTO zacks.subscription_generations(
-                            venue_id, generation, updated_at
-                        )
-                        VALUES (:venue_id, 0, :updated_at)
-                        ON CONFLICT (venue_id) DO NOTHING
-                        """
-                    ),
-                    {"venue_id": venue_id, "updated_at": now},
-                )
-        _SCHEMA_READY = True
+        _SCHEMA_ENGINES.discard(target)
+        for attempt in range(SCHEMA_ATTEMPTS):
+            try:
+                _ensure_schema_once(target, force=force)
+                break
+            except DBAPIError as exc:
+                code = getattr(exc.orig, "pgcode", None) or getattr(exc.orig, "sqlstate", None)
+                if code not in {"40P01", "55P03"} or attempt == SCHEMA_ATTEMPTS - 1:
+                    raise
+                time.sleep(0.5 * (attempt + 1))
+        # Cache by engine, and only AFTER transaction commit. A new CLI process
+        # reads the durable fingerprint instead of rerunning CREATE INDEX/ALTER.
+        _SCHEMA_ENGINES.add(target)
 
 
 @contextmanager
@@ -130,7 +167,7 @@ def ping(engine: Engine | None = None) -> dict[str, Any]:
                     ) AS schema_ready
                 """
                 ),
-                {"version": SCHEMA_VERSION},
+                {"version": SCHEMA_REVISION},
             )
             .mappings()
             .one()
@@ -139,8 +176,8 @@ def ping(engine: Engine | None = None) -> dict[str, Any]:
 
 
 def reset_engine_for_test() -> None:
-    global _ENGINE, _SCHEMA_READY
+    global _ENGINE
     if _ENGINE is not None:
         _ENGINE.dispose()
     _ENGINE = None
-    _SCHEMA_READY = False
+    _SCHEMA_ENGINES.clear()

--- a/src/wechat_airflow/host_core/release_checkpoint.py
+++ b/src/wechat_airflow/host_core/release_checkpoint.py
@@ -41,12 +41,24 @@ def read_checkpoint(expected_commit: str) -> dict[str, Any]:
     # prepare-runtime has already migrated the schema. This diagnostic itself
     # performs ONLY SELECTs, without ensure_schema or any business writes.
     with get_engine().connect() as connection:
-        state = connection.execute(
-            text("SELECT activated_at, delivery_enabled, wechat_enabled FROM zacks.runtime_control WHERE singleton")
-        ).mappings().one()
-        migration = connection.execute(
-            text("SELECT source_revision, imported_at, details FROM zacks.migration_state WHERE source='cloudflare-d1'")
-        ).mappings().first()
+        state = (
+            connection.execute(
+                text(
+                    "SELECT activated_at, delivery_enabled, wechat_enabled FROM zacks.runtime_control WHERE singleton"
+                )
+            )
+            .mappings()
+            .one()
+        )
+        migration = (
+            connection.execute(
+                text(
+                    "SELECT source_revision, imported_at, details FROM zacks.migration_state WHERE source='cloudflare-d1'"
+                )
+            )
+            .mappings()
+            .first()
+        )
     complete = bool(
         migration and migration["imported_at"] and migration_reconciled(migration["details"])
     )

--- a/src/wechat_airflow/host_core/release_checkpoint.py
+++ b/src/wechat_airflow/host_core/release_checkpoint.py
@@ -1,0 +1,73 @@
+"""Read-only, privacy-safe checkpoint for resuming an interrupted first cutover."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from typing import Any
+
+from sqlalchemy import text
+
+from .database import get_engine
+from .migration import EXPORT_TABLES
+
+
+def migration_reconciled(details: Any) -> bool:
+    if not isinstance(details, dict):
+        return False
+    proof = details.get("reconciliation")
+    if not isinstance(proof, dict) or proof.get("providerIdentityPreserved") is not True:
+        return False
+    for table in EXPORT_TABLES:
+        entry = proof.get(table)
+        if not isinstance(entry, dict):
+            return False
+        count = entry.get("sourceCount")
+        matched = entry.get("matchedCount")
+        if type(count) is not int or type(matched) is not int or count < 0 or count != matched:
+            return False
+        if not re.fullmatch(r"[0-9a-f]{64}", str(entry.get("keysSha256", ""))):
+            return False
+    return True
+
+
+def read_checkpoint(expected_commit: str) -> dict[str, Any]:
+    if not re.fullmatch(r"[0-9a-f]{40}", expected_commit):
+        raise RuntimeError("an exact commit is required")
+    if os.environ.get("DEPLOYMENT_COMMIT") != expected_commit:
+        raise RuntimeError("checkpoint container commit mismatch")
+    # prepare-runtime has already migrated the schema. This diagnostic itself
+    # performs ONLY SELECTs, without ensure_schema or any business writes.
+    with get_engine().connect() as connection:
+        state = connection.execute(
+            text("SELECT activated_at, delivery_enabled, wechat_enabled FROM zacks.runtime_control WHERE singleton")
+        ).mappings().one()
+        migration = connection.execute(
+            text("SELECT source_revision, imported_at, details FROM zacks.migration_state WHERE source='cloudflare-d1'")
+        ).mappings().first()
+    complete = bool(
+        migration and migration["imported_at"] and migration_reconciled(migration["details"])
+    )
+    if state["activated_at"] is not None and not complete:
+        raise RuntimeError("activated Host Core has no verified migration checkpoint")
+    return {
+        "deploymentCommit": expected_commit,
+        "migrationComplete": complete,
+        "everActivated": state["activated_at"] is not None,
+        "deliveryEnabled": state["delivery_enabled"],
+        "wechatEnabled": state["wechat_enabled"],
+        "sourceRevision": migration["source_revision"] if complete and migration else None,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--expected-commit", required=True)
+    args = parser.parse_args()
+    print(json.dumps(read_checkpoint(args.expected_commit), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/host_core_release_checkpoint_test.py
+++ b/tests/host_core_release_checkpoint_test.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from wechat_airflow.host_core.migration import EXPORT_TABLES
+from wechat_airflow.host_core.release_checkpoint import migration_reconciled
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def proof():
+    return {
+        "reconciliation": {
+            **{table: {"sourceCount": 2, "matchedCount": 2, "keysSha256": "a" * 64} for table in EXPORT_TABLES},
+            "providerIdentityPreserved": True,
+        }
+    }
+
+
+def test_migration_checkpoint_requires_all_identities_and_provider_proof():
+    assert migration_reconciled(proof()) is True
+    for table in EXPORT_TABLES:
+        value = copy.deepcopy(proof())
+        del value["reconciliation"][table]
+        assert migration_reconciled(value) is False
+    value = proof()
+    value["reconciliation"]["providerIdentityPreserved"] = False
+    assert migration_reconciled(value) is False
+
+
+@pytest.mark.parametrize("count", [None, True, -1, "2", 3])
+def test_migration_checkpoint_rejects_invalid_or_unmatched_counts(count):
+    value = proof()
+    value["reconciliation"]["subscriptions"]["sourceCount"] = count
+    assert migration_reconciled(value) is False
+
+
+@pytest.mark.parametrize("value", [None, {}, {"reconciliation": []}])
+def test_migration_checkpoint_rejects_missing_or_malformed_proof(value):
+    assert migration_reconciled(value) is False
+
+
+@pytest.mark.parametrize("complete,edge_active,success", [(True, True, True), (False, True, False)])
+def test_release_resume_never_reimports_after_completed_migration(tmp_path, complete, edge_active, success):
+    if not shutil.which("jq"):
+        pytest.skip("jq is required for the release shell contract")
+    binaries = tmp_path / "bin"
+    binaries.mkdir()
+    log = tmp_path / "calls"
+    scripts = {
+        "ssh": (
+            '#!/bin/sh\necho "ssh $*" >> "$CALL_LOG"\n'
+            'case "$*" in\n'
+            '*release_checkpoint*) printf "%s\\n" "$CHECKPOINT" ;;\n'
+            '*prepare-runtime*) echo \'{"previouslyActivated":false,"success":true}\' ;;\n'
+            '*) echo \'{"success":true}\' ;;\nesac\n'
+        ),
+        "curl": '#!/bin/sh\nprintf "%s\\n" "$EDGE_RESPONSE"\n',
+        "node": '#!/bin/sh\necho "node $*" >> "$CALL_LOG"\ncat >/dev/null\n',
+        "npx": '#!/bin/sh\necho "npx $*" >> "$CALL_LOG"\n',
+        "python": '#!/bin/sh\necho "python health" >> "$CALL_LOG"\n',
+        "sleep": '#!/bin/sh\necho "sleep $*" >> "$CALL_LOG"\n',
+    }
+    for name, content in scripts.items():
+        path = binaries / name
+        path.write_text(content)
+        path.chmod(0o755)
+    environment = dict(
+        os.environ,
+        PATH=str(binaries) + os.pathsep + os.environ["PATH"],
+        TARGET_COMMIT="a" * 40,
+        OPERATION="full-cutover",
+        AIRFLOW_SSH_HOST="test-only-host",
+        AIRFLOW_SSH_PORT="22",
+        AIRFLOW_SSH_USER="test-only-user",
+        AIRFLOW_REPOSITORY_PATH="/test-only-repository",
+        CALL_LOG=str(log),
+        CHECKPOINT=json.dumps({"migrationComplete": complete, "everActivated": False}),
+        EDGE_RESPONSE=json.dumps({"cutover": edge_active}),
+    )
+    result = subprocess.run(
+        ["bash", str(ROOT / "scripts/host_core_release.sh")],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    calls = log.read_text()
+    assert (result.returncode == 0) is success
+    for forbidden in ("d1 export", "migrate-sql", "sync-secrets", "node - maintenance", "sleep 300"):
+        assert forbidden not in calls
+    if success:
+        assert "resume_verified_migration" in result.stdout
+        assert "prepare-routing" in calls
+        assert "node - production" in calls
+        assert " cutover " in calls
+    else:
+        assert "refusing D1 re-import" in result.stderr
+        assert "pause-host-delivery" in calls

--- a/tests/host_core_release_checkpoint_test.py
+++ b/tests/host_core_release_checkpoint_test.py
@@ -18,7 +18,10 @@ ROOT = Path(__file__).resolve().parents[1]
 def proof():
     return {
         "reconciliation": {
-            **{table: {"sourceCount": 2, "matchedCount": 2, "keysSha256": "a" * 64} for table in EXPORT_TABLES},
+            **{
+                table: {"sourceCount": 2, "matchedCount": 2, "keysSha256": "a" * 64}
+                for table in EXPORT_TABLES
+            },
             "providerIdentityPreserved": True,
         }
     }
@@ -48,7 +51,9 @@ def test_migration_checkpoint_rejects_missing_or_malformed_proof(value):
 
 
 @pytest.mark.parametrize("complete,edge_active,success", [(True, True, True), (False, True, False)])
-def test_release_resume_never_reimports_after_completed_migration(tmp_path, complete, edge_active, success):
+def test_release_resume_never_reimports_after_completed_migration(
+    tmp_path, complete, edge_active, success
+):
     if not shutil.which("jq"):
         pytest.skip("jq is required for the release shell contract")
     binaries = tmp_path / "bin"
@@ -60,7 +65,7 @@ def test_release_resume_never_reimports_after_completed_migration(tmp_path, comp
             'case "$*" in\n'
             '*release_checkpoint*) printf "%s\\n" "$CHECKPOINT" ;;\n'
             '*prepare-runtime*) echo \'{"previouslyActivated":false,"success":true}\' ;;\n'
-            '*) echo \'{"success":true}\' ;;\nesac\n'
+            "*) echo '{\"success\":true}' ;;\nesac\n"
         ),
         "curl": '#!/bin/sh\nprintf "%s\\n" "$EDGE_RESPONSE"\n',
         "node": '#!/bin/sh\necho "node $*" >> "$CALL_LOG"\ncat >/dev/null\n',
@@ -95,7 +100,13 @@ def test_release_resume_never_reimports_after_completed_migration(tmp_path, comp
     )
     calls = log.read_text()
     assert (result.returncode == 0) is success
-    for forbidden in ("d1 export", "migrate-sql", "sync-secrets", "node - maintenance", "sleep 300"):
+    for forbidden in (
+        "d1 export",
+        "migrate-sql",
+        "sync-secrets",
+        "node - maintenance",
+        "sleep 300",
+    ):
         assert forbidden not in calls
     if success:
         assert "resume_verified_migration" in result.stdout

--- a/tests/host_core_schema_checkpoint_test.py
+++ b/tests/host_core_schema_checkpoint_test.py
@@ -42,7 +42,9 @@ def pg(monkeypatch):
 def test_schema_fingerprint_is_durable_and_health_uses_it(pg):
     database.ensure_schema(pg)
     with pg.connect() as connection:
-        versions = set(connection.execute(text("SELECT version FROM zacks.schema_versions")).scalars())
+        versions = set(
+            connection.execute(text("SELECT version FROM zacks.schema_versions")).scalars()
+        )
     assert {database.SCHEMA_VERSION, database.SCHEMA_REVISION} <= versions
     assert database.ping(pg)["schema_ready"] is True
 
@@ -61,7 +63,9 @@ def test_cold_process_does_not_issue_ddl_or_block_active_observation(pg):
             # CREATE INDEX, including IF NOT EXISTS, needs a conflicting table
             # lock here. A cold CLI process must only read the fingerprint.
             writer.execute(text("LOCK TABLE zacks.observed_slots IN ROW EXCLUSIVE MODE"))
-            with patch.object(database, "_apply_schema", side_effect=AssertionError("DDL on startup")):
+            with patch.object(
+                database, "_apply_schema", side_effect=AssertionError("DDL on startup")
+            ):
                 database.ensure_schema(other)
         assert statements
         assert not any(s.startswith(("CREATE", "ALTER", "INSERT", "UPDATE")) for s in statements)
@@ -93,7 +97,10 @@ def test_failed_schema_transaction_never_records_ready(pg):
             database.ensure_schema(pg)
     assert pg not in database._SCHEMA_ENGINES
     with pg.connect() as connection:
-        assert connection.execute(text("SELECT to_regclass('zacks.schema_versions')")).scalar_one() is None
+        assert (
+            connection.execute(text("SELECT to_regclass('zacks.schema_versions')")).scalar_one()
+            is None
+        )
     database.ensure_schema(pg)
     assert database.ping(pg)["schema_ready"] is True
 

--- a/tests/host_core_schema_checkpoint_test.py
+++ b/tests/host_core_schema_checkpoint_test.py
@@ -1,0 +1,135 @@
+"""Startup/lock regressions, against an isolated PostgreSQL database only."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import requests
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import OperationalError
+
+from wechat_airflow.host_core import database
+
+URL = os.environ.get("ZACKS_TEST_DATABASE_URL", "")
+
+
+@pytest.fixture
+def pg(monkeypatch):
+    if not URL:
+        pytest.skip("isolated PostgreSQL test URL not supplied")
+    url = make_url(URL)
+    if url.database != "zacks_test" or url.host not in {"localhost", "127.0.0.1", "postgres"}:
+        pytest.fail("Refusing schema fixture outside isolated zacks_test")
+    monkeypatch.setenv("ZACKS_DATABASE_URL", URL)
+    database.reset_engine_for_test()
+    engine = database.get_engine()
+    with engine.begin() as connection:
+        assert connection.execute(text("SELECT current_database()")).scalar_one() == "zacks_test"
+        connection.execute(text("DROP SCHEMA IF EXISTS zacks CASCADE"))
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("external network is forbidden in PostgreSQL tests")
+
+    monkeypatch.setattr(requests.sessions.Session, "request", forbidden)
+    yield engine
+    database.reset_engine_for_test()
+
+
+def test_schema_fingerprint_is_durable_and_health_uses_it(pg):
+    database.ensure_schema(pg)
+    with pg.connect() as connection:
+        versions = set(connection.execute(text("SELECT version FROM zacks.schema_versions")).scalars())
+    assert {database.SCHEMA_VERSION, database.SCHEMA_REVISION} <= versions
+    assert database.ping(pg)["schema_ready"] is True
+
+
+def test_cold_process_does_not_issue_ddl_or_block_active_observation(pg):
+    database.ensure_schema(pg)
+    other = create_engine(URL)
+    statements = []
+
+    def record(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement.strip().upper())
+
+    event.listen(other, "before_cursor_execute", record)
+    try:
+        with pg.begin() as writer:
+            # CREATE INDEX, including IF NOT EXISTS, needs a conflicting table
+            # lock here. A cold CLI process must only read the fingerprint.
+            writer.execute(text("LOCK TABLE zacks.observed_slots IN ROW EXCLUSIVE MODE"))
+            with patch.object(database, "_apply_schema", side_effect=AssertionError("DDL on startup")):
+                database.ensure_schema(other)
+        assert statements
+        assert not any(s.startswith(("CREATE", "ALTER", "INSERT", "UPDATE")) for s in statements)
+        assert database.ping(other)["schema_ready"] is True
+    finally:
+        other.dispose()
+
+
+def test_cache_is_per_engine_and_marker_loss_requires_migration(pg):
+    database.ensure_schema(pg)
+    with pg.begin() as connection:
+        connection.execute(
+            text("DELETE FROM zacks.schema_versions WHERE version=:version"),
+            {"version": database.SCHEMA_REVISION},
+        )
+    other = create_engine(URL)
+    try:
+        with patch.object(database, "_apply_schema", wraps=database._apply_schema) as apply:
+            database.ensure_schema(other)
+        apply.assert_called_once()
+        assert database.ping(other)["schema_ready"] is True
+    finally:
+        other.dispose()
+
+
+def test_failed_schema_transaction_never_records_ready(pg):
+    with patch.object(database, "_apply_schema", side_effect=RuntimeError("test rollback")):
+        with pytest.raises(RuntimeError, match="test rollback"):
+            database.ensure_schema(pg)
+    assert pg not in database._SCHEMA_ENGINES
+    with pg.connect() as connection:
+        assert connection.execute(text("SELECT to_regclass('zacks.schema_versions')")).scalar_one() is None
+    database.ensure_schema(pg)
+    assert database.ping(pg)["schema_ready"] is True
+
+
+@pytest.mark.parametrize("code", ["40P01", "55P03"])
+def test_schema_lock_errors_retry_fresh_transactions(code):
+    engine = create_engine("sqlite://")
+    error = OperationalError("test", {}, Exception("synthetic lock failure"))
+    error.orig = SimpleNamespace(pgcode=code)
+    try:
+        with (
+            patch.object(database, "_ensure_schema_once", side_effect=[error, None]) as once,
+            patch.object(database.time, "sleep") as sleep,
+        ):
+            database.ensure_schema(engine)
+        assert once.call_count == 2
+        sleep.assert_called_once_with(0.5)
+        assert engine in database._SCHEMA_ENGINES
+    finally:
+        database._SCHEMA_ENGINES.discard(engine)
+        engine.dispose()
+
+
+def test_non_lock_error_is_not_retried_or_cached():
+    engine = create_engine("sqlite://")
+    error = OperationalError("test", {}, Exception("synthetic permission failure"))
+    error.orig = SimpleNamespace(pgcode="42501")
+    try:
+        with (
+            patch.object(database, "_ensure_schema_once", side_effect=error) as once,
+            patch.object(database.time, "sleep") as sleep,
+            pytest.raises(OperationalError),
+        ):
+            database.ensure_schema(engine)
+        once.assert_called_once()
+        sleep.assert_not_called()
+        assert engine not in database._SCHEMA_ENGINES
+    finally:
+        engine.dispose()


### PR DESCRIPTION
## Verified production failure
Ship `33961782432` completed encrypted secret transfer, 15-table reconciliation (104 subscriptions), and the pure edge deployment, but failed enabling delivery with `DeadlockDetected` in `CREATE INDEX IF NOT EXISTS observed_slots_venue_date_idx`. The previous subprocess repair (#208) succeeded; production delivery is paused, not accepted.

## Repair
- Persist a schema fingerprint covering base DDL, extensions and venue seeds. Cold CLI processes read that ledger instead of rerunning DDL against live observations. Cache by Engine only after commit.
- Bound schema lock/statement waits and retry only rolled-back PostgreSQL deadlocks/lock timeouts.
- Resume a completely reconciled first-cutover checkpoint without another maintenance edge, secret transfer or stale D1 re-import. Refuse a pure edge with missing migration proof.
- Add isolated PostgreSQL and network-free release-shell regressions; record incident and remaining Cloudflare browser-entry quota boundary.

## Safety and release
No production data deletion, D1 changes, secret rotation, synthetic real notifications, schedule changes or gate bypass. User requested complete repair and version update. Require exact CI, then the protected `0.7.0` full ship (`scope=all sender=true`), natural email and WeChat receipts, all 26 venue DAGs and production subscription transaction probe before tagging. This PR alone is not production completion.