### PR TITLE
fix(dsh): prevent duplicate subscriber emails from split/merged slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,7 +355,7 @@ and operational changes.
   Web health checks, and one release gate spanning Web, Airflow, and the sender.
 - Notify `Zacks_大沙河限定免费` for Dashah River free-court availability after
   the Web observation and WeChat dedupe cache are written.
-- Append venue booking mini-program footers for WeChat availability alerts, at most
+- Append venue booking mini-program links to WeChat availability alerts, at most
   once per chat and mini-program every two hours, with Shenzhen Bay and Greater
   Bay Area sharing the 未来荟 card.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ and operational changes.
 
 ## Unreleased
 
+## [0.8.1] - 2026-09-06
+
+### Fixed
+
+- Canonicalize contiguous Dashah International (`dsh`) scraper cells into stable
+  maximal availability ranges before publishing them to Host Core. A poll that
+  reports `21:00-21:30` plus `21:30-22:00` now has the same subscriber-email
+  event identity as a later poll that reports `21:00-22:00`, preventing the
+  duplicate reminder reproduced on 2026-09-06.
+- Use the same canonical availability shape for Web subscription observations
+  and the existing WeChat notification path, with regression coverage for the
+  split-half-hour versus merged-one-hour representation.
+
+### Operations
+
+- This is an Airflow-only patch. It does not change Web assets, Sender runtime,
+  polling cadence, PostgreSQL schema, subscription data, or provider credentials,
+  and release acceptance must not emit synthetic email or WeChat notifications.
+
 ## [0.8.0] - 2026-09-05
 
 ### Court Studio
@@ -336,7 +355,7 @@ and operational changes.
   Web health checks, and one release gate spanning Web, Airflow, and the sender.
 - Notify `Zacks_大沙河限定免费` for Dashah River free-court availability after
   the Web observation and WeChat dedupe cache are written.
-- Append venue booking mini-program links to WeChat availability alerts, at most
+- Append venue booking mini-program footers for WeChat availability alerts, at most
   once per chat and mini-program every two hours, with Shenzhen Bay and Greater
   Bay Area sharing the 未来荟 card.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wechat-on-airflow"
-version = "0.8.0"
+version = "0.8.1"
 description = "Airflow workflows for Shenzhen tennis availability notifications."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/src/wechat_airflow/__init__.py
+++ b/src/wechat_airflow/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime code for the production Airflow workflows."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/src/wechat_airflow/venues/dsh_ydmap_watcher.py
+++ b/src/wechat_airflow/venues/dsh_ydmap_watcher.py
@@ -134,7 +134,7 @@ def filter_court_data_for_notification(
 
     for court_name, free_slots in court_data.items():
         filtered_slots: list[list[str]] = []
-        for slot in free_slots:
+        for slot in merge_time_ranges(free_slots):
             start_time = datetime.datetime.strptime(slot[0], "%H:%M")
             duration_minutes = (
                 parse_end_time_for_duration(slot[1]) - start_time

--- a/src/wechat_airflow/venues/dsh_ydmap_watcher.py
+++ b/src/wechat_airflow/venues/dsh_ydmap_watcher.py
@@ -90,6 +90,22 @@ def merge_time_ranges(data: list[list[str]]) -> list[list[str]]:
     ]
 
 
+def canonicalize_court_availability(court_data: CourtAvailability) -> CourtAvailability:
+    """Collapse scraper segmentation into stable maximal availability ranges.
+
+    The upstream mini-program may report one continuous hour as two adjacent
+    half-hour cells in one poll and as one one-hour range in the next. Publishing
+    those raw shapes would create different Host Core event identities for the
+    same availability and can produce duplicate subscriber email reminders.
+    """
+    canonical: CourtAvailability = {}
+    for court_name, free_slots in court_data.items():
+        merged = merge_time_ranges(free_slots)
+        if merged:
+            canonical[court_name] = merged
+    return canonical
+
+
 def parse_end_time_for_duration(end_time: str) -> datetime.datetime:
     if end_time == "24:00":
         return datetime.datetime.strptime("23:59", "%H:%M") + datetime.timedelta(minutes=1)
@@ -118,7 +134,7 @@ def filter_court_data_for_notification(
 
     for court_name, free_slots in court_data.items():
         filtered_slots: list[list[str]] = []
-        for slot in merge_time_ranges(free_slots):
+        for slot in free_slots:
             start_time = datetime.datetime.strptime(slot[0], "%H:%M")
             duration_minutes = (
                 parse_end_time_for_duration(slot[1]) - start_time
@@ -201,7 +217,8 @@ def run_check_tennis_courts() -> None:
         availability = parse_inspect_payload(payload)
         for offset in range(inspection_days):
             input_date = (now.date() + datetime.timedelta(days=offset)).isoformat()
-            court_data = availability.get(input_date, {})
+            raw_court_data = availability.get(input_date, {})
+            court_data = canonicalize_court_availability(raw_court_data)
             webapp_slots.extend(flatten_court_slots(input_date, court_data))
             print_court_data(input_date, court_data)
             up_for_send_data_list.extend(filter_court_data_for_notification(input_date, court_data))

--- a/tests/dsh_ydmap_canonicalization_test.py
+++ b/tests/dsh_ydmap_canonicalization_test.py
@@ -86,9 +86,7 @@ class DshYdmapCanonicalizationTest(unittest.TestCase):
             },
             {
                 "ok": True,
-                "days": [
-                    {"date": "2026-09-06", "courts": {"7号场": [["21:00", "22:00"]]}}
-                ],
+                "days": [{"date": "2026-09-06", "courts": {"7号场": [["21:00", "22:00"]]}}],
             },
         ]
 

--- a/tests/dsh_ydmap_canonicalization_test.py
+++ b/tests/dsh_ydmap_canonicalization_test.py
@@ -58,6 +58,7 @@ class DshYdmapCanonicalizationTest(unittest.TestCase):
         self.assertEqual(dsh_watcher.canonicalize_court_availability(merged), merged)
 
     def test_run_publishes_same_host_core_slot_for_split_and_merged_shapes(self) -> None:
+        original_load = dsh_watcher._load_device_config
         original_fetch = dsh_watcher.fetch_inspect_payload
         original_publish = dsh_watcher.publish_venue_observation
         original_enqueue = dsh_watcher.enqueue_wechat_message
@@ -102,15 +103,16 @@ class DshYdmapCanonicalizationTest(unittest.TestCase):
             published.append(slots)
             return {"success": True}
 
+        dsh_watcher._load_device_config = lambda: object()
         dsh_watcher.fetch_inspect_payload = fake_fetch
         dsh_watcher.publish_venue_observation = fake_publish
         dsh_watcher.enqueue_wechat_message = lambda message: {"success": True}
         dsh_watcher.datetime = FixedDatetimeModule
         try:
             dsh_watcher.run_check_tennis_courts()
-            FakeVariable.values[dsh_watcher.CACHE_KEY] = []
             dsh_watcher.run_check_tennis_courts()
         finally:
+            dsh_watcher._load_device_config = original_load
             dsh_watcher.fetch_inspect_payload = original_fetch
             dsh_watcher.publish_venue_observation = original_publish
             dsh_watcher.enqueue_wechat_message = original_enqueue

--- a/tests/dsh_ydmap_canonicalization_test.py
+++ b/tests/dsh_ydmap_canonicalization_test.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import unittest
+
+
+class FakeVariable:
+    values: dict[str, object] = {}
+
+    @classmethod
+    def get(cls, key: str, default: object = None, deserialize_json: bool = False) -> object:
+        return cls.values.get(key, default)
+
+    @classmethod
+    def set(
+        cls,
+        key: str,
+        value: object,
+        description: str | None = None,
+        serialize_json: bool = False,
+    ) -> None:
+        cls.values[key] = value
+
+
+def install_airflow_stubs() -> None:
+    airflow_module = types.ModuleType("airflow")
+    airflow_sdk_module = types.ModuleType("airflow.sdk")
+    airflow_sdk_module.Variable = FakeVariable
+    sys.modules.setdefault("airflow", airflow_module)
+    sys.modules.setdefault("airflow.sdk", airflow_sdk_module)
+
+
+install_airflow_stubs()
+dsh_watcher = importlib.import_module("wechat_airflow.venues.dsh_ydmap_watcher")
+dsh_watcher.Variable = FakeVariable
+
+
+class DshYdmapCanonicalizationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        FakeVariable.values = {
+            "PI_DEVICE_SSH": {
+                "host": "203.0.113.10",
+                "port": 6000,
+                "username": "pi-user",
+                "password": "secret",
+                "host_key_sha256": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            },
+            "SZ_TENNIS_CHATROOMS": "Zacks_网球场",
+        }
+
+    def test_adjacent_scraper_cells_canonicalize_to_one_stable_range(self) -> None:
+        split = {"7号场": [["21:00", "21:30"], ["21:30", "22:00"]]}
+        merged = {"7号场": [["21:00", "22:00"]]}
+
+        self.assertEqual(dsh_watcher.canonicalize_court_availability(split), merged)
+        self.assertEqual(dsh_watcher.canonicalize_court_availability(merged), merged)
+
+    def test_run_publishes_same_host_core_slot_for_split_and_merged_shapes(self) -> None:
+        original_fetch = dsh_watcher.fetch_inspect_payload
+        original_publish = dsh_watcher.publish_venue_observation
+        original_enqueue = dsh_watcher.enqueue_wechat_message
+        original_datetime = dsh_watcher.datetime
+
+        class FixedDatetime(original_datetime.datetime):
+            @classmethod
+            def now(cls, tz: object = None) -> FixedDatetime:
+                return cls(2026, 9, 6, 13, 0, 0)
+
+        class FixedDatetimeModule:
+            datetime = FixedDatetime
+            time = original_datetime.time
+            timedelta = original_datetime.timedelta
+
+        published: list[list[dict[str, str]]] = []
+        payloads = [
+            {
+                "ok": True,
+                "days": [
+                    {
+                        "date": "2026-09-06",
+                        "courts": {"7号场": [["21:00", "21:30"], ["21:30", "22:00"]]},
+                    }
+                ],
+            },
+            {
+                "ok": True,
+                "days": [
+                    {"date": "2026-09-06", "courts": {"7号场": [["21:00", "22:00"]]}}
+                ],
+            },
+        ]
+
+        def fake_fetch(config: object, *, days: int) -> dict[str, object]:
+            return payloads.pop(0)
+
+        def fake_publish(
+            venue_id: str,
+            venue_name: str,
+            slots: list[dict[str, str]],
+            **kwargs: object,
+        ) -> dict[str, bool]:
+            published.append(slots)
+            return {"success": True}
+
+        dsh_watcher.fetch_inspect_payload = fake_fetch
+        dsh_watcher.publish_venue_observation = fake_publish
+        dsh_watcher.enqueue_wechat_message = lambda message: {"success": True}
+        dsh_watcher.datetime = FixedDatetimeModule
+        try:
+            dsh_watcher.run_check_tennis_courts()
+            FakeVariable.values[dsh_watcher.CACHE_KEY] = []
+            dsh_watcher.run_check_tennis_courts()
+        finally:
+            dsh_watcher.fetch_inspect_payload = original_fetch
+            dsh_watcher.publish_venue_observation = original_publish
+            dsh_watcher.enqueue_wechat_message = original_enqueue
+            dsh_watcher.datetime = original_datetime
+
+        expected = [
+            {
+                "date": "2026-09-06",
+                "court_name": "7号场",
+                "start_time": "21:00",
+                "end_time": "22:00",
+            }
+        ]
+        self.assertEqual(published, [expected, expected])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
Production subscriber mail for 大沙河国际网球中心 could send the same availability twice when the upstream scraper represented one continuous interval differently across adjacent 3-minute polls, e.g. `21:00-21:30 + 21:30-22:00` followed by `21:00-22:00`.

## Fix
- Canonicalize each court's contiguous/overlapping scraper ranges into stable maximal intervals before publishing the Host Core observation.
- Feed that same canonical shape to the existing WeChat notification path.
- Add a focused regression that proves split half-hour cells and a merged one-hour cell publish the identical Host Core slot.
- Prepare patch release `0.8.1`; release scope is Airflow-only and must not emit synthetic email/WeChat.

## Safety
No polling cadence, PostgreSQL schema/data migration, Web assets, Sender runtime, credentials, or provider behavior changes. Existing Host Core idempotency remains the final delivery fence.