### PR TITLE
fix(email): reconcile documented Tencent SES processing failures

### DIFF
--- a/.github/workflows/production-host-core.yml
+++ b/.github/workflows/production-host-core.yml
@@ -90,6 +90,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install and validate runner operations dependencies
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check PyYAML==6.0.3
+          PYTHONPATH=scripts python scripts/webapp_production_health.py --help >/dev/null
+
       - name: Require successful CI for exact commit
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/docs/incidents/2026-09-05-runner-health-dependency.md
+++ b/docs/incidents/2026-09-05-runner-health-dependency.md
@@ -1,0 +1,31 @@
+# Host Core runner dependency and SES reconciliation — 2026-09-05
+
+Production ship `33964942587` on `c7f73b4013fe50f27e11c2838fdb5cc71f1a1d8d`
+confirmed that the durable schema ledger and migration checkpoint repair work.
+At 12:08:00 UTC the checkpoint reported migrationComplete=true, and no D1
+re-import or secret transfer ran. At 12:08:28 UTC Host Core became the delivery
+owner and both new workers started without a DDL deadlock.
+
+Immediately afterward, the runner-side public health CLI failed importing
+`yaml`: Production Host Core set up a fresh Python interpreter without the
+PyYAML dependency already installed by the other production workflows. The
+failure handler paused both workers at 12:08:50 UTC. Subsequent Airflow/Sender
+deployments and final acceptance did not run; no 0.7.0 tag was published.
+
+The workflow now explicitly installs pinned PyYAML and invokes the health
+CLI's credential-free `--help` path before SSH identity setup or any production
+mutation. Regression tests preserve this ordering and execute the CLI import.
+All existing exact-SHA, Environment, migration and delivery gates remain.
+
+The same investigation found that the Python Tencent SES normalizer omitted
+the provider's documented processing failure codes (for example 1006 frequency
+control and 1010 daily quota), leaving such sends pending. Explicit failures
+now become failed; record-not-found 2001 stays unconfirmed. Queued/delayed
+receipts never become delivered merely because a timestamp exists. Fifty-six
+offline cases cover numeric/string failure codes, delivery, rejection, absence
+and timestamp overflow. This does not replay or send any messages.
+
+Primary provider contract: https://cloud.tencent.com/document/api/1288/51053#SendEmailStatus
+
+Production completion must still be recorded from a subsequent successful full
+ship and actual natural delivery acceptance, not inferred from these changes.

--- a/src/wechat_airflow/host_core/tencent_ses.py
+++ b/src/wechat_airflow/host_core/tencent_ses.py
@@ -193,6 +193,36 @@ def get_email_status(
     return None
 
 
+# Tencent SES SendEmailStatus: nonzero processing codes are not pending sends.
+# 2001 means the status record was not found; absence alone is not proof of failure.
+# Source: https://cloud.tencent.com/document/api/1288/51053#SendEmailStatus
+SEND_FAILURE_CODES = frozenset(
+    {
+        "1001",
+        "1002",
+        "1003",
+        "1004",
+        "1005",
+        "1006",
+        "1007",
+        "1008",
+        "1009",
+        "1010",
+        "1011",
+        "1013",
+        "3007",
+        "3008",
+        "3009",
+        "3010",
+        "3014",
+        "3020",
+        "3024",
+        "3030",
+        "3033",
+    }
+)
+
+
 def normalize_status(value: dict[str, Any] | None) -> tuple[str, str | None, datetime | None]:
     if not value:
         return "pending", None, None
@@ -207,12 +237,14 @@ def normalize_status(value: dict[str, Any] | None) -> tuple[str, str | None, dat
             if numeric > 10_000_000_000:
                 numeric //= 1_000
             delivered_at = datetime.fromtimestamp(numeric, UTC)
-        except (TypeError, ValueError, OSError):
+        except (TypeError, ValueError, OSError, OverflowError):
             delivered_at = None
     if deliver_status in {"1", "success", "delivered"}:
         return "delivered", message, delivered_at or datetime.now(UTC)
     if deliver_status in {"2", "3", "failed", "bounce", "rejected"}:
         return "failed", message or "provider delivery failed", delivered_at
-    if send_status in {"2", "3", "failed", "rejected"}:
-        return "failed", message or "provider send failed", delivered_at
+    if send_status in SEND_FAILURE_CODES or send_status in {"2", "3", "failed", "rejected"}:
+        return "failed", message or f"provider send failed: {send_status}", delivered_at
+    if send_status == "2001":
+        return "pending", message or "provider status record not found", None
     return "pending", message, delivered_at

--- a/tests/host_core_runner_dependencies_test.py
+++ b/tests/host_core_runner_dependencies_test.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_runner_installs_and_smokes_health_tool_before_production_mutation():
+    workflow = yaml.safe_load((ROOT / ".github/workflows/production-host-core.yml").read_text())
+    job = workflow["jobs"]["operate"]
+    steps = job["steps"]
+    names = [step.get("name", "") for step in steps]
+    index = names.index("Install and validate runner operations dependencies")
+    install = steps[index]
+    assert "PyYAML==6.0.3" in install["run"]
+    assert "scripts/webapp_production_health.py --help" in install["run"]
+    assert "if" not in install
+    assert "continue-on-error" not in install
+    assert index < names.index("Configure SSH identity")
+    assert index < names.index("Prepare exact remote commit")
+    assert index < names.index("Operate host core")
+    assert job["environment"] == "production"
+    assert "Require successful CI for exact commit" in names
+
+
+def test_health_cli_import_and_help_require_no_production_access():
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts/webapp_production_health.py"), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=True,
+    )
+    assert "--expected-commit" in result.stdout

--- a/tests/host_core_ses_status_test.py
+++ b/tests/host_core_ses_status_test.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from wechat_airflow.host_core.tencent_ses import normalize_status
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        1001,
+        1002,
+        1003,
+        1004,
+        1005,
+        1006,
+        1007,
+        1008,
+        1009,
+        1010,
+        1011,
+        1013,
+        3007,
+        3008,
+        3009,
+        3010,
+        3014,
+        3020,
+        3024,
+        3030,
+        3033,
+    ],
+)
+@pytest.mark.parametrize("as_string", [False, True])
+def test_documented_processing_failures_are_terminal(code, as_string):
+    state, reason, _ = normalize_status(
+        {"SendStatus": str(code) if as_string else code, "DeliverStatus": 0}
+    )
+    assert state == "failed"
+    assert str(code) in reason
+
+
+@pytest.mark.parametrize("deliver", [0, 8, "0", "8"])
+def test_queued_or_delayed_is_never_delivered_from_timestamp_alone(deliver):
+    state, _, _ = normalize_status(
+        {"SendStatus": 0, "DeliverStatus": deliver, "DeliverTime": 1788609600}
+    )
+    assert state == "pending"
+
+
+@pytest.mark.parametrize("deliver", [2, 3, "2", "3"])
+def test_recipient_rejection_preserves_reason(deliver):
+    state, reason, _ = normalize_status(
+        {"SendStatus": 0, "DeliverStatus": deliver, "DeliverMessage": "synthetic rejection"}
+    )
+    assert state == "failed"
+    assert reason == "synthetic rejection"
+
+
+def test_explicit_delivery_and_timestamp_are_preserved():
+    state, _, delivered_at = normalize_status(
+        {"SendStatus": 0, "DeliverStatus": 1, "DeliverTime": 1788609600}
+    )
+    assert state == "delivered"
+    assert delivered_at == datetime.fromtimestamp(1788609600, UTC)
+
+
+@pytest.mark.parametrize("record", [None, {}, {"SendStatus": 2001}, {"SendStatus": "2001"}])
+def test_missing_provider_record_is_not_proof_of_delivery_or_failure(record):
+    assert normalize_status(record)[0] == "pending"
+
+
+def test_malformed_timestamp_does_not_hide_explicit_provider_failure():
+    state, reason, delivered_at = normalize_status(
+        {"SendStatus": 1010, "DeliverStatus": 0, "DeliverTime": "9" * 100}
+    )
+    assert state == "failed"
+    assert "1010" in reason
+    assert delivered_at is None


### PR DESCRIPTION
## Finding
Host Core's Python SES status normalizer recognized only SendStatus 2/3 or textual failures. The provider documents processing failures such as 1006 (recipient frequency), 1010 (daily quota), 1007 (blocked recipient), 3010 (template parameters), etc. These records incorrectly remained pending.

Primary source: https://cloud.tencent.com/document/api/1288/51053#SendEmailStatus

## Repair and tests
Classify the explicit documented processing failure codes. Keep 2001 (record not found) as unconfirmed; do not infer delivery from timestamps when DeliverStatus is queued/delayed. Preserve explicit delivered status and reject overflowing timestamps safely. Add 56 offline cases, numeric and string codes included. No test sends, forced retries, historic replay, credentials or quota policy changes.

## Release coordination
Production recovery run 33964942587 is currently using exact main c7f73b4013fe50f27e11c2838fdb5cc71f1a1d8d. Do not advance main while that protected transaction is running. Merge only after CI and the transaction reaches a terminal state, then deploy through the full Host Core lifecycle and record actual acceptance.