### PR TITLE
fix: prevent silent notification loss and ship all notification runtimes (0.8.2)

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -123,6 +123,7 @@ jobs:
           if [ "$INCLUDE_SENDER" = true ]; then
             args+=(--include-sender)
           fi
+          python scripts/host_core_release_scope.py --scope "$SCOPE"
           python scripts/release_plan.py "${args[@]}" | tee /tmp/release-plan.json
           {
             echo "## Release plan"

--- a/.github/workflows/production-ship.yml
+++ b/.github/workflows/production-ship.yml
@@ -86,13 +86,14 @@ jobs:
           SENDER: ${{ inputs.include_sender }}
         run: |
           python scripts/release_contract.py --version "$VERSION"
-          if [ "$VERSION" = 0.7.0 ]; then
+          python scripts/host_core_release_scope.py --scope "$SCOPE"
+          if [ "$VERSION" = 0.7.0 ] || [ "$SCOPE" = all ]; then
             test "$SCOPE" = all
             test "$SENDER" = true
           fi
 
   host_core_cutover:
-    if: inputs.version == '0.7.0'
+    if: inputs.version == '0.7.0' || inputs.scope == 'all'
     needs: contract
     uses: ./.github/workflows/production-host-core.yml
     with:
@@ -105,7 +106,7 @@ jobs:
     if: >-
       always() &&
       needs.contract.result == 'success' &&
-      (inputs.version != '0.7.0' || needs.host_core_cutover.result == 'success')
+      ((inputs.version != '0.7.0' && inputs.scope != 'all') || needs.host_core_cutover.result == 'success')
     uses: ./.github/workflows/production-release.yml
     with:
       mode: apply
@@ -115,7 +116,7 @@ jobs:
     secrets: inherit
 
   natural_cycles:
-    if: inputs.version == '0.7.0'
+    if: inputs.version == '0.7.0' || inputs.scope == 'all'
     needs: deploy
     uses: ./.github/workflows/production-host-core.yml
     with:
@@ -124,7 +125,7 @@ jobs:
     secrets: inherit
 
   acceptance:
-    if: inputs.version == '0.7.0'
+    if: inputs.version == '0.7.0' || inputs.scope == 'all'
     needs: natural_cycles
     uses: ./.github/workflows/production-host-core.yml
     with:
@@ -134,7 +135,7 @@ jobs:
 
   safe_pause_on_failure:
     if: >-
-      always() && inputs.version == '0.7.0' &&
+      always() && (inputs.version == '0.7.0' || inputs.scope == 'all') &&
       needs.host_core_cutover.result == 'success' &&
       (needs.deploy.result != 'success' || needs.natural_cycles.result != 'success' || needs.acceptance.result != 'success')
     needs: [host_core_cutover, deploy, natural_cycles, acceptance]
@@ -149,7 +150,7 @@ jobs:
     if: >-
       always() &&
       needs.deploy.result == 'success' &&
-      (inputs.version != '0.7.0' || needs.acceptance.result == 'success')
+      ((inputs.version != '0.7.0' && inputs.scope != 'all') || needs.acceptance.result == 'success')
     uses: ./.github/workflows/release-tag-chatops.yml
     with:
       version: ${{ inputs.version }}
@@ -194,7 +195,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           test "$CONTRACT_RESULT" = success
           test "$DEPLOY_RESULT" = success
-          if [ "$VERSION" = 0.7.0 ]; then
+          if [ "$VERSION" = 0.7.0 ] || [ "$REQUESTED_SCOPE" = all ]; then
             test "$HOST_CORE_CUTOVER_RESULT" = success
             test "$NATURAL_CYCLES_RESULT" = success
             test "$ACCEPTANCE_RESULT" = success

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,32 @@
 This project follows Semantic Versioning. Entries describe user-visible runtime
 and operational changes.
 
-## Unreleased
+## [0.8.2] - 2026-09-07
 
 ### Fixed
 
-- Treat PosPal `result.enrollSlots` as occupied court overlays before publishing direct-booking availability. Organized activities can leave the underlying `slots[].apptInfo.canApptOrNot` flag true even though the official mini-program assigns the court; overlapping cells are now suppressed across 福中福, TOPS, PICKLE POP, the shared 泛思博特 chain, and FFT 前海 adapters.
-- Add a regression reproducing the 2026-09-07 福中福 5/6号风雨场 18:00-24:00 enrollment blocks so participant-count activities such as 4/4, 2/4, or 0/4 are never announced as empty whole courts.
+- Include the mainline PosPal enrollment-overlay fix (#216); occupied activity courts
+  are no longer advertised as directly bookable whole courts.
+- Exclude already-started Dashah free slots using Asia/Shanghai and reject malformed
+  upstream collections instead of publishing a false healthy-empty result.
+- Require a durable observation acknowledgement before claiming WeChat notices;
+  stale lines no longer block unrelated valid lines at enqueue or dispatch.
+- Distinguish sender preparation from irreversible UI submission with a durable
+  checkpoint; only proven-unsent outcomes retry (bounded), never ambiguous sends.
+  Remove click-level stale-element retries and preserve privacy-safe error codes.
+- Reconcile uncertain transport outcomes with the sender ledger using the exact
+  payload hash; only confirmed sent records are finalized, never replayed.
+- Explain inactive/expired personal subscriptions separately from global email
+  delivery. Existing disabled subscriptions remain untouched.
+- Run the fenced Host Core lifecycle and natural-delivery acceptance for every
+  scope=all ship, not only 0.7.0. Reject Host Core changes under a partial scope.
 
 ### Operations
 
-- Airflow-only parsing correction. No polling cadence, subscriber data, database schema, Web asset, Sender runtime, or provider credential changes; acceptance must use natural inspections without synthetic notifications.
+- Ship with `scope=all sender=true` after exact-SHA CI. All runtime components
+  must pass production acceptance before the immutable release is published.
+- Preserve historical unknown outcomes, subscriptions, credentials and the D1
+  archive. No synthetic emails or WeChat messages are sent for verification.
 
 ## [0.8.1] - 2026-09-06
 

--- a/docs/runbooks/host-core-cutover.md
+++ b/docs/runbooks/host-core-cutover.md
@@ -101,3 +101,31 @@ transport does not traverse a Cloudflare proxy before claiming end-to-end
 Cloudflare-independent delivery. Neither frontend cache nor D1 is an automatic
 business recovery source. Back up the PG business schema and Sender ledger and
 rehearse recovery in isolation; do not claim high availability from a single host.
+
+## Notification reliability releases (0.8.2 and later)
+
+A change under `src/wechat_airflow/host_core/` requires `scope=all sender=true`
+and the protected **ship** lifecycle, not an Airflow-only apply. The lifecycle
+builds and checks the new Host Core image, fences delivery, updates all consumers,
+then requires exact identities, three natural venue cycles, API transaction
+rollback acceptance and natural email/WeChat evidence before tagging. A verified
+existing migration checkpoint skips the D1 import. Never clear the checkpoint or
+reimport the archive to get a later release through its gate.
+
+Collection, enqueue and delivery are separate signals. In particular, a green
+venue DAG is not a delivery receipt. Enqueue failures are recorded as hashed
+`wechat_delivery_incidents` and checked independently by business acceptance;
+new terminal send failures and unknown submissions fail the release health gate.
+The website's latest venue email receipt is channel-wide, not the logged-in
+subscriber's receipt or a WeChat receipt. No effective subscription means no
+email will be generated; do not automatically revive cancelled/expired rules.
+
+Expired availability lines are removed individually at enqueue and dispatch;
+malformed lines remain protocol errors. Sender records `preparing` before UI
+navigation and durably switches to `dispatching` immediately before the first
+irreversible send action. Only proven `not_submitted` outcomes get bounded
+retries. Historical `dispatching`/`submission_unknown` rows are never replayed.
+Read-only status reconciliation requires both idempotency key and payload hash,
+and can only mark a message sent when the device ledger confirms it. Missing
+or uncertain device evidence stays quarantined for operator review. Never send
+synthetic notifications or reset old queue/cache entries as acceptance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wechat-on-airflow"
-version = "0.8.1"
+version = "0.8.2"
 description = "Airflow workflows for Shenzhen tennis availability notifications."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/scripts/host_core_release_scope.py
+++ b/scripts/host_core_release_scope.py
@@ -1,0 +1,27 @@
+"""Prevent a Host Core runtime patch from being shipped as an Airflow-only update."""
+
+from __future__ import annotations
+
+import argparse
+
+from release_plan import diff_files, previous_release_commit, resolve_commit
+
+
+def requires_host_core(paths: list[str]) -> bool:
+    return any(path.startswith("src/wechat_airflow/host_core/") for path in paths)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scope", required=True)
+    args = parser.parse_args()
+    target = resolve_commit("HEAD")
+    if (
+        requires_host_core(diff_files(previous_release_commit(target), target))
+        and args.scope != "all"
+    ):
+        parser.error("Host Core changes require scope=all sender=true and full business acceptance")
+
+
+if __name__ == "__main__":
+    main()

--- a/sender_agent/app.py
+++ b/sender_agent/app.py
@@ -18,6 +18,7 @@ from wechat_sender import (
     cleanup_appium_device,
     send_text_messages,
 )
+from wechat_sender.appium_text_sender import SendProgress
 
 APP_NAME = "wechat-sender-agent"
 DEFAULT_APPIUM_URL = "http://127.0.0.1:6002"
@@ -197,6 +198,24 @@ def readyz():
     }
 
 
+class StatusRequest(BaseModel):
+    idempotency_key: str = Field(min_length=1, max_length=256)
+    payload_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+@app.post("/v1/wechat/status")
+def send_status(request: StatusRequest):
+    """Read ledger evidence only. Missing/unknown is never permission to resend."""
+    if not device_lock.acquire(blocking=False):
+        return _json_error(409, "device_busy", "sender currently processing")
+    try:
+        return ledger.lookup(request.idempotency_key, request.payload_hash)
+    except Exception:
+        return _json_error(503, "ledger_unavailable", "durable sender ledger is unavailable")
+    finally:
+        device_lock.release()
+
+
 @app.post("/v1/wechat/send")
 def send_wechat(request: SendRequest):
     global _warm_operator, _warm_appium_url
@@ -228,7 +247,7 @@ def send_wechat(request: SendRequest):
         payload_hash = hashlib.sha256(canonical.encode()).hexdigest()
         key = request.idempotency_key or payload_hash
         try:
-            phase, cached = ledger.claim(key, payload_hash)
+            phase, cached = ledger.claim(key, payload_hash, preparing=True)
         except Exception:
             return _json_error(503, "ledger_unavailable", "durable sender ledger is unavailable")
         if phase == "sent":
@@ -244,6 +263,7 @@ def send_wechat(request: SendRequest):
 
         appium_url = _appium_url()
         existing_operator = _usable_warm_operator(request.device_name, appium_url)
+        progress = SendProgress(before_submit=lambda: ledger.mark_submitting(key))
         try:
             result = send_text_messages(
                 appium_server_url=appium_url,
@@ -252,13 +272,28 @@ def send_wechat(request: SendRequest):
                 messages=request.messages,
                 existing_operator=existing_operator,
                 close_operator=False,
+                progress=progress,
                 preflight_cleanup=None if existing_operator else cleanup_appium_device,
                 startup_wait_seconds=0 if existing_operator else 1.0,
             )
-        except Exception:
+        except Exception as exc:
             _discard_warm_operator()
-            ledger.finish(key, "submission_unknown")
-            raise
+            code = exc.error_code if isinstance(exc, WeChatSenderError) else "send_failed"
+            outcome = "submission_unknown" if progress.submission_started else "not_submitted"
+            payload = {
+                "success": False,
+                "error": code,
+                "message": "sender outcome requires reconciliation"
+                if progress.submission_started
+                else "sender failed before submission",
+                "submission_state": outcome,
+                "safe_to_retry": not progress.submission_started,
+                "sent_count": progress.confirmed_count,
+            }
+            ledger.finish(key, outcome, payload)
+            return JSONResponse(
+                status_code=504 if code == "appium_timeout" else 500, content=payload
+            )
 
         _warm_operator = result.operator
         _warm_appium_url = appium_url

--- a/sender_agent/ledger.py
+++ b/sender_agent/ledger.py
@@ -32,7 +32,7 @@ def connection():
         database.close()
 
 
-def claim(key: str, payload_hash: str) -> tuple[str, dict | None]:
+def claim(key: str, payload_hash: str, *, preparing: bool = False) -> tuple[str, dict | None]:
     with connection() as database:
         database.execute("BEGIN IMMEDIATE")
         try:
@@ -45,12 +45,18 @@ def claim(key: str, payload_hash: str) -> tuple[str, dict | None]:
                     result = ("conflict", None)
                 elif row[1] == "sent":
                     result = ("sent", json.loads(row[2]))
+                elif preparing and row[1] in {"preparing", "not_submitted"}:
+                    database.execute(
+                        "UPDATE sends SET status='preparing', result_json=NULL, updated_at=CURRENT_TIMESTAMP WHERE idempotency_key=?",
+                        (key,),
+                    )
+                    result = ("claimed", None)
                 else:
                     result = ("submission_unknown", None)
             else:
                 database.execute(
-                    "INSERT INTO sends(idempotency_key,payload_hash,status) VALUES(?,?,'dispatching')",
-                    (key, payload_hash),
+                    "INSERT INTO sends(idempotency_key,payload_hash,status) VALUES(?,?,?)",
+                    (key, payload_hash, "preparing" if preparing else "dispatching"),
                 )
                 result = ("claimed", None)
             database.execute("COMMIT")
@@ -60,14 +66,27 @@ def claim(key: str, payload_hash: str) -> tuple[str, dict | None]:
             raise
 
 
+def mark_submitting(key: str) -> None:
+    """Durably cross the irreversible boundary BEFORE the first UI send action."""
+    with connection() as database:
+        changed = database.execute(
+            "UPDATE sends SET status='dispatching', updated_at=CURRENT_TIMESTAMP "
+            "WHERE idempotency_key=? AND status='preparing'",
+            (key,),
+        ).rowcount
+        if changed != 1:
+            raise RuntimeError("sender checkpoint was not acknowledged")
+
+
 def finish(key: str, status: str, result: dict | None = None) -> None:
-    if status not in {"sent", "submission_unknown"}:
+    if status not in {"sent", "submission_unknown", "not_submitted"}:
         raise ValueError("invalid sender ledger result")
     with connection() as database:
         database.execute(
             "UPDATE sends SET status=?, result_json=?, updated_at=CURRENT_TIMESTAMP "
-            "WHERE idempotency_key=? AND status='dispatching'",
-            (status, json.dumps(result, ensure_ascii=False) if result else None, key),
+            "WHERE idempotency_key=? AND status IN ('preparing','dispatching') "
+            "AND (? != 'not_submitted' OR status='preparing')",
+            (status, json.dumps(result, ensure_ascii=False) if result else None, key, status),
         )
 
 
@@ -77,3 +96,20 @@ def ready() -> bool:
             return database.execute("PRAGMA quick_check").fetchone()[0] == "ok"
     except (OSError, RuntimeError, sqlite3.Error):
         return False
+
+
+def lookup(key: str, payload_hash: str) -> dict:
+    with connection() as database:
+        row = database.execute(
+            "SELECT status, result_json, updated_at FROM sends WHERE idempotency_key=? AND payload_hash=?",
+            (key, payload_hash),
+        ).fetchone()
+    if row is None:
+        return {"status": "not_found"}
+    payload = json.loads(row[1]) if row[1] else {}
+    return {
+        "status": row[0],
+        "updated_at": row[2],
+        "confirmed": row[0] == "sent" and payload.get("success") is True,
+        "sent_count": payload.get("sent_count", 0),
+    }

--- a/src/wechat_airflow/__init__.py
+++ b/src/wechat_airflow/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime code for the production Airflow workflows."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/src/wechat_airflow/host_core/health.py
+++ b/src/wechat_airflow/host_core/health.py
@@ -210,12 +210,22 @@ def business_report(expected_commit: str, *, require_delivery: bool = False) -> 
             queues[table] = {"allHistory": groups, "createdThisRelease": recent}
             unknown = sum(row["count"] for row in recent if row["status"] == "submission_unknown")
             checks[f"{table}:noNewUnknownSubmission"] = unknown == 0
+            failed = sum(row["count"] for row in recent if row["status"] == "failed")
+            checks[f"{table}:noNewTerminalFailure"] = failed == 0
             overdue = connection.execute(
                 text(f"""SELECT count(*) FROM zacks.{table}
                 WHERE status IN ('pending','retry','processing','dispatching')
                 AND created_at < now() - interval '15 minutes'""")
             ).scalar_one()
             checks[f"{table}:noStalledBacklog"] = overdue == 0
+        enqueue_incidents = connection.execute(
+            text("""
+            SELECT count(*) FROM zacks.wechat_delivery_incidents
+            WHERE source LIKE 'enqueue:%' AND resolved_at IS NULL AND last_failed_at >= :since
+        """),
+            {"since": since},
+        ).scalar_one()
+        checks["wechatEnqueueIncidentsResolved"] = enqueue_incidents == 0
         natural = dict(
             connection.execute(
                 text("""SELECT
@@ -256,6 +266,7 @@ def business_report(expected_commit: str, *, require_delivery: bool = False) -> 
         "observationScopes": scopes,
         "dags": dag_results,
         "queues": queues,
+        "unresolvedEnqueueIncidents": enqueue_incidents,
         "naturalDelivery": natural,
         "sender": sender,
         "notificationsGeneratedForAcceptance": 0,

--- a/src/wechat_airflow/host_core/service.py
+++ b/src/wechat_airflow/host_core/service.py
@@ -12,6 +12,7 @@ from sqlalchemy.engine import Connection
 
 from .database import transaction
 from .domain import (
+    SHANGHAI,
     VenueObservation,
     format_slot_line,
     observation_fingerprint,
@@ -265,6 +266,11 @@ def ingest_observation(payload: object) -> dict[str, Any]:
         matched_notifications = 0
         if observation.healthy:
             for slot in observation.slots:
+                start_at = datetime.combine(
+                    slot.booking_date, datetime.strptime(slot.start_time, "%H:%M").time(), SHANGHAI
+                )
+                if start_at <= now:
+                    continue
                 event_key = slot_event_key(observation.venue_id, slot)
                 for subscription in subscriptions:
                     if not slot_matches(

--- a/src/wechat_airflow/host_core/wechat_queue.py
+++ b/src/wechat_airflow/host_core/wechat_queue.py
@@ -11,12 +11,16 @@ from sqlalchemy import text
 
 from .database import transaction
 from .domain import VENUES, utc_now
-from .service import active_subscription_for_venue
+from .service import active_subscription_for_venue, record_wechat_incident
 
 LINE = re.compile(
     r"^【(.+)】星期[一二三四五六日]\((\d{2}-\d{2})\)空场[:：]\s*(\d{2}:\d{2})-(\d{2}:\d{2})$"
 )
 SHANGHAI = ZoneInfo("Asia/Shanghai")
+
+
+class AvailabilityChanged(ValueError):
+    """One well-formed interval no longer has complete current coverage."""
 
 
 def covered_events(message: str, slots: list[dict[str, Any]]) -> list[str]:
@@ -27,6 +31,8 @@ def covered_events(message: str, slots: list[dict[str, Any]]) -> list[str]:
         if not match:
             raise ValueError("Wechat observation line is invalid")
         court, day, start, end = match.groups()
+        if not "00:00" <= start < end <= "24:00" or start[3:] > "59" or end[3:] > "59":
+            raise ValueError("Wechat observation interval is invalid")
         if end == "24:00":
             end = "23:59"
         candidates = sorted(
@@ -50,14 +56,35 @@ def covered_events(message: str, slots: list[dict[str, Any]]) -> list[str]:
             if cursor >= end:
                 break
         if cursor < end:
-            raise ValueError("Wechat availability changed before enqueue")
+            raise AvailabilityChanged("Wechat availability changed before enqueue")
         result.update(keys)
     if not result:
         raise ValueError("Wechat message has no current availability")
     return sorted(result)
 
 
-def enqueue(payload: dict[str, Any]) -> dict[str, Any]:
+def current_message(message: str, slots: list[dict[str, Any]]) -> tuple[str, list[str], list[str]]:
+    """Drop unavailable lines without letting one poison unrelated valid lines.
+
+    Malformed lines remain errors. Never trim a partially covered interval into
+    an invented availability interval. Rejected lines can release collector claims.
+    """
+    retained: list[str] = []
+    rejected: list[str] = []
+    keys: set[str] = set()
+    for line in sorted(set(message.splitlines())):
+        line = line.strip()
+        try:
+            covered = covered_events(line, slots)
+        except AvailabilityChanged:
+            rejected.append(line)
+        else:
+            retained.append(line)
+            keys.update(covered)
+    return "\n".join(retained), sorted(keys), rejected
+
+
+def _enqueue(payload: dict[str, Any]) -> dict[str, Any]:
     venue = str(payload.get("venue_id") or "")
     message = str(payload.get("message") or "").strip()
     device = str(payload.get("device_name") or "").strip()
@@ -97,8 +124,17 @@ def enqueue(payload: dict[str, Any]) -> dict[str, Any]:
                 {"venue": venue},
             ).mappings()
         ]
-        keys = covered_events(message, slots)
-        start_at = min(
+        message, keys, rejected = current_message(message, slots)
+        if not keys:
+            return {
+                "success": True,
+                "queued": 0,
+                "suppressed": True,
+                "reason": "availability_changed",
+                "rejected_lines": rejected,
+            }
+        # An early-starting line must not expire later lines in the same digest.
+        start_at = max(
             datetime.combine(
                 s["booking_date"], datetime.strptime(s["start_time"], "%H:%M").time(), SHANGHAI
             )
@@ -130,4 +166,53 @@ def enqueue(payload: dict[str, Any]) -> dict[str, Any]:
                 },
             )
             ids.append(key)
-    return {"success": True, "queued": len(ids), "ids": ids, "durable": True}
+    return {
+        "success": True,
+        "queued": len(ids),
+        "ids": ids,
+        "durable": True,
+        "rejected_lines": rejected,
+    }
+
+
+def enqueue(payload: dict[str, Any]) -> dict[str, Any]:
+    """Record transport-independent failures without exposing targets or content."""
+    venue = str(payload.get("venue_id") or "")
+    message = str(payload.get("message") or "").strip()
+    receivers = payload.get("receivers")
+    groups = [str(r).strip() for r in receivers[:20]] if isinstance(receivers, list) else []
+    source = f"enqueue:{venue}"
+    try:
+        result = _enqueue(payload)
+    except Exception as exc:
+        if venue in VENUES:
+            for receiver in groups:
+                record_wechat_incident(
+                    source=source,
+                    receiver=receiver,
+                    message=message,
+                    error=RuntimeError(type(exc).__name__),
+                    error_code=type(exc).__name__,
+                )
+        raise
+    # A subsequent acknowledged retry resolves only this digest's own incident.
+    # A resolution-write failure must not turn an already durable enqueue into failure.
+    try:
+        with transaction() as connection:
+            connection.execute(
+                text("""
+                UPDATE zacks.wechat_delivery_incidents SET resolved_at=now()
+                WHERE source=:source AND message_hash=:message
+                  AND receiver_hash=ANY(:receivers) AND resolved_at IS NULL
+            """),
+                {
+                    "source": source,
+                    "message": hashlib.sha256(message.encode()).hexdigest(),
+                    "receivers": [
+                        hashlib.sha256(receiver.encode()).hexdigest() for receiver in groups
+                    ],
+                },
+            )
+    except Exception:
+        pass
+    return result

--- a/src/wechat_airflow/host_core/wechat_worker.py
+++ b/src/wechat_airflow/host_core/wechat_worker.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import socket
 import time
 import uuid
+from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -22,10 +24,26 @@ from .control import delivery_guard, runtime_state
 from .database import ensure_schema, get_engine, transaction
 from .service import active_subscription_for_venue, runtime_heartbeat
 from .settings import _first_value, load_settings
+from .wechat_queue import current_message
 
 LOGGER = logging.getLogger(__name__)
 # One host consumer across all devices; the sender independently serializes each device.
 CONSUMER_LOCK = 728190316
+MAX_ATTEMPTS = 3
+SENDER_ERRORS = {
+    "device_busy",
+    "device_not_ready",
+    "service_misconfigured",
+    "ledger_unavailable",
+    "wechat_not_ready",
+    "contact_not_found",
+    "appium_timeout",
+    "send_failed",
+    "submission_unknown",
+    "idempotency_conflict",
+    "invalid_request",
+    "device_not_allowed",
+}
 
 
 def sender_readiness() -> dict[str, Any]:
@@ -91,6 +109,13 @@ def _claim(worker_id: str) -> dict[str, Any] | None:
 
 
 def _finish(row: dict[str, Any], worker: str, status: str, reason: str | None = None) -> None:
+    if status in {"failed", "submission_unknown"}:
+        LOGGER.error(
+            "WeChat delivery requires attention venue=%s status=%s reason=%s",
+            row["venue_id"],
+            status,
+            reason,
+        )
     with transaction() as connection:
         connection.execute(
             text("""
@@ -121,20 +146,25 @@ def _prepare(row: dict[str, Any], worker: str) -> bool:
         _finish(row, worker, "cancelled", "no_active_subscription")
         return False
     with transaction() as connection:
-        keys = row["event_keys"]
-        count = connection.execute(
-            text("""
-            SELECT count(*) FROM zacks.observed_slots s WHERE s.event_key = ANY(:keys)
+        slots = [
+            dict(slot)
+            for slot in connection.execute(
+                text("""
+            SELECT s.* FROM zacks.observed_slots s WHERE s.event_key = ANY(:keys)
             AND (s.booking_date + CAST(s.start_time AS time)) AT TIME ZONE 'Asia/Shanghai' > now()
             AND EXISTS (SELECT 1 FROM zacks.current_availability c
                 WHERE c.event_key = s.event_key AND c.last_seen_at > now() - interval '15 minutes')
-        """),
-            {"keys": keys},
-        ).scalar_one()
-        if count != len(keys):
-            valid = False
-        else:
-            valid = True
+            """),
+                {"keys": row["event_keys"]},
+            ).mappings()
+        ]
+        message, keys, _rejected = current_message(row["message"], slots)
+        valid = bool(keys)
+        if valid:
+            if message != row["message"]:
+                row["outbound_message"] = None
+                row["message"] = message
+            row["event_keys"] = keys
             outbound = row.get("outbound_message") or row["message"]
             program = program_for_venue(str(row["venue_id"]))
             program_id = row.get("program_id")
@@ -159,14 +189,25 @@ def _prepare(row: dict[str, Any], worker: str) -> bool:
             connection.execute(
                 text("""
                 UPDATE zacks.wechat_outbox SET status = 'dispatching', outbound_message = :message,
-                    program_id = :program, updated_at = now()
+                    message = :source_message, event_keys = CAST(:keys AS jsonb), program_id = :program, updated_at = now()
                 WHERE id = :id AND lease_owner = :worker AND status = 'processing'
             """),
-                {"message": outbound, "program": program_id, "id": row["id"], "worker": worker},
+                {
+                    "message": outbound,
+                    "source_message": row["message"],
+                    "keys": json.dumps(keys),
+                    "program": program_id,
+                    "id": row["id"],
+                    "worker": worker,
+                },
             )
     if not valid:
         _finish(row, worker, "expired", "availability_changed")
     return valid
+
+
+def _retry(row: dict[str, Any], worker: str, reason: str) -> None:
+    _finish(row, worker, "retry" if row["attempt_count"] < MAX_ATTEMPTS else "failed", reason)
 
 
 def deliver(row: dict[str, Any], worker: str) -> None:
@@ -181,7 +222,7 @@ def deliver(row: dict[str, Any], worker: str) -> None:
             or not readiness.get("durableIdempotency")
             or readiness.get("deploymentCommit") != os.environ.get("DEPLOYMENT_COMMIT")
         ):
-            _finish(row, worker, "retry", "sender_not_ready")
+            _retry(row, worker, "sender_not_ready")
             return
         if not _prepare(row, worker):
             return
@@ -193,28 +234,131 @@ def deliver(row: dict[str, Any], worker: str) -> None:
                     "receiver": row["receiver"],
                     "device_name": row["device_name"],
                     "messages": [row["outbound_message"]],
-                    "idempotency_key": row["id"],
+                    # Retries with an unchanged payload keep the same identity.
+                    # A known-unsent digest pruned before retry gets its own payload identity.
+                    "idempotency_key": hashlib.sha256(
+                        (row["id"] + "\0" + row["outbound_message"]).encode()
+                    ).hexdigest(),
                 },
                 timeout=210,
             )
             payload = response.json()
+            if not isinstance(payload, dict):
+                raise ValueError("sender_response_invalid")
+            error = str(payload.get("error") or "sender_result_unknown")
+            if error not in SENDER_ERRORS:
+                error = "sender_result_unknown"
             if response.status_code == 200 and payload.get("success") is True:
                 _finish(row, worker, "sent")
-            elif payload.get("error") in {
+            elif error in {
                 "device_busy",
                 "device_not_ready",
                 "service_misconfigured",
-            }:
-                _finish(row, worker, "retry", str(payload.get("error")))
+                "ledger_unavailable",
+            } or (
+                payload.get("safe_to_retry") is True
+                and payload.get("submission_state") == "not_submitted"
+                and payload.get("sent_count") == 0
+                and error in SENDER_ERRORS
+            ):
+                _retry(row, worker, error)
             elif payload.get("error") in {"invalid_request", "device_not_allowed"}:
                 _finish(row, worker, "failed", str(payload.get("error")))
             else:
                 # Unknown/partial UI send is NOT retried automatically.
-                _finish(row, worker, "submission_unknown", "sender_result_unknown")
+                _finish(row, worker, "submission_unknown", error)
         except requests.ConnectTimeout:
-            _finish(row, worker, "retry", "connection_timeout_before_submission")
+            _retry(row, worker, "connection_timeout_before_submission")
         except Exception as exc:
             _finish(row, worker, "submission_unknown", type(exc).__name__)
+
+
+def reconcile_unknown() -> None:
+    """A ledger-confirmed send may clear uncertainty; all other states stay quarantined."""
+    endpoint = _first_value("WECHAT_SEND_API_URL") or ""
+    if not endpoint:
+        return
+    parsed = urlsplit(endpoint)
+    endpoint = urlunsplit((parsed.scheme, parsed.netloc, "/v1/wechat/status", "", ""))
+    with transaction() as connection:
+        rows = [
+            dict(row)
+            for row in connection.execute(
+                text("""
+            SELECT * FROM zacks.wechat_outbox WHERE status='submission_unknown'
+            AND created_at > now() - interval '1 day' AND next_attempt_at <= now()
+            ORDER BY next_attempt_at LIMIT 5 FOR UPDATE SKIP LOCKED
+        """)
+            ).mappings()
+        ]
+        for row in rows:
+            connection.execute(
+                text("""
+                UPDATE zacks.wechat_outbox SET next_attempt_at=now()+interval '5 minutes'
+                WHERE id=:id AND status='submission_unknown'
+            """),
+                {"id": row["id"]},
+            )
+    for row in rows:
+        if not row.get("outbound_message"):
+            continue
+        canonical = json.dumps(
+            {
+                "device": row["device_name"],
+                "receiver": row["receiver"],
+                "messages": [row["outbound_message"]],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        payload_hash = hashlib.sha256(canonical.encode()).hexdigest()
+        derived_key = hashlib.sha256(
+            (row["id"] + "\0" + row["outbound_message"]).encode()
+        ).hexdigest()
+        # Old rows used the queue ID directly. Either lookup must match the full payload.
+        for key in (derived_key, row["id"]):
+            try:
+                response = requests.post(
+                    endpoint, json={"idempotency_key": key, "payload_hash": payload_hash}, timeout=5
+                )
+                response.raise_for_status()
+                evidence = response.json()
+                if (
+                    not isinstance(evidence, dict)
+                    or evidence.get("confirmed") is not True
+                    or evidence.get("sent_count") != 1
+                ):
+                    continue
+                stamp = datetime.fromisoformat(str(evidence["updated_at"]).replace("Z", "+00:00"))
+                if stamp.tzinfo is None:
+                    stamp = stamp.replace(tzinfo=UTC)
+                with transaction() as connection:
+                    connection.execute(
+                        text("""
+                        UPDATE zacks.wechat_outbox SET status='sent', sent_at=:sent,
+                        last_error=NULL, lease_owner=NULL, lease_until=NULL, updated_at=now()
+                        WHERE id=:id AND status='submission_unknown'
+                    """),
+                        {"id": row["id"], "sent": stamp},
+                    )
+                    if row.get("program_id"):
+                        connection.execute(
+                            text("""
+                            INSERT INTO zacks.booking_link_cooldowns(receiver_hash,program_id,sent_at)
+                            VALUES(:receiver,:program,:sent) ON CONFLICT(receiver_hash,program_id)
+                            DO UPDATE SET sent_at=GREATEST(zacks.booking_link_cooldowns.sent_at,EXCLUDED.sent_at)
+                        """),
+                            {
+                                "receiver": hashlib.sha256(row["receiver"].encode()).hexdigest(),
+                                "program": row["program_id"],
+                                "sent": stamp,
+                            },
+                        )
+                break
+            except Exception as exc:
+                LOGGER.warning("Sender reconciliation unavailable: %s", type(exc).__name__)
+                break
 
 
 def main() -> None:
@@ -228,6 +372,7 @@ def main() -> None:
             raise RuntimeError("Another WeChat consumer already owns the device queue")
         backend_pid = lock.execute(text("SELECT pg_backend_pid()")).scalar_one()
         lock.commit()
+        next_reconcile = 0.0
         while True:
             # Losing the dedicated lock connection is fatal: never auto-reconnect
             # and continue sending without the session-level device fence.
@@ -250,6 +395,9 @@ def main() -> None:
                 )
                 if row:
                     deliver(row, worker)
+                elif time.monotonic() >= next_reconcile:
+                    reconcile_unknown()
+                    next_reconcile = time.monotonic() + 60
                 else:
                     time.sleep(5)
             except KeyboardInterrupt:

--- a/src/wechat_airflow/notifications/webapp.py
+++ b/src/wechat_airflow/notifications/webapp.py
@@ -235,9 +235,9 @@ def publish_venue_observation(
             response_payload = response.json()
         except ValueError:
             response_payload = {}
-        gate = _normalize_gate(
-            response_payload.get("wechatGate") if isinstance(response_payload, dict) else None
-        )
+        if not isinstance(response_payload, dict) or response_payload.get("success") is not True:
+            raise RuntimeError("observation_not_acknowledged")
+        gate = _normalize_gate(response_payload.get("wechatGate"))
         print(
             f"[WEBAPP] observation published venue={venue_id}, "
             f"scope={normalized_scope}, healthy={healthy}, slots={slot_count}, "

--- a/src/wechat_airflow/notifications/wechat.py
+++ b/src/wechat_airflow/notifications/wechat.py
@@ -418,7 +418,11 @@ def send_wechat_text_to_chatrooms_best_effort(
             raise RuntimeError("Host Core did not acknowledge the durable intent")
         if result.get("suppressed"):
             _release_subscription_gate_dedupe(str(booking_venue_id or ""), message)
-        return [{"success": True, "queued": True, "result": result}]
+        elif result.get("rejected_lines"):
+            rejected = result["rejected_lines"]
+            if isinstance(rejected, list) and all(isinstance(line, str) for line in rejected):
+                _release_subscription_gate_dedupe(str(booking_venue_id or ""), "\n".join(rejected))
+        return [{"success": True, "queued": bool(result.get("queued")), "result": result}]
     except Exception as exc:
         # Release the watcher preclaim only; the durable queue ID makes retry safe.
         _release_subscription_gate_dedupe(str(booking_venue_id or ""), message)

--- a/src/wechat_airflow/venues/dashahe_free_watcher.py
+++ b/src/wechat_airflow/venues/dashahe_free_watcher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from datetime import date, datetime, timedelta
 from typing import Any, cast
+from zoneinfo import ZoneInfo
 
 from wechat_airflow.notifications.webapp import publish_venue_observation
 from wechat_airflow.notifications.wechat import send_wechat_text_to_chatrooms_best_effort
@@ -15,6 +16,39 @@ VENUE_NAME = "大沙河免费场"
 DAG_ID = "大沙河免费场巡检"
 WECHAT_CHATROOMS = ("Zacks_大沙河限定免费",)
 MAX_SUBSCRIPTION_DAYS = 14
+SHANGHAI = ZoneInfo("Asia/Shanghai")
+
+
+class NswttProtocolError(ValueError):
+    """A missing/malformed collection is not evidence of an empty venue."""
+
+
+def _rows(data: object, *names: str) -> list[dict[str, Any]]:
+    if not isinstance(data, dict):
+        raise NswttProtocolError("NSWTT data must be an object")
+    for name in names:
+        if name in data:
+            value = data[name]
+            if not isinstance(value, list) or any(not isinstance(row, dict) for row in value):
+                raise NswttProtocolError("NSWTT collection must be a list of objects")
+            return cast(list[dict[str, Any]], value)
+    raise NswttProtocolError("NSWTT collection is missing")
+
+
+def future_slots(
+    slots: list[dict[str, str]], *, now: datetime | None = None
+) -> list[dict[str, str]]:
+    instant = now or datetime.now(SHANGHAI)
+    if instant.tzinfo is None:
+        raise ValueError("now must include a timezone")
+    return [
+        slot
+        for slot in slots
+        if datetime.fromisoformat(f"{slot['date']}T{slot['start_time']}").replace(tzinfo=SHANGHAI)
+        > instant
+    ]
+
+
 TIME_PATTERN = re.compile(r"^(?:[01]\d|2[0-3]):[0-5]\d$")
 
 
@@ -73,15 +107,11 @@ def ready_free_dates(
     *,
     today: date | None = None,
 ) -> list[str]:
-    if not isinstance(calendar_data, dict):
-        return []
-    current_date = today or date.today()
+    rows = _rows(calendar_data, "list")
+    current_date = today or datetime.now(SHANGHAI).date()
     last_date = current_date + timedelta(days=MAX_SUBSCRIPTION_DAYS)
-    rows = cast(dict[str, Any], calendar_data).get("list") or []
     ready: list[str] = []
     for row in rows:
-        if not isinstance(row, dict):
-            continue
         try:
             booking_date = date.fromisoformat(str(row.get("slicedate") or ""))
         except ValueError:
@@ -122,11 +152,11 @@ def extract_free_slots(
     booking_date: str,
     slice_data: object,
 ) -> tuple[bool, list[dict[str, str]]]:
-    if not isinstance(slice_data, dict):
-        return False, []
-    data = cast(dict[str, Any], slice_data)
-    places = data.get("placelist") or data.get("placeList") or []
-    if not isinstance(places, list) or not places:
+    places = _rows(slice_data, "placelist", "placeList")
+    raw_slots = _rows(slice_data, "slicelist", "sliceList")
+    if not places:
+        if raw_slots:
+            raise NswttProtocolError("NSWTT slots have no corresponding courts")
         return False, []
     place_names = {
         str(place.get("id") or place.get("placeid") or ""): str(
@@ -136,9 +166,6 @@ def extract_free_slots(
         if isinstance(place, dict)
     }
     slots: list[dict[str, str]] = []
-    raw_slots = data.get("slicelist") or data.get("sliceList") or []
-    if not isinstance(raw_slots, list):
-        return True, []
     for raw_slot in raw_slots:
         if not isinstance(raw_slot, dict) or not _slice_is_free(raw_slot):
             continue
@@ -149,8 +176,9 @@ def extract_free_slots(
             not court_name
             or not TIME_PATTERN.fullmatch(start_time)
             or not TIME_PATTERN.fullmatch(end_time)
+            or start_time >= end_time
         ):
-            continue
+            raise NswttProtocolError("NSWTT available slot has invalid court or times")
         slots.append(
             {
                 "date": booking_date,
@@ -196,7 +224,8 @@ def run_check_dashahe_free_courts() -> dict[str, object]:
                 slots.extend(date_slots)
             except Exception as exc:
                 errors.append(f"{booking_date}: {type(exc).__name__}")
-        publish_venue_observation(
+        slots = future_slots(slots)
+        observation = publish_venue_observation(
             VENUE_ID,
             VENUE_NAME,
             slots,
@@ -205,14 +234,25 @@ def run_check_dashahe_free_courts() -> dict[str, object]:
         )
         if errors:
             raise RuntimeError("one or more NSWTT free-date checks failed")
+        # No WeChat preclaim until the email/observation authority durably ACKs.
+        if observation.get("success") is not True:
+            print("[NSWTT] notification pipeline degraded: observation_not_acknowledged")
+            return {
+                "ready_dates": dates,
+                "free_dates": free_dates,
+                "available_slot_count": len(slots),
+                "observation_published": False,
+                "wechat_queued": False,
+            }
         cache = _load_cache()
+        delivery: list[dict[str, Any]] = []
         pending_messages = [
             message for message in format_wechat_messages(slots) if message not in cache
         ]
         if pending_messages:
             cache.extend(pending_messages)
             _store_cache(cache)
-            send_wechat_text_to_chatrooms_best_effort(
+            delivery = send_wechat_text_to_chatrooms_best_effort(
                 list(WECHAT_CHATROOMS),
                 "\n".join(pending_messages),
                 source=DAG_ID,
@@ -226,6 +266,10 @@ def run_check_dashahe_free_courts() -> dict[str, object]:
             "ready_dates": dates,
             "free_dates": free_dates,
             "available_slot_count": len(slots),
+            "observation_published": True,
+            "wechat_queued": bool(delivery)
+            and all(item.get("queued") is True for item in delivery),
+            "wechat_enqueue_failed": any(item.get("success") is not True for item in delivery),
         }
     except Exception as exc:
         if (

--- a/tests/dashahe_free_watcher_test.py
+++ b/tests/dashahe_free_watcher_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import sys
-from datetime import date
+from datetime import date, timedelta
 from types import ModuleType
 from unittest.mock import Mock, patch
 
@@ -131,7 +131,9 @@ def test_inspection_skips_unreleased_date_before_publishing() -> None:
             watcher, "_load_config_value", return_value={"app_version": "v", "cookie": "sid=x"}
         ),
         patch.object(watcher, "NswttClient", return_value=client),
-        patch.object(watcher, "publish_venue_observation") as publish,
+        patch.object(
+            watcher, "publish_venue_observation", return_value={"success": True}
+        ) as publish,
         patch.object(watcher, "_load_cache", return_value=[]),
         patch.object(watcher, "send_wechat_text_to_chatrooms_best_effort") as send,
     ):
@@ -165,7 +167,7 @@ def test_format_wechat_messages_uses_venue_and_weekday() -> None:
 
 def test_wechat_notifies_only_the_dashah_free_group_after_cache_write() -> None:
     client = Mock()
-    today = date.today().isoformat()
+    today = (date.today() + timedelta(days=1)).isoformat()
     client.calendar_list.return_value = {
         "data": {
             "list": [
@@ -199,7 +201,9 @@ def test_wechat_notifies_only_the_dashah_free_group_after_cache_write() -> None:
             watcher, "_load_config_value", return_value={"app_version": "v", "cookie": "sid=x"}
         ),
         patch.object(watcher, "NswttClient", return_value=client),
-        patch.object(watcher, "publish_venue_observation") as publish,
+        patch.object(
+            watcher, "publish_venue_observation", return_value={"success": True}
+        ) as publish,
         patch.object(watcher, "_load_cache", return_value=[]),
         patch.object(watcher, "_store_cache", side_effect=lambda cache: stored.append(list(cache))),
         patch.object(watcher, "send_wechat_text_to_chatrooms_best_effort") as send,
@@ -277,7 +281,7 @@ def test_wechat_skips_already_cached_dashah_messages() -> None:
             watcher, "_load_config_value", return_value={"app_version": "v", "cookie": "sid=x"}
         ),
         patch.object(watcher, "NswttClient", return_value=client),
-        patch.object(watcher, "publish_venue_observation"),
+        patch.object(watcher, "publish_venue_observation", return_value={"success": True}),
         patch.object(watcher, "_load_cache", return_value=[message]),
         patch.object(watcher, "_store_cache") as store,
         patch.object(watcher, "send_wechat_text_to_chatrooms_best_effort") as send,

--- a/tests/host_core_postgres_test.py
+++ b/tests/host_core_postgres_test.py
@@ -609,3 +609,146 @@ def test_business_acceptance_requires_real_cycles_and_delivery(monkeypatch):
     )
     report = health.business_report("a" * 40)
     assert not report["checks"]["allNaturalDagCycles"]
+
+
+def test_wechat_mixed_stale_batch_keeps_valid_lines_and_dispatch_prunes_again():
+    from wechat_airflow.host_core import wechat_queue, wechat_worker
+
+    with client() as c:
+        assert subscription(c, identity(), start="08:00", end="23:00").status_code == 201
+        payload = observation()
+        day = payload["slots"][0]["date"]
+        late = {
+            **payload["slots"][0],
+            "court_name": "2号场",
+            "start_time": "20:00",
+            "end_time": "21:00",
+        }
+        payload["slots"].append(late)
+        service.ingest_observation(payload)
+    early_line = f"【1号场】星期日({day[5:]})空场: 18:00-19:00"
+    late_line = f"【2号场】星期日({day[5:]})空场: 20:00-21:00"
+    stale_line = f"【9号场】星期日({day[5:]})空场: 10:00-11:00"
+    request = {
+        "venue_id": "tops",
+        "receivers": ["test-only-group"],
+        "device_name": "test-device",
+        "message": "\n".join([early_line, stale_line, late_line]),
+        "source": "test",
+    }
+    first = wechat_queue.enqueue(request)
+    assert first["queued"] == 1
+    assert first["rejected_lines"] == [stale_line]
+    assert wechat_queue.enqueue(request)["ids"] == first["ids"]
+    assert sql("SELECT count(*) n FROM zacks.wechat_outbox")[0]["n"] == 1
+    row = wechat_worker._claim("test-worker")
+    service.ingest_observation(observation(slots=[late]))
+    assert wechat_worker._prepare(row, "test-worker") is True
+    saved = sql("SELECT message,event_keys,status FROM zacks.wechat_outbox")[0]
+    assert saved["message"] == late_line
+    assert len(saved["event_keys"]) == 1
+    assert saved["status"] == "dispatching"
+    # No send function was invoked; both validations use the real isolated DB.
+
+
+def test_wechat_invalid_enqueue_is_durable_and_successful_retry_resolves_incident():
+    from wechat_airflow.host_core import wechat_queue
+
+    with client() as c:
+        assert subscription(c, identity()).status_code == 201
+        payload = observation()
+        service.ingest_observation(payload)
+    day = payload["slots"][0]["date"]
+    request = {
+        "venue_id": "tops",
+        "receivers": ["test-only-group"],
+        "device_name": "",
+        "message": f"【1号场】星期日({day[5:]})空场: 18:00-19:00",
+    }
+    with pytest.raises(ValueError):
+        wechat_queue.enqueue(request)
+    incident = sql(
+        "SELECT error_code,error_message,resolved_at FROM zacks.wechat_delivery_incidents"
+    )[0]
+    assert incident == {
+        "error_code": "ValueError",
+        "error_message": "ValueError",
+        "resolved_at": None,
+    }
+    request["device_name"] = "test-device"
+    assert wechat_queue.enqueue(request)["queued"] == 1
+    assert (
+        sql("SELECT resolved_at FROM zacks.wechat_delivery_incidents")[0]["resolved_at"] is not None
+    )
+
+
+@pytest.mark.parametrize("inactive", [True, False])
+def test_disabled_or_expired_subscription_never_creates_email_or_reactivates(inactive):
+    with client() as c:
+        assert subscription(c, identity()).status_code == 201
+    if inactive:
+        sql("UPDATE zacks.subscriptions SET active=false")
+    else:
+        sql("UPDATE zacks.subscriptions SET active_until=now()-interval '1 second'")
+    result = service.ingest_observation(observation())
+    assert result["matchedNotifications"] == 0
+    assert not sql("SELECT id FROM zacks.notification_outbox")
+    assert service.active_subscription_for_venue("tops") is False
+
+
+def test_past_slots_never_create_email_even_with_an_active_all_day_subscription():
+    with client() as c:
+        assert subscription(c, identity(), start="00:00", end="23:59").status_code == 201
+    day = (utc_now().astimezone(ZoneInfo("Asia/Shanghai")).date() - timedelta(days=1)).isoformat()
+    payload = observation(
+        slots=[{"date": day, "court_name": "1号场", "start_time": "10:00", "end_time": "11:00"}]
+    )
+    assert service.ingest_observation(payload)["matchedNotifications"] == 0
+    assert not sql("SELECT id FROM zacks.notification_outbox")
+
+
+def test_unknown_reconciliation_is_status_only_and_does_not_replay(monkeypatch):
+    from wechat_airflow.host_core import wechat_queue, wechat_worker
+
+    with client() as c:
+        assert subscription(c, identity()).status_code == 201
+        payload = observation()
+        service.ingest_observation(payload)
+    day = payload["slots"][0]["date"]
+    wechat_queue.enqueue(
+        {
+            "venue_id": "tops",
+            "receivers": ["test-only-group"],
+            "device_name": "test-device",
+            "message": f"【1号场】星期日({day[5:]})空场: 18:00-19:00",
+        }
+    )
+    row = wechat_worker._claim("test-worker")
+    assert wechat_worker._prepare(row, "test-worker")
+    wechat_worker._finish(row, "test-worker", "submission_unknown", "ReadTimeout")
+    sql("UPDATE zacks.wechat_outbox SET next_attempt_at=now()-interval '1 second'")
+    monkeypatch.setattr(
+        wechat_worker, "_first_value", lambda _: "http://isolated.invalid/v1/wechat/send"
+    )
+    urls = []
+
+    def lookup(url, **kwargs):
+        assert url.endswith("/v1/wechat/status")
+        assert set(kwargs["json"]) == {"idempotency_key", "payload_hash"}
+        urls.append(url)
+        return SimpleNamespace(
+            status_code=200,
+            raise_for_status=lambda: None,
+            json=lambda: {
+                "status": "sent",
+                "confirmed": True,
+                "sent_count": 1,
+                "updated_at": utc_now().isoformat(),
+            },
+        )
+
+    monkeypatch.setattr(wechat_worker.requests, "post", lookup)
+    wechat_worker.reconcile_unknown()
+    assert urls
+    assert sql("SELECT status FROM zacks.wechat_outbox")[0]["status"] == "sent"
+    assert wechat_worker._claim("test-worker") is None

--- a/tests/notification_reliability_test.py
+++ b/tests/notification_reliability_test.py
@@ -1,0 +1,265 @@
+"""Incident regressions: expired lines, durable ACKs and uncertain UI outcomes.
+
+All data is synthetic. No test may contact a venue, mail provider or device.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import date, datetime
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+from fastapi.testclient import TestClient
+
+import sender_agent.app as sender
+from sender_agent import ledger
+from wechat_airflow.host_core import wechat_worker
+from wechat_airflow.host_core.wechat_queue import current_message
+from wechat_airflow.notifications import webapp, wechat
+from wechat_airflow.venues import dashahe_free_watcher as free
+from wechat_sender import SendFailedError
+from wechat_sender.appium_text_sender import SendProgress
+
+SH = ZoneInfo("Asia/Shanghai")
+STALE = "【大沙河免费场2号场】星期一(09-07)空场: 10:00-11:00"
+FUTURE = "【大沙河免费场5号场】星期一(09-07)空场: 16:00-17:00"
+SLOT = {"date": "2026-09-07", "court_name": "5号场", "start_time": "16:00", "end_time": "17:00"}
+CURRENT = {
+    "booking_date": date(2026, 9, 7),
+    "court_name": "5号场",
+    "start_time": "16:00",
+    "end_time": "17:00",
+    "event_key": "future",
+}
+
+
+def test_started_line_cannot_poison_valid_line_or_depend_on_order():
+    for message in (STALE + "\n" + FUTURE, FUTURE + "\n" + STALE):
+        assert current_message(message, [CURRENT]) == (FUTURE, ["future"], [STALE])
+
+
+def test_all_stale_has_no_send_and_malformed_is_not_silently_hidden():
+    assert current_message(STALE, []) == ("", [], [STALE])
+    with pytest.raises(ValueError, match="invalid"):
+        current_message("not an availability line\n" + FUTURE, [CURRENT])
+
+
+def test_partly_covered_interval_does_not_invent_a_shorter_slot():
+    long_line = FUTURE.replace("16:00-17:00", "15:00-17:00")
+    assert current_message(long_line, [CURRENT]) == ("", [], [long_line])
+
+
+@pytest.mark.parametrize(
+    "instant,expected",
+    [
+        ("2026-09-07T15:59:59+08:00", 1),
+        ("2026-09-07T16:00:00+08:00", 0),
+        ("2026-09-07T08:01:00+00:00", 0),
+    ],
+)
+def test_filter_uses_shanghai_start_instant(instant, expected):
+    assert len(free.future_slots([SLOT], now=datetime.fromisoformat(instant))) == expected
+
+
+@pytest.mark.parametrize("data", [None, {}, {"list": None}, {"list": {}}, {"list": [None]}])
+def test_calendar_protocol_error_is_not_healthy_empty(data):
+    with pytest.raises(free.NswttProtocolError):
+        free.ready_free_dates(data)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        None,
+        {},
+        {"placelist": []},
+        {"placelist": [], "slicelist": None},
+        {"placelist": [], "slicelist": [{}]},
+    ],
+)
+def test_slot_protocol_error_is_not_unreleased_date(data):
+    with pytest.raises(free.NswttProtocolError):
+        free.extract_free_slots("2026-09-07", data)
+
+
+def test_explicit_empty_collections_remain_healthy_empty():
+    assert free.ready_free_dates({"list": []}) == []
+    assert free.extract_free_slots("2026-09-07", {"placelist": [], "slicelist": []}) == (False, [])
+
+
+def test_observation_requires_business_ack_even_when_http_succeeds():
+    with (
+        patch.object(webapp, "_host_token", return_value="isolated"),
+        patch.object(webapp, "_get_variable", return_value="5"),
+        patch.object(
+            webapp.requests,
+            "post",
+            return_value=SimpleNamespace(
+                raise_for_status=lambda: None, json=lambda: {"success": False}
+            ),
+        ),
+    ):
+        assert (
+            webapp.publish_venue_observation("dsh_free", "free", [], healthy=True)["success"]
+            is False
+        )
+
+
+def test_no_wechat_preclaim_when_observation_was_not_acknowledged():
+    client = Mock()
+    client.calendar_list.return_value = {"data": {"list": []}}
+    with (
+        patch.object(
+            free, "_load_config_value", return_value={"app_version": "v", "cookie": "sid=isolated"}
+        ),
+        patch.object(free, "NswttClient", return_value=client),
+        patch.object(free, "publish_venue_observation", return_value={"success": False}),
+        patch.object(free, "_load_cache") as cache,
+        patch.object(free, "send_wechat_text_to_chatrooms_best_effort") as send,
+    ):
+        assert free.run_check_dashahe_free_courts()["observation_published"] is False
+    cache.assert_not_called()
+    send.assert_not_called()
+
+
+def test_partial_enqueue_ack_releases_only_the_stale_preclaim():
+    response = SimpleNamespace(
+        raise_for_status=lambda: None,
+        json=lambda: {"success": True, "queued": 1, "rejected_lines": [STALE]},
+    )
+    with (
+        patch.object(webapp, "_host_token", return_value="isolated"),
+        patch.object(wechat.requests, "post", return_value=response),
+        patch.object(wechat, "_get_variable", return_value="isolated-device"),
+        patch.object(wechat, "_release_subscription_gate_dedupe") as release,
+    ):
+        result = wechat.send_wechat_text_to_chatrooms_best_effort(
+            ["isolated-group"], STALE + "\n" + FUTURE, booking_venue_id="dsh_free"
+        )
+    assert result[0]["queued"] is True
+    release.assert_called_once_with("dsh_free", STALE)
+
+
+def test_sender_pre_submit_failure_is_retryable_but_click_failure_never_is(tmp_path, monkeypatch):
+    monkeypatch.setenv("WECHAT_IDEMPOTENCY_PATH", str(tmp_path / "sender.sqlite3"))
+    monkeypatch.setenv("WECHAT_ALLOWED_DEVICE_NAME", "test-device")
+    sender.reset_runtime_state()
+    request = {
+        "receiver": "isolated-group",
+        "device_name": "test-device",
+        "messages": ["isolated"],
+        "idempotency_key": "test-key",
+    }
+    client = TestClient(sender.app)
+    with patch.object(sender, "send_text_messages", side_effect=SendFailedError("navigation")):
+        response = client.post("/v1/wechat/send", json=request)
+    assert response.json()["safe_to_retry"] is True
+    assert response.json()["submission_state"] == "not_submitted"
+    assert "navigation" not in response.text
+
+    def uncertain(**kwargs):
+        kwargs["progress"].submitting()
+        raise SendFailedError("lost click response")
+
+    with patch.object(sender, "send_text_messages", side_effect=uncertain) as send:
+        response = client.post("/v1/wechat/send", json=request)
+        assert response.json()["safe_to_retry"] is False
+        assert response.json()["submission_state"] == "submission_unknown"
+        repeated = client.post("/v1/wechat/send", json=request)
+    assert repeated.status_code == 409
+    assert send.call_count == 1
+
+
+def test_preparing_crash_can_retry_but_old_dispatch_cannot(tmp_path, monkeypatch):
+    monkeypatch.setenv("WECHAT_IDEMPOTENCY_PATH", str(tmp_path / "sender.sqlite3"))
+    assert ledger.claim("new", "p", preparing=True)[0] == "claimed"
+    assert ledger.claim("new", "p", preparing=True)[0] == "claimed"
+    ledger.mark_submitting("new")
+    ledger.finish("new", "not_submitted")  # Must not undo the boundary.
+    assert ledger.claim("new", "p", preparing=True)[0] == "submission_unknown"
+    ledger.claim("old", "p")
+    assert ledger.claim("old", "p", preparing=True)[0] == "submission_unknown"
+
+
+def test_submission_checkpoint_runs_before_ui_and_once_for_a_digest():
+    check = Mock()
+    progress = SendProgress(before_submit=check)
+    progress.submitting()
+    progress.submitting()
+    check.assert_called_once()
+    assert progress.submission_started
+
+
+@contextmanager
+def enabled_guard():
+    yield True
+
+
+@pytest.mark.parametrize(
+    "safe,attempt,expected",
+    [(True, 1, "retry"), (True, 3, "failed"), (False, 1, "submission_unknown")],
+)
+def test_worker_retries_only_proven_unsent_and_bounds_attempts(
+    safe, attempt, expected, monkeypatch
+):
+    monkeypatch.setenv("DEPLOYMENT_COMMIT", "a" * 40)
+    row = {
+        "id": "id",
+        "venue_id": "dsh_free",
+        "receiver": "isolated",
+        "device_name": "isolated",
+        "outbound_message": FUTURE,
+        "attempt_count": attempt,
+    }
+    payload = {
+        "success": False,
+        "error": "contact_not_found",
+        "safe_to_retry": safe,
+        "submission_state": "not_submitted" if safe else "submission_unknown",
+        "sent_count": 0,
+    }
+    with (
+        patch.object(wechat_worker, "delivery_guard", enabled_guard),
+        patch.object(
+            wechat_worker,
+            "sender_readiness",
+            return_value={"ok": True, "durableIdempotency": True, "deploymentCommit": "a" * 40},
+        ),
+        patch.object(wechat_worker, "_prepare", return_value=True),
+        patch.object(
+            wechat_worker, "_first_value", return_value="http://isolated.invalid/v1/wechat/send"
+        ),
+        patch.object(
+            wechat_worker.requests,
+            "post",
+            return_value=SimpleNamespace(status_code=500, json=lambda: payload),
+        ),
+        patch.object(wechat_worker, "_finish") as finish,
+    ):
+        wechat_worker.deliver(row, "worker")
+    finish.assert_called_once_with(row, "worker", expected, "contact_not_found")
+
+
+def test_host_core_changes_cannot_bypass_the_full_lifecycle():
+    import importlib.util
+    import sys
+    from pathlib import Path
+    from unittest.mock import patch
+
+    root = Path(__file__).parents[1]
+    with patch.object(sys, "path", [str(root / "scripts"), *sys.path]):
+        spec = importlib.util.spec_from_file_location(
+            "host_scope", root / "scripts/host_core_release_scope.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    assert module.requires_host_core(["src/wechat_airflow/host_core/wechat_worker.py"])
+    assert not module.requires_host_core(["webapp/src/CourtStudio.tsx"])
+    ship = (root / ".github/workflows/production-ship.yml").read_text()
+    assert "inputs.scope == 'all'" in ship
+    assert "host_core_release_scope.py" in ship
+    deploy = (root / ".github/workflows/production-release.yml").read_text()
+    assert "host_core_release_scope.py" in deploy

--- a/tests/sender_agent_test.py
+++ b/tests/sender_agent_test.py
@@ -282,7 +282,8 @@ class SenderAgentTest(unittest.TestCase):
 
         self.assertEqual(response.status_code, 500)
         self.assertEqual(response.json()["error"], "send_failed")
-        self.assertIn("send button missing", response.json()["message"])
+        self.assertEqual(response.json()["submission_state"], "not_submitted")
+        self.assertNotIn("send button missing", response.json()["message"])
 
     @patch("sender_agent.app.send_text_messages")
     def test_reuses_warm_session_and_skips_preflight_cleanup(self, mock_send):

--- a/tests/webapp_notification_test.py
+++ b/tests/webapp_notification_test.py
@@ -170,6 +170,7 @@ class WebappNotificationTest(TestCase):
         get_variable.side_effect = lambda key, default=None: values.get(key, default)
         response = MagicMock()
         response.raise_for_status.return_value = None
+        response.json.return_value = {"success": True}
         post.return_value = response
 
         result = webapp.publish_venue_observation(
@@ -222,6 +223,7 @@ class WebappNotificationTest(TestCase):
         get_variable.side_effect = lambda key, default=None: values.get(key, default)
         response = MagicMock()
         response.raise_for_status.return_value = None
+        response.json.return_value = {"success": True}
         post.return_value = response
 
         result = webapp.publish_venue_observation(

--- a/tests/wechat_send_api_test.py
+++ b/tests/wechat_send_api_test.py
@@ -183,7 +183,9 @@ class WeChatSendApiTest(unittest.TestCase):
             patch.object(
                 wechat_send_api.requests,
                 "post",
-                return_value=FakeResponse({"success": True, "durable": True, "ids": ["x"]}),
+                return_value=FakeResponse(
+                    {"success": True, "durable": True, "queued": 1, "ids": ["x"]}
+                ),
             ) as post,
             patch.object(
                 wechat_send_api,

--- a/tests/wechat_sender_test.py
+++ b/tests/wechat_sender_test.py
@@ -13,6 +13,7 @@ from wechat_sender.appium_text_sender import (
     InvalidSendRequestError,
     OcrLine,
     SendFailedError,
+    SendProgress,
     SendResult,
     TextWeChatOperator,
     _fingerprints_match,
@@ -564,6 +565,7 @@ class WeChatSenderTest(unittest.TestCase):
     def test_visual_input_clear_uses_batched_adb_key_events(self, mock_run):
         mock_run.return_value.returncode = 0
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.device_name = "test-device"
         regions = []
         operator._find_visual_green_button = lambda *, region: regions.append(region)
@@ -582,6 +584,7 @@ class WeChatSenderTest(unittest.TestCase):
     @patch("wechat_sender.appium_text_sender.time.sleep")
     def test_visual_send_checks_only_the_bottom_input_row(self, _mock_sleep):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.driver.set_clipboard_text = lambda _value: None
         operator.driver.press_keycode = lambda _value: None
@@ -612,6 +615,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_visual_only_device_opens_visible_chat_without_scrolling(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.current_receiver = None
         operator.is_at_main_page = lambda: True
@@ -640,6 +644,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_visible_candidates_prefer_exact_numbered_group_over_earlier_prefix(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator._ocr_lines = lambda **_kwargs: [
             OcrLine("Zacks网球场预定小助手", 100, 300, 700, 360),
             OcrLine("Zacks网球场预定小助手_2群", 100, 500, 800, 560),
@@ -660,6 +665,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_unambiguous_recent_chat_uses_activity_when_title_ocr_is_unavailable(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator._wait_for_activity = lambda suffix, timeout: suffix == "ChattingUI" and bool(
             timeout
         )
@@ -677,6 +683,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_ambiguous_recent_chat_still_requires_matching_title(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator._wait_for_activity = lambda *_args, **_kwargs: True
         operator._wait_for_chat = lambda receiver, timeout: False
 
@@ -690,6 +697,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_visual_recent_chat_rescans_after_the_list_reorders(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.current_receiver = None
         operator.navigation_path = "unknown"
@@ -717,6 +725,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_visual_recent_chat_never_taps_or_searches_with_stale_coordinates(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.current_receiver = None
         operator.navigation_path = "unknown"
@@ -739,6 +748,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_partial_accessibility_still_checks_visible_chat_without_scrolling(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.current_receiver = None
         operator.is_at_main_page = lambda: True
@@ -773,6 +783,7 @@ class WeChatSenderTest(unittest.TestCase):
                 return None
 
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.current_receiver = None
         operator.is_at_main_page = lambda: True
@@ -788,6 +799,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_non_chat_wechat_page_is_not_accepted_as_target_chat(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.driver.current_activity = ".plugin.profile.ui.ContactInfoUI"
         operator._has_accessible_title = lambda _receiver: True
@@ -803,6 +815,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_chat_activity_requires_matching_title(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.driver.current_activity = ".ui.chatting.ChattingUI"
         operator._has_accessible_title = lambda _receiver: False
@@ -812,6 +825,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_launcher_activity_accepts_verified_chat_title(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.driver.current_activity = ".ui.LauncherUI"
         operator._is_visual_main_page = lambda: False
@@ -821,6 +835,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_launcher_main_page_is_not_accepted_as_chat(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.driver.current_activity = ".ui.LauncherUI"
         operator._is_visual_main_page = lambda: True
@@ -857,6 +872,7 @@ class WeChatSenderTest(unittest.TestCase):
         pil_module.Image = image_module
 
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.driver.get_screenshot_as_png = lambda: b"png"
 
@@ -871,6 +887,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_send_reuses_an_already_open_verified_target_chat(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.current_receiver = None
         operator.is_target_chat_open = lambda _receiver: True
         operator.is_contact_in_recent_chats = lambda _receiver: (_ for _ in ()).throw(
@@ -892,6 +909,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_send_uses_visible_numbered_group_without_opening_search(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.current_receiver = None
         operator.navigation_path = "unknown"
@@ -914,6 +932,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_verified_chat_does_not_repeat_unstable_title_ocr(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.driver.current_activity = ".ui.chatting.ChattingUI"
         operator.current_receiver = "Zacks网球场预定小助手_2群"
@@ -925,6 +944,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_return_to_chats_clears_verified_launcher_chat(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.driver.current_activity = ".ui.LauncherUI"
         operator.current_receiver = "Zacks网球场预定小助手_2群"
@@ -952,6 +972,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_search_tries_next_visual_result_after_wrong_entry(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.driver.current_activity = ".ui.FTSMainUI"
         operator.driver.set_clipboard_text = lambda _value: None
@@ -996,6 +1017,7 @@ class WeChatSenderTest(unittest.TestCase):
                 self.rect = {"x": 100, "y": top, "width": 700, "height": 80}
 
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.driver.current_activity = ".ui.FTSMainUI"
         operator.driver.set_clipboard_text = lambda _value: None
@@ -1040,6 +1062,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_search_button_is_accepted_when_click_leaves_main_page(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator._wait_for_search_page = lambda timeout: False
         operator.is_at_main_page = lambda: False
@@ -1070,6 +1093,7 @@ class WeChatSenderTest(unittest.TestCase):
 
     def test_launcher_search_page_is_detected_from_top_input(self):
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.driver.current_activity = ".ui.LauncherUI"
         operator._activity_ends_with = lambda suffix: suffix == "LauncherUI"
@@ -1082,6 +1106,7 @@ class WeChatSenderTest(unittest.TestCase):
             rect = {"x": 0, "y": 2000, "width": 900, "height": 100}
 
         operator = TextWeChatOperator.__new__(TextWeChatOperator)
+        operator.progress = SendProgress()
         operator.driver = VisualOnlyDriver()
         operator.driver.find_elements = lambda **_kwargs: [Input()]
 

--- a/webapp/src/CourtStudio.tsx
+++ b/webapp/src/CourtStudio.tsx
@@ -168,11 +168,12 @@ export function CourtStudio(props: Props) {
           <div className={`tier-row tier-${dashboard.identity.tier}`}><span><StarIcon size={16} />{dashboard.identity.tier === "priority" ? "优先用户" : "普通用户"}</span><button type="button" onClick={() => onPanel("priority")}>{dashboard.identity.tier === "priority" ? "查看规则" : "输入邀请码"}</button></div>
           <div className="quota-card" aria-label="今日邮件额度"><div><span>今日邮件额度</span><strong>剩余 {dashboard.identity.remainingToday} / {dashboard.identity.dailyLimit}</strong></div><span className="quota-track" aria-hidden="true"><i style={{ width: `${quotaPercent}%` }} /></span><p>已提交 {dashboard.identity.submittedToday} · 送达 {dashboard.identity.deliveredToday} · 失败 {dashboard.identity.failedToday}</p></div>
         </> : null}
+        {verified && dashboard.identity.activeSubscriptionCount === 0 ? <p role="status" className="studio-disclaimer">当前邮箱没有有效订阅，不会收到场地邮件。已停用或过期的订阅不会自动恢复，请创建新的订阅。</p> : null}
         <p className="studio-disclaimer"><ShieldCheckIcon size={15} />只做提醒，不代订，也不保证订到。</p>
       </section>
 
       <section className="venue-section studio-directory" ref={directoryRef} id="studio-directory" aria-labelledby="venue-heading">
-        <div className="section-heading"><div><span className="studio-eyebrow">THE COURT DIRECTORY</span><h2 id="venue-heading">找到你想去的球场<span>{dashboard.venues.length}</span></h2><p>点按场地，直接设置提醒。状态仅表示后台最近巡检结果。</p></div></div>
+        <div className="section-heading"><div><span className="studio-eyebrow">THE COURT DIRECTORY</span><h2 id="venue-heading">找到你想去的球场<span>{dashboard.venues.length}</span></h2><p>点按场地，直接设置提醒。巡检、邮件和微信是独立环节；场地邮件时间为全站记录，不代表当前邮箱或微信群已收到。</p></div></div>
         <div className="studio-toolbar">
           <label className="studio-search"><MagnifyingGlassIcon size={19} aria-hidden="true" /><KeyboardInput ref={searchRef} type="search" aria-label="搜索场地" placeholder="搜索场地名称…" autoComplete="off" value={query} onChange={event => setQuery(event.target.value)} />{query ? <button type="button" aria-label="清除搜索" onClick={() => { setQuery(""); searchRef.current?.focus(); }}><XIcon size={16} /></button> : null}</label>
           <div className="studio-filters" role="group" aria-label="筛选场地">
@@ -192,7 +193,7 @@ export function CourtStudio(props: Props) {
               <span className="venue-card-name">{venue.name}</span>
               <span className="venue-card-status"><span><i className={`venue-status-dot ${state}`} />{stateText}</span><small>{cadence} / 次</small></span>
               <span className="venue-card-meta"><span><ClockIcon size={13} />{relativeTime(venue.lastInspectionAt)}</span><span className="venue-card-followers"><UsersThreeIcon size={13} />{hasData ? venue.subscriberCount : "—"}</span></span>
-              <span className="venue-card-mail"><EnvelopeSimpleIcon size={13} />{mail}</span>
+              <span className="venue-card-mail"><EnvelopeSimpleIcon size={13} />邮件渠道 · {mail}</span>
             </button>;
           })}
         </div>

--- a/wechat_sender/appium_text_sender.py
+++ b/wechat_sender/appium_text_sender.py
@@ -38,6 +38,20 @@ class SendFailedError(WeChatSenderError):
     error_code = "send_failed"
 
 
+@dataclass
+class SendProgress:
+    before_submit: Callable[[], None] = lambda: None
+    submission_started: bool = False
+    confirmed_count: int = 0
+    cleanup_failed: bool = False
+
+    def submitting(self) -> None:
+        if not self.submission_started:
+            # Set memory first. A failed checkpoint must never permit a click.
+            self.submission_started = True
+            self.before_submit()
+
+
 @dataclass(frozen=True)
 class SendResult:
     success: bool
@@ -428,6 +442,7 @@ class TextWeChatOperator:
         self.device_name = device_name
         self.current_receiver: str | None = None
         self.navigation_path = "unknown"
+        self.progress = SendProgress()
         self.driver = AppiumWebDriver(
             command_executor=appium_server_url,
             options=UiAutomator2Options().load_capabilities(capabilities),
@@ -453,7 +468,11 @@ class TextWeChatOperator:
         else:
             self._send_visual_messages(messages)
 
-        self.return_to_chats()
+        try:
+            self.return_to_chats()
+        except Exception:
+            # Every message was confirmed. Navigation cleanup is not a failed send.
+            self.progress.cleanup_failed = True
 
     def is_contact_in_recent_chats(self, receiver: str) -> bool:
         if not self.is_at_main_page():
@@ -695,21 +714,34 @@ class TextWeChatOperator:
         for index, message in enumerate(messages):
             try:
 
-                def send_current_message(current_message: str = message) -> None:
+                def prepare_current_message(current_message: str = message) -> Any:
                     message_input = WebDriverWait(self.driver, 10).until(
                         EC.presence_of_element_located(
                             (AppiumBy.XPATH, "//android.widget.EditText")
                         )
                     )
+                    message_input.clear()
                     message_input.send_keys(current_message)
                     send_btn = WebDriverWait(self.driver, 10).until(
                         EC.presence_of_element_located(
                             (AppiumBy.XPATH, "//android.widget.Button[@text='发送']")
                         )
                     )
-                    send_btn.click()
+                    return send_btn
 
-                _run_stale_retry(send_current_message)
+                send_btn = _run_stale_retry(prepare_current_message)
+                self.progress.submitting()
+                # Never retry a click after a stale-element/transport exception.
+                send_btn.click()
+                WebDriverWait(self.driver, 10).until(
+                    lambda driver: any(
+                        not str(element.get_attribute("text") or "").strip()
+                        for element in driver.find_elements(
+                            AppiumBy.XPATH, "//android.widget.EditText"
+                        )
+                    )
+                )
+                self.progress.confirmed_count += 1
                 if index < len(messages) - 1:
                     time.sleep(random.uniform(0.3, 3))
             except TimeoutException as exc:
@@ -739,19 +771,24 @@ class TextWeChatOperator:
                     )
                 if send_line is None:
                     raise AppiumTimeoutError("visual send button was not found")
+                self.progress.submitting()
                 self._tap_ocr_line(send_line)
                 time.sleep(0.8)
                 if self.driver.current_package != "com.tencent.mm":
                     raise SendFailedError("WeChat left the chat page during send")
                 if self._find_visual_green_button(region=VISUAL_SEND_BUTTON_REGION) is not None:
                     raise SendFailedError("visual send button remained active after tap")
+                self.progress.confirmed_count += 1
                 if index < len(messages) - 1:
                     time.sleep(random.uniform(0.3, 3))
             except WeChatSenderError:
                 raise
             except Exception as exc:
                 raise SendFailedError(str(exc)) from exc
-        self.driver.set_clipboard_text("")
+        try:
+            self.driver.set_clipboard_text("")
+        except Exception:
+            self.progress.cleanup_failed = True
 
     def _clear_visual_input(self) -> None:
         commands = (
@@ -1212,6 +1249,7 @@ def send_text_messages(
     sleeper: Callable[[float], None] = time.sleep,
     existing_operator: TextWeChatOperator | None = None,
     close_operator: bool = True,
+    progress: SendProgress | None = None,
 ) -> SendResult:
     normalized_messages = _validate_send_request(
         appium_server_url=appium_server_url,
@@ -1262,8 +1300,9 @@ def send_text_messages(
                 if not _operator_can_send(operator, normalized_receiver):
                     raise DeviceNotReadyError("WeChat main page is not available")
 
+        operator.progress = progress or SendProgress()
         operator.send_message(receiver=normalized_receiver, messages=normalized_messages)
-        failed = False
+        failed = operator.progress.cleanup_failed
         return SendResult(
             success=True,
             device_name=device_name,
@@ -1271,7 +1310,7 @@ def send_text_messages(
             sent_count=len(normalized_messages),
             navigation_path=getattr(operator, "navigation_path", "unknown"),
             session_reused=session_reused,
-            operator=None if close_operator else operator,
+            operator=None if close_operator or failed else operator,
         )
     except WeChatSenderError:
         raise


### PR DESCRIPTION
## Incident and scope

Addresses the 2026-09-07 `dsh_free` notification incident recorded in #39: started slots poisoned otherwise-valid WeChat digests; sender preparation failures were indistinguishable from possible UI submission; green venue tasks and global email timestamps did not prove personal delivery. The connected Gmail subscription was inactive/expired and must NOT be automatically restored.

## Changes

- Shanghai-aware future-slot filtering and strict NSWTT response collection validation (explicit empty arrays remain valid).
- Require a business observation ACK before WeChat preclaims. Keep valid lines when unrelated lines expire at enqueue or dispatch; record/resolve redacted durable enqueue incidents independently of DAG success.
- Do not generate subscriber-email work for started slots. Disabled/expired subscriptions remain excluded.
- Sender durable `preparing -> dispatching` checkpoint immediately before the first irreversible UI action. Only proven-not-submitted errors retry, with a finite cap. No click-level stale retries; successful sends are not invalidated by navigation cleanup.
- Payload-bound sender status reconciliation can confirm successful historical submissions without ever replaying uncertain sends. Preserve privacy-safe failure codes.
- Business acceptance rejects new terminal failures, unknown submissions, unresolved enqueue incidents and stalled queues.
- Clarify effective personal subscription state versus channel-wide email activity in the website.
- Full `scope=all sender=true` ship now runs the existing fenced Host Core lifecycle for later versions too; a Host Core patch cannot pass partial-scope deployment gates. Existing verified migration checkpoints skip D1 re-import.

## Verification

Local: Ruff lint/format passed; strict mypy passed (63 source files); 497 tests passed, 34 isolated PostgreSQL tests skipped locally because the test DB is absent. `make verify` reached Web tests and stopped because local vitest dependencies are not installed. This is NOT a full local verification claim. Required GitHub `CI / verify` must pass the exact commit, including real isolated PostgreSQL regressions, Web/Playwright, Compose, Airflow/Sender images and DAG imports.

Added incident regressions for mixed stale/future lines, dispatch-time pruning, malformed versus legitimate empty upstream responses, durable ACKs, sender pre/post-submit outcomes, payload-bound reconciliation, retry caps, disabled/expired subscriptions, independent incident tracking and release lifecycle scope.

## Release / handoff

User explicitly requested fix and deployment. After review and exact-main CI, use protected `/release ship 0.8.2 <FULL_MAIN_SHA> scope=all sender=true`. Verify exact Host Core/Airflow/Sender/edge identities, three natural venue cycles, no new unknown/terminal failures, API rollback acceptance, and natural provider email/WeChat evidence before tagging. On a failed gate retain evidence and pause/roll forward using the existing workflow; never bypass checks.

No production secrets, subscriber addresses, one-off production workflows, synthetic notifications, subscription reactivation, queue/cache resets or D1 mutation are part of this PR. Temporary source transport is outside this branch and has no production access.