### PR TITLE
chore(cadence): tune Dashah inspection intervals

### DIFF
--- a/config/active-components.yaml
+++ b/config/active-components.yaml
@@ -163,7 +163,7 @@ active_dags:
 
   - dag_id: 大沙河免费场巡检
     file: dags/tennis_dags/sz_tennis/dashahe_free_watcher.py
-    schedule: every_1_minutes
+    schedule: every_15_seconds
     tasks:
       - check_free_courts
     variables:
@@ -196,7 +196,7 @@ active_dags:
 
   - dag_id: 大沙河国际网球中心巡检
     file: dags/tennis_dags/sz_tennis/dsh_ydmap_watcher.py
-    schedule: every_3_minutes
+    schedule: every_2_minutes
     tasks:
       - check_tennis_courts
     variables:

--- a/config/venue-schedule-policy.yaml
+++ b/config/venue-schedule-policy.yaml
@@ -9,10 +9,14 @@ exceptions:
     schedule: every_15_seconds
     interval_seconds: 15
     reason: Existing business-approved low-latency polling exception.
+  大沙河免费场巡检:
+    schedule: every_15_seconds
+    interval_seconds: 15
+    reason: Business-approved low-latency polling for rapidly released free-court inventory.
   大沙河国际网球中心巡检:
-    schedule: every_3_minutes
-    interval_seconds: 180
-    reason: Raspberry Pi Chromium scraping needs a slower resource-safe cadence.
+    schedule: every_2_minutes
+    interval_seconds: 120
+    reason: Business-approved two-minute cadence for Raspberry Pi Chromium scraping.
 change_control:
   new_venues_use_default: true
   exceptions_require:

--- a/dags/tennis_dags/sz_tennis/dashahe_free_watcher.py
+++ b/dags/tennis_dags/sz_tennis/dashahe_free_watcher.py
@@ -21,7 +21,7 @@ dag = DAG(
     "大沙河免费场巡检",
     default_args=DEFAULT_ARGS,
     description="南山文体通大沙河免费场巡检",
-    schedule=timedelta(minutes=1),
+    schedule=timedelta(seconds=15),
     max_active_runs=1,
     dagrun_timeout=timedelta(minutes=10),
     catchup=False,

--- a/dags/tennis_dags/sz_tennis/dsh_ydmap_watcher.py
+++ b/dags/tennis_dags/sz_tennis/dsh_ydmap_watcher.py
@@ -21,7 +21,7 @@ dag = DAG(
     "大沙河国际网球中心巡检",
     default_args=DEFAULT_ARGS,
     description="大沙河国际网球中心网球场巡检 - YDMap 树莓派浏览器采集",
-    schedule=timedelta(minutes=3),
+    schedule=timedelta(minutes=2),
     max_active_runs=1,
     dagrun_timeout=timedelta(minutes=10),
     catchup=False,

--- a/docs/adr/0014-default-venue-inspection-cadence.md
+++ b/docs/adr/0014-default-venue-inspection-cadence.md
@@ -10,16 +10,17 @@ number of upstream and public-proxy requests without a corresponding product
 requirement, increased contention for the single-device WeChat sender, and made
 new integrations likely to copy an unnecessarily aggressive default.
 
-Two existing integrations have deliberate exceptions. Shenzhen Bay retains its
-15-second low-latency polling requirement. Dashah International Tennis Center
-retains a three-minute cadence because each run drives a Raspberry Pi Chromium
-scrape and needs a slower resource-safe interval.
+Three integrations have deliberate exceptions. Shenzhen Bay and Dashah River
+free courts use a 15-second low-latency polling requirement. Dashah International
+Tennis Center uses a two-minute cadence because each run drives a Raspberry Pi
+Chromium scrape and still needs a slower resource-safe interval than ordinary API
+polling.
 
 ## Decision
 
 - Set the default production tennis-venue inspection cadence to one minute.
-- Keep Shenzhen Bay at 15 seconds and Dashah International Tennis Center at
-  three minutes.
+- Keep Shenzhen Bay and Dashah River free courts at 15 seconds, and Dashah
+  International Tennis Center at two minutes.
 - Normalize every other active venue DAG, including Shenzhen Sports Center, to
   `timedelta(minutes=1)` and declare `every_1_minutes` in the active-component
   manifest.
@@ -37,7 +38,9 @@ scrape and needs a slower resource-safe interval.
 
 - New venue integrations fail CI when they copy a sub-minute or otherwise
   non-default cadence without an explicit reviewed exception.
-- Existing 30-second venue traffic is reduced by approximately half while the
-  two approved latency/resource exceptions remain unchanged.
-- A venue run that exceeds one minute remains serialized; its effective cadence
-  becomes the task duration rather than creating overlapping upstream traffic.
+- Dashah River free-court polling makes four checks per minute to reduce latency
+  for rapidly released inventory; Dashah International increases from one check
+  every three minutes to one every two minutes while remaining serialized.
+- A venue run that exceeds its configured interval remains serialized; its
+  effective cadence becomes the task duration rather than creating overlapping
+  upstream traffic.

--- a/tests/venue_schedule_policy_test.py
+++ b/tests/venue_schedule_policy_test.py
@@ -17,7 +17,8 @@ MANIFEST_PATH = ROOT / "config" / "active-components.yaml"
 POLICY_PATH = ROOT / "config" / "venue-schedule-policy.yaml"
 EXPECTED_EXCEPTIONS = {
     "深圳湾网球场巡检": "every_15_seconds",
-    "大沙河国际网球中心巡检": "every_3_minutes",
+    "大沙河免费场巡检": "every_15_seconds",
+    "大沙河国际网球中心巡检": "every_2_minutes",
 }
 
 

--- a/tests/webapp_venue_status_display_test.py
+++ b/tests/webapp_venue_status_display_test.py
@@ -13,6 +13,7 @@ def test_web_venue_cadence_labels_match_the_airflow_policy() -> None:
 
     exception_ids = {
         "深圳湾网球场巡检": "szw",
+        "大沙河免费场巡检": "dsh_free",
         "大沙河国际网球中心巡检": "dsh",
     }
     for dag_id, venue_id in exception_ids.items():

--- a/webapp/cloudflare/venue-inspection-display.test.ts
+++ b/webapp/cloudflare/venue-inspection-display.test.ts
@@ -18,8 +18,13 @@ describe("venue inspection cadence display", () => {
     expect(formatInspectionCadence("szw")).toBe("15秒/次");
   });
 
-  it("shows the resource-safe Dashah International exception", () => {
-    expect(inspectionCadenceSeconds("dsh")).toBe(180);
-    expect(formatInspectionCadence("dsh")).toBe("3分钟/次");
+  it("shows the approved Dashah free-court low-latency exception", () => {
+    expect(inspectionCadenceSeconds("dsh_free")).toBe(15);
+    expect(formatInspectionCadence("dsh_free")).toBe("15秒/次");
+  });
+
+  it("shows the approved Dashah International exception", () => {
+    expect(inspectionCadenceSeconds("dsh")).toBe(120);
+    expect(formatInspectionCadence("dsh")).toBe("2分钟/次");
   });
 });

--- a/webapp/src/venue-inspection-display.ts
+++ b/webapp/src/venue-inspection-display.ts
@@ -2,7 +2,8 @@ export const DEFAULT_INSPECTION_CADENCE_SECONDS = 60;
 
 const INSPECTION_CADENCE_SECONDS: Readonly<Record<string, number>> = {
   szw: 15,
-  dsh: 180,
+  dsh_free: 15,
+  dsh: 120,
 };
 
 export function inspectionCadenceSeconds(venueId: string): number {


### PR DESCRIPTION
## Summary

Adjust the two Dashah production inspection cadences requested for low-latency availability detection:

- `大沙河国际网球中心巡检`: 3 minutes → **2 minutes**
- `大沙河免费场巡检`: 1 minute → **15 seconds**

## Implementation

- update the two Airflow DAG schedules while preserving `max_active_runs=1`
- declare both non-default cadences in `config/venue-schedule-policy.yaml`
- synchronize `config/active-components.yaml`
- keep the public cadence labels aligned (`dsh=120s`, `dsh_free=15s`)
- update the cadence ADR and regression coverage

No scraper, availability filtering, subscriber matching, dedupe, email, or WeChat delivery behavior is changed.

## Verification / handoff

- branch starts from current `main` `a730feea501fc3d50dd78b96f3ba67a8b1dc897b`
- compare shows only the 9 intended files and no unrelated changes
- require PR `CI / verify` before merge
- after merge, require exact merged-main CI, protected `/release preflight <sha> scope=auto sender=false`, then `/release apply <sha> scope=auto sender=false`
- production acceptance must use natural inspection cycles only; do not send synthetic email/WeChat messages

Rollback: redeploy the previous exact production commit if the protected apply or post-deploy health checks fail.